### PR TITLE
Uniform `type` syntax

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -16,6 +16,8 @@ rule token = parse
  | ':' { COLON }
  | '{' { LBRACKET }
  | '}' { RBRACKET }
+ | '=' { EQUALS }
+ | "type" { TYPE }
  | "struct" { STRUCT }
  | "interface" { INTERFACE }
  | ident { IDENT (Lexing.lexeme lexbuf) }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -33,33 +33,34 @@ let type_definition ==
   TYPE;
   name = ident;
   EQUALS;
-  expr = expr;
+  expr = located(expr);
   { make_type_definition ~name: name ~expr: expr () }
 )
 
 let expr ==
  | struct_definition
  | interface_definition
+ | ~= raw_ident; <Reference>
 
 let struct_definition ==
-| located ( 
-  STRUCT; 
+| STRUCT; 
   fields = delimited_separated_trailing_list(LBRACKET, struct_fields, COMMA, RBRACKET);
   { Struct (make_struct_definition ~fields: fields ()) }
-)
 
 let struct_fields ==
-| located ( name = ident; COLON; typ = ident; { make_struct_field ~name: name ~typ: typ () } )
+| located ( name = ident; COLON; typ = located(expr); { make_struct_field ~field_name: name ~field_type: typ () } )
 
 let interface_definition ==
-| located ( 
+|
   INTERFACE;
   LBRACKET ; RBRACKET ;
   { Interface (make_interface_definition ~members: [] ()) }
-)
 
 let ident ==
-  located ( ~= IDENT ; <Ident> )
+  located ( raw_ident )
+
+let raw_ident ==
+  ~= IDENT ; <Ident>
 
 let delimited_separated_trailing_list(opening, x, sep, closing) ==
  | l = delimited(opening, nonempty_list(terminated(x, sep)), closing); { l } 

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -17,6 +17,7 @@ program: TYPE TYPE
 ## list(top_level_expr) -> TYPE . IDENT EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE . IDENT EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE . IDENT EQUALS INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE . IDENT EQUALS IDENT list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPE
@@ -31,6 +32,7 @@ program: TYPE IDENT TYPE
 ## list(top_level_expr) -> TYPE IDENT . EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE IDENT . EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE IDENT . EQUALS INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT . EQUALS IDENT list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPE IDENT
@@ -45,6 +47,7 @@ program: TYPE IDENT EQUALS TYPE
 ## list(top_level_expr) -> TYPE IDENT EQUALS . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE IDENT EQUALS . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
 ## list(top_level_expr) -> TYPE IDENT EQUALS . INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS . IDENT list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPE IDENT EQUALS
@@ -82,9 +85,21 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT TYPE
 ##
 ## Ends in an error in state: 6.
 ##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON INTERFACE LBRACKET RBRACKET COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON IDENT COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON INTERFACE LBRACKET RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON IDENT COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON INTERFACE LBRACKET RBRACKET [ RBRACKET ]
 ## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON IDENT [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON INTERFACE LBRACKET RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
 ## separated_nonempty_list(COMMA,struct_fields) -> IDENT . COLON IDENT COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
@@ -97,9 +112,21 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON TYPE
 ##
 ## Ends in an error in state: 7.
 ##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . INTERFACE LBRACKET RBRACKET COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . IDENT COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . INTERFACE LBRACKET RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . IDENT COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . INTERFACE LBRACKET RBRACKET [ RBRACKET ]
 ## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . IDENT [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . INTERFACE LBRACKET RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
 ## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON . IDENT COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
@@ -108,9 +135,164 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON TYPE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT TYPE
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT TYPE
 ##
 ## Ends in an error in state: 8.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT LBRACKET TYPE
+##
+## Ends in an error in state: 9.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT LBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT LBRACKET IDENT COLON IDENT COMMA RBRACKET TYPE
+##
+## Ends in an error in state: 12.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT LBRACKET IDENT COLON IDENT COMMA RBRACKET COMMA TYPE
+##
+## Ends in an error in state: 13.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA . [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA . separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT LBRACKET RBRACKET TYPE
+##
+## Ends in an error in state: 17.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON STRUCT LBRACKET RBRACKET COMMA TYPE
+##
+## Ends in an error in state: 18.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA . [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA . separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON INTERFACE TYPE
+##
+## Ends in an error in state: 21.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE . LBRACKET RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE . LBRACKET RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE . LBRACKET RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE . LBRACKET RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON INTERFACE
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON INTERFACE LBRACKET TYPE
+##
+## Ends in an error in state: 22.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET . RBRACKET COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET . RBRACKET COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE LBRACKET . RBRACKET [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE LBRACKET . RBRACKET COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON INTERFACE LBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON INTERFACE LBRACKET RBRACKET TYPE
+##
+## Ends in an error in state: 23.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET RBRACKET . COMMA [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET RBRACKET . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE LBRACKET RBRACKET . [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE LBRACKET RBRACKET . COMMA separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON INTERFACE LBRACKET RBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON INTERFACE LBRACKET RBRACKET COMMA TYPE
+##
+## Ends in an error in state: 24.
+##
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET RBRACKET COMMA . [ RBRACKET ]
+## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON INTERFACE LBRACKET RBRACKET COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
+## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON INTERFACE LBRACKET RBRACKET COMMA . separated_nonempty_list(COMMA,struct_fields) [ RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON INTERFACE LBRACKET RBRACKET COMMA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT TYPE
+##
+## Ends in an error in state: 27.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT . COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -125,7 +307,7 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT TYPE
 
 program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA TYPE
 ##
-## Ends in an error in state: 9.
+## Ends in an error in state: 28.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT COMMA . [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -139,7 +321,7 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA TYPE
 
 program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA RBRACKET STRUCT
 ##
-## Ends in an error in state: 14.
+## Ends in an error in state: 32.
 ##
 ## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . list(top_level_expr) [ EOF ]
 ##
@@ -151,7 +333,7 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA RBRACKET STRU
 
 program: TYPE IDENT EQUALS STRUCT LBRACKET RBRACKET STRUCT
 ##
-## Ends in an error in state: 17.
+## Ends in an error in state: 35.
 ##
 ## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . list(top_level_expr) [ EOF ]
 ##
@@ -163,7 +345,7 @@ program: TYPE IDENT EQUALS STRUCT LBRACKET RBRACKET STRUCT
 
 program: TYPE IDENT EQUALS INTERFACE TYPE
 ##
-## Ends in an error in state: 19.
+## Ends in an error in state: 37.
 ##
 ## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE . LBRACKET RBRACKET list(top_level_expr) [ EOF ]
 ##
@@ -175,7 +357,7 @@ program: TYPE IDENT EQUALS INTERFACE TYPE
 
 program: TYPE IDENT EQUALS INTERFACE LBRACKET TYPE
 ##
-## Ends in an error in state: 20.
+## Ends in an error in state: 38.
 ##
 ## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE LBRACKET . RBRACKET list(top_level_expr) [ EOF ]
 ##
@@ -187,12 +369,24 @@ program: TYPE IDENT EQUALS INTERFACE LBRACKET TYPE
 
 program: TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET STRUCT
 ##
-## Ends in an error in state: 21.
+## Ends in an error in state: 39.
 ##
 ## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET . list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS IDENT STRUCT
+##
+## Ends in an error in state: 41.
+##
+## list(top_level_expr) -> TYPE IDENT EQUALS IDENT . list(top_level_expr) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## TYPE IDENT EQUALS IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -1,4 +1,4 @@
-program: RBRACKET
+program: STRUCT
 ##
 ## Ends in an error in state: 0.
 ##
@@ -10,48 +10,77 @@ program: RBRACKET
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT STRUCT
+program: TYPE TYPE
 ##
 ## Ends in an error in state: 1.
 ##
-## list(top_level_expr) -> STRUCT . IDENT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
-## list(top_level_expr) -> STRUCT . IDENT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE . IDENT EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE . IDENT EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE . IDENT EQUALS INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT
+## TYPE
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT STRUCT
+program: TYPE IDENT TYPE
 ##
 ## Ends in an error in state: 2.
 ##
-## list(top_level_expr) -> STRUCT IDENT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
-## list(top_level_expr) -> STRUCT IDENT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT . EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT . EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT . EQUALS INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT
+## TYPE IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET STRUCT
+program: TYPE IDENT EQUALS TYPE
 ##
 ## Ends in an error in state: 3.
 ##
-## list(top_level_expr) -> STRUCT IDENT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
-## list(top_level_expr) -> STRUCT IDENT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS . STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS . STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS . INTERFACE LBRACKET RBRACKET list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET
+## TYPE IDENT EQUALS
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET IDENT STRUCT
+program: TYPE IDENT EQUALS STRUCT TYPE
 ##
 ## Ends in an error in state: 4.
+##
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT . LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT . LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## TYPE IDENT EQUALS STRUCT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET TYPE
+##
+## Ends in an error in state: 5.
+##
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET . nonempty_list(terminated(struct_fields,COMMA)) RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET . loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET list(top_level_expr) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## TYPE IDENT EQUALS STRUCT LBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT TYPE
+##
+## Ends in an error in state: 6.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON IDENT COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT . COLON IDENT COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -64,9 +93,9 @@ program: STRUCT IDENT LBRACKET IDENT STRUCT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET IDENT COLON STRUCT
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON TYPE
 ##
-## Ends in an error in state: 5.
+## Ends in an error in state: 7.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . IDENT COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON . IDENT COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -79,9 +108,9 @@ program: STRUCT IDENT LBRACKET IDENT COLON STRUCT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET IDENT COLON IDENT STRUCT
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT TYPE
 ##
-## Ends in an error in state: 6.
+## Ends in an error in state: 8.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT . COMMA [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -94,9 +123,9 @@ program: STRUCT IDENT LBRACKET IDENT COLON IDENT STRUCT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET IDENT COLON IDENT COMMA STRUCT
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA TYPE
 ##
-## Ends in an error in state: 7.
+## Ends in an error in state: 9.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT COMMA . [ RBRACKET ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON IDENT COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACKET ]
@@ -108,74 +137,62 @@ program: STRUCT IDENT LBRACKET IDENT COLON IDENT COMMA STRUCT
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET IDENT COLON IDENT COMMA RBRACKET RBRACKET
-##
-## Ends in an error in state: 12.
-##
-## list(top_level_expr) -> STRUCT IDENT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . list(top_level_expr) [ EOF ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: INTERFACE STRUCT
-##
-## Ends in an error in state: 13.
-##
-## list(top_level_expr) -> INTERFACE . IDENT LBRACKET RBRACKET list(top_level_expr) [ EOF ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: INTERFACE IDENT STRUCT
+program: TYPE IDENT EQUALS STRUCT LBRACKET IDENT COLON IDENT COMMA RBRACKET STRUCT
 ##
 ## Ends in an error in state: 14.
 ##
-## list(top_level_expr) -> INTERFACE IDENT . LBRACKET RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET . list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## INTERFACE IDENT
+## TYPE IDENT EQUALS STRUCT LBRACKET nonempty_list(terminated(struct_fields,COMMA)) RBRACKET
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: INTERFACE IDENT LBRACKET STRUCT
+program: TYPE IDENT EQUALS STRUCT LBRACKET RBRACKET STRUCT
 ##
-## Ends in an error in state: 15.
+## Ends in an error in state: 17.
 ##
-## list(top_level_expr) -> INTERFACE IDENT LBRACKET . RBRACKET list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET
+## TYPE IDENT EQUALS STRUCT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: INTERFACE IDENT LBRACKET RBRACKET RBRACKET
+program: TYPE IDENT EQUALS INTERFACE TYPE
 ##
-## Ends in an error in state: 16.
+## Ends in an error in state: 19.
 ##
-## list(top_level_expr) -> INTERFACE IDENT LBRACKET RBRACKET . list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE . LBRACKET RBRACKET list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET RBRACKET
+## TYPE IDENT EQUALS INTERFACE
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: STRUCT IDENT LBRACKET RBRACKET RBRACKET
+program: TYPE IDENT EQUALS INTERFACE LBRACKET TYPE
 ##
 ## Ends in an error in state: 20.
 ##
-## list(top_level_expr) -> STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET . list(top_level_expr) [ EOF ]
+## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE LBRACKET . RBRACKET list(top_level_expr) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,struct_fields)) RBRACKET
+## TYPE IDENT EQUALS INTERFACE LBRACKET
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET STRUCT
+##
+## Ends in an error in state: 21.
+##
+## list(top_level_expr) -> TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET . list(top_level_expr) [ EOF ]
+##
+## The known suffix of the stack is as follows:
+## TYPE IDENT EQUALS INTERFACE LBRACKET RBRACKET
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -7,27 +7,28 @@ type 'a located =
 
 type ident = Ident of string [@@deriving show]
 
-type struct_field = {
-  name: ident located;
-  typ: ident located;
-} [@@deriving show, make]
-
-type struct_definition = {
+and struct_definition = {
   fields: struct_field located list;
 } [@@deriving show, make]
 
-type interface_member = {
-  name: ident located;
+and interface_member = {
+  member_name: ident located;
 } [@@deriving show, make]
 
-type interface_definition = {
+and interface_definition = {
   members: interface_member located list;
 } [@@deriving show, make]
 
-type expr = 
+and expr = 
   | Struct of struct_definition
   | Interface of interface_definition
+  | Reference of ident
   [@@deriving show]
+
+and struct_field = {
+  field_name: ident located;
+  field_type: expr located;
+} [@@deriving show, make]
 
 type type_definition = {
   name: ident located;

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -13,21 +13,31 @@ type struct_field = {
 } [@@deriving show, make]
 
 type struct_definition = {
-  name: ident located;
   fields: struct_field located list;
 } [@@deriving show, make]
 
-type interface_definition = {
+type interface_member = {
   name: ident located;
 } [@@deriving show, make]
 
+type interface_definition = {
+  members: interface_member located list;
+} [@@deriving show, make]
+
+type expr = 
+  | Struct of struct_definition
+  | Interface of interface_definition
+  [@@deriving show]
+
+type type_definition = {
+  name: ident located;
+  expr: expr located;
+} [@@deriving show, make]
+
 type top_level_expr = 
-  | Struct of struct_definition located
-  | Interface of interface_definition located
+  | Type of type_definition located
   [@@deriving show]
 
 type program = {
-    structs: (struct_definition located) list;
-    interfaces: (interface_definition located) list;
-  }
-  [@@deriving show, make]
+    types: (type_definition located) list;
+} [@@deriving show, make]


### PR DESCRIPTION
Having `struct Name { ... }`, `interface Name { ... }`, `enum Name {
... }` syntax has the following downsides:

* Harder to scan the source code for types
* More difficult to introduce type-as-expression syntax later

Therefore, we're changing it to a uniform syntax:

```
type Test = struct {
  test: Type
}

type Query = interface {
}
```

and even

```
type Test = struct {
  test: struct {
    a: Int257,
    iface: interface { }
  }
}

type Query = interface {
}

```
