### PR TITLE
Add ~ syntax and field access syntax.

### DIFF
--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -36,6 +36,7 @@ rule token = parse
  | ')' { RPAREN }
  | '=' { EQUALS }
  | '~' { TILDA }
+ | '.' { DOT }
  | "let" { LET }
  | "type" { TYPE }
  | "struct" { STRUCT }

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -35,6 +35,7 @@ rule token = parse
  | '(' { LPAREN }
  | ')' { RPAREN }
  | '=' { EQUALS }
+ | '~' { TILDA }
  | "let" { LET }
  | "type" { TYPE }
  | "struct" { STRUCT }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -1,5 +1,4 @@
 %parameter<Syntax : Syntax.T>
-
 %start <Syntax.program> program
 
 %{              
@@ -225,6 +224,8 @@ let fexpr :=
  | function_call
  (* can be an integer *)
  | ~= INT; <Int>
+ (* can be mutation ref *)
+ | TILDA; ~= located(ident); <MutRef>
 
 let params ==
     delimited_separated_trailing_list(LPAREN, function_param, COMMA, RPAREN)

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -1,4 +1,5 @@
 %parameter<Syntax : Syntax.T>
+
 %start <Syntax.program> program
 
 %{              
@@ -219,8 +220,10 @@ let fexpr :=
  | (_, e) = enum_definition(nothing); { e }
  (* can be an `union` definition *)
  | (_, u) = union_definition(nothing); { u }
-  (* can be an identifier, as a reference to some identifier *)
- | reference
+ (* can be an identifier, as a reference to some identifier *)
+ | ~= ident; <Reference>
+ (* can be access to the field via dot *)
+ | field_access
  (* can be a function call *)
  | function_call
  (* can be an integer *)
@@ -231,9 +234,8 @@ let fexpr :=
 let params ==
     delimited_separated_trailing_list(LPAREN, function_param, COMMA, RPAREN)
 
-let reference :=
-  | ident = located(ident); {FieldAccess (make_path ~first_elem:ident ~last_elems:[] ()) }
-  | ident = located(ident); DOT; idents = separated_list(DOT, located(ident)); 
+let field_access := 
+  ident = located(ident); DOT; idents = separated_list(DOT, located(ident)); 
     {FieldAccess (make_path ~first_elem:ident ~last_elems:idents ())}
 
 (* Struct

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -199,6 +199,9 @@ let type_expr :=
 (* Expression *)
 let expr :=
  | expr_
+ (* can be access to the field via dot *)
+ | from_expr = located(expr); DOT; to_field = located(ident); 
+    {FieldAccess (make_field_access ~from_expr ~to_field ())}
  (* can be a type constructor *)
  | struct_constructor
  (* can be a function definition *)
@@ -222,8 +225,6 @@ let fexpr :=
  | (_, u) = union_definition(nothing); { u }
  (* can be an identifier, as a reference to some identifier *)
  | ~= ident; <Reference>
- (* can be access to the field via dot *)
- | field_access
  (* can be a function call *)
  | function_call
  (* can be an integer *)
@@ -233,10 +234,6 @@ let fexpr :=
 
 let params ==
     delimited_separated_trailing_list(LPAREN, function_param, COMMA, RPAREN)
-
-let field_access := 
-  ident = located(ident); DOT; idents = separated_list(DOT, located(ident)); 
-    {FieldAccess (make_path ~first_elem:ident ~last_elems:idents ())}
 
 (* Struct
 

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -73,7 +73,6 @@ let let_binding ==
       ~binding_expr:
       (make_located ~loc: $loc ~value: (expand_fn_sugar params $loc (Reference (Ident "Type")) expr) ()) 
       ()
-
   }
 )
 let shorthand_binding ==
@@ -233,9 +232,9 @@ let params ==
     delimited_separated_trailing_list(LPAREN, function_param, COMMA, RPAREN)
 
 let reference :=
-  | ident = located(ident); {Reference (make_path ~first_elem:ident ~last_elems:[] ()) }
+  | ident = located(ident); {FieldAccess (make_path ~first_elem:ident ~last_elems:[] ()) }
   | ident = located(ident); DOT; idents = separated_list(DOT, located(ident)); 
-    {Reference (make_path ~first_elem:ident ~last_elems:idents ())}
+    {FieldAccess (make_path ~first_elem:ident ~last_elems:idents ())}
 
 (* Struct
 
@@ -267,7 +266,6 @@ let struct_definition(name) ==
 let struct_fields ==
 | located ( name = located(ident); COLON; typ = located(expr); { make_struct_field ~field_name: name ~field_type: typ () } )
 | located ( name = located(ident); { make_struct_field ~field_name: name ~field_type: (make_located ~loc: (loc name) ~value: (Reference (value name)) ()) () } )
-
 
 (* Struct constructor 
  *
@@ -370,7 +368,7 @@ let union_member :=
  (* can be an `union` definition *)
  | (_, u) = union_definition(nothing); { u }
  (* can be an identifier, as a reference to some identifier *)
- | ident = located(ident); {Reference (make_path ~first_elem:ident ~last_elems:[] ()) }
+ | ident = ident; {Reference ident }
  (* can be a function call [by identifier only] *)
  | fn = located(ident);
   arguments = delimited_separated_trailing_list(LPAREN, located(expr), COMMA, RPAREN);

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -494,7 +494,9 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -536,7 +538,7 @@ program: LET IDENT EQUALS LPAREN TYPE
 ## type_expr -> LPAREN . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
-## type_expr -> LPAREN . IDENT RPAREN [ LBRACE ]
+## type_expr -> LPAREN . reference RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . function_call RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . INT RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . TILDA IDENT RPAREN [ LBRACE ]
@@ -672,8 +674,8 @@ program: LET IDENT EQUALS IDENT UNION
 ##
 ## Ends in an error in state: 60.
 ##
-## expr -> IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## fexpr -> IDENT . [ LPAREN ]
+## reference -> IDENT . [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
+## reference -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
 ## type_expr -> IDENT . [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
@@ -682,9 +684,46 @@ program: LET IDENT EQUALS IDENT UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS FN UNION
+program: LET IDENT EQUALS IDENT DOT TYPE
 ##
 ## Ends in an error in state: 61.
+##
+## reference -> IDENT DOT . loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+##
+## The known suffix of the stack is as follows:
+## IDENT DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS IDENT DOT IDENT TYPE
+##
+## Ends in an error in state: 62.
+##
+## separated_nonempty_list(DOT,located(ident)) -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## separated_nonempty_list(DOT,located(ident)) -> IDENT . DOT separated_nonempty_list(DOT,located(ident)) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS IDENT DOT IDENT DOT UNION
+##
+## Ends in an error in state: 63.
+##
+## separated_nonempty_list(DOT,located(ident)) -> IDENT DOT . separated_nonempty_list(DOT,located(ident)) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+##
+## The known suffix of the stack is as follows:
+## IDENT DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS FN UNION
+##
+## Ends in an error in state: 67.
 ##
 ## function_definition(nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## function_definition(nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -697,7 +736,7 @@ program: LET IDENT EQUALS FN UNION
 
 program: LET IDENT EQUALS FN LPAREN UNION
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 68.
 ##
 ## function_definition(nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## function_definition(nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -710,7 +749,7 @@ program: LET IDENT EQUALS FN LPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 64.
+## Ends in an error in state: 70.
 ##
 ## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -722,7 +761,7 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 65.
+## Ends in an error in state: 71.
 ##
 ## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -733,14 +772,16 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 75.
 ##
 ## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -752,7 +793,7 @@ program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 76.
 ##
 ## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -763,14 +804,16 @@ program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM UNION
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 78.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -785,7 +828,7 @@ program: LET IDENT EQUALS ENUM UNION
 
 program: LET IDENT EQUALS ENUM LBRACE UNION
 ##
-## Ends in an error in state: 73.
+## Ends in an error in state: 79.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -800,7 +843,7 @@ program: LET IDENT EQUALS ENUM LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 80.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN ]
@@ -819,7 +862,7 @@ program: ENUM IDENT LBRACE IDENT UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 81.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -834,7 +877,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 82.
 ##
 ## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -847,7 +890,7 @@ program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 
 program: LET IDENT EQUALS IDENT LBRACE UNION
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 83.
 ##
 ## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -860,7 +903,7 @@ program: LET IDENT EQUALS IDENT LBRACE UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 84.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -875,7 +918,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 85.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -888,9 +931,29 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: LET IDENT EQUALS IDENT DOT UNION
+##
+## Ends in an error in state: 87.
+##
+## expr -> reference . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## fexpr -> reference . [ LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## reference
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
+## In state 66, spurious reduction of production reference -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 89.
 ##
 ## expr -> function_call . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -902,9 +965,9 @@ program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: FN IDENT LPAREN RPAREN RARROW LPAREN INT UNION
+program: FN IDENT LPAREN RPAREN RARROW LPAREN INT TYPE
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 90.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
@@ -917,7 +980,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN INT UNION
 
 program: LET IDENT EQUALS IDENT LPAREN TYPE
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 91.
 ##
 ## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -930,7 +993,7 @@ program: LET IDENT EQUALS IDENT LPAREN TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 97.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -944,14 +1007,15 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 ##
-## Ends in an error in state: 91.
+## Ends in an error in state: 98.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -965,7 +1029,7 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 101.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -979,14 +1043,15 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 102.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1000,7 +1065,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 110.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1014,14 +1079,15 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 111.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1035,7 +1101,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA UNION
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 114.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1049,7 +1115,7 @@ program: ENUM IDENT LBRACE IDENT COMMA UNION
 
 program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 120.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -1062,7 +1128,7 @@ program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 121.
 ##
 ## list(sugared_function_definition) -> function_definition(located_ident_with_params) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1073,16 +1139,16 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 282, spurious reduction of production option(code_block) ->
-## In state 283, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 288, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 289, spurious reduction of production option(code_block) ->
+## In state 290, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 123.
 ##
 ## list(sugared_function_definition) -> function_definition(located(ident)) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1093,16 +1159,16 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 224, spurious reduction of production option(code_block) ->
-## In state 225, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 231, spurious reduction of production option(code_block) ->
+## In state 232, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 127.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -1115,7 +1181,7 @@ program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE ENUM UNION
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 132.
 ##
 ## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1128,7 +1194,7 @@ program: UNION IDENT LBRACE ENUM UNION
 
 program: UNION IDENT LBRACE ENUM LBRACE UNION
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 133.
 ##
 ## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1141,7 +1207,7 @@ program: UNION IDENT LBRACE ENUM LBRACE UNION
 
 program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 133.
+## Ends in an error in state: 140.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1156,7 +1222,7 @@ program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE IDENT COMMA TYPE
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 141.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1170,7 +1236,7 @@ program: UNION IDENT LBRACE IDENT COMMA TYPE
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 147.
 ##
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1183,7 +1249,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 151.
 ##
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1196,7 +1262,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN TILDA UNION
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 153.
 ##
 ## fexpr -> TILDA . IDENT [ LPAREN ]
 ## type_expr -> LPAREN TILDA . IDENT RPAREN [ LBRACE ]
@@ -1209,7 +1275,7 @@ program: LET IDENT EQUALS LPAREN TILDA UNION
 
 program: LET IDENT EQUALS LPAREN TILDA IDENT UNION
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 154.
 ##
 ## fexpr -> TILDA IDENT . [ LPAREN ]
 ## type_expr -> LPAREN TILDA IDENT . RPAREN [ LBRACE ]
@@ -1222,7 +1288,7 @@ program: LET IDENT EQUALS LPAREN TILDA IDENT UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT UNION
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 156.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1237,7 +1303,7 @@ program: LET IDENT EQUALS LPAREN STRUCT UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 157.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1252,7 +1318,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 158.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1267,7 +1333,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 161.
 ##
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1280,7 +1346,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 165.
 ##
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1293,7 +1359,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE UNION
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 167.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1306,7 +1372,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 168.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1319,7 +1385,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 163.
+## Ends in an error in state: 170.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE ]
@@ -1332,7 +1398,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INT UNION
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 172.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE ]
@@ -1343,23 +1409,9 @@ program: LET IDENT EQUALS LPAREN INT UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS LPAREN IDENT UNION
-##
-## Ends in an error in state: 167.
-##
-## fexpr -> IDENT . [ LPAREN ]
-## type_expr -> LPAREN IDENT . RPAREN [ LBRACE ]
-## type_expr -> IDENT . [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN IDENT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 program: LET IDENT EQUALS LPAREN ENUM UNION
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 174.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1374,7 +1426,7 @@ program: LET IDENT EQUALS LPAREN ENUM UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 175.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1389,7 +1441,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 178.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1402,7 +1454,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 182.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1415,7 +1467,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 184.
 ##
 ## fexpr -> LPAREN struct_constructor . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1425,9 +1477,28 @@ program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: LET IDENT EQUALS LPAREN IDENT SEMICOLON
+##
+## Ends in an error in state: 186.
+##
+## fexpr -> reference . [ LPAREN ]
+## type_expr -> LPAREN reference . RPAREN [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN reference
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 60, spurious reduction of production reference -> IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 188.
 ##
 ## fexpr -> LPAREN function_definition(nothing) . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1438,16 +1509,16 @@ program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 69, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 70, spurious reduction of production option(code_block) ->
-## In state 71, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 75, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 76, spurious reduction of production option(code_block) ->
+## In state 77, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 190.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE ]
@@ -1461,7 +1532,7 @@ program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 192.
 ##
 ## stmt -> RETURN expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1472,14 +1543,15 @@ program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 194.
 ##
 ## stmt -> LET . IDENT EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1493,7 +1565,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 195.
 ##
 ## stmt -> LET IDENT . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1507,7 +1579,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 196.
 ##
 ## stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1520,7 +1592,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 198.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1532,7 +1604,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 199.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1544,7 +1616,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 200.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1555,14 +1627,15 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 203.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1574,7 +1647,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 204.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1586,7 +1659,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 205.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1597,14 +1670,15 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 200.
+## Ends in an error in state: 207.
 ##
 ## stmt -> LET IDENT EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1616,7 +1690,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 208.
 ##
 ## stmt -> LET IDENT EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1627,14 +1701,15 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 210.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1646,7 +1721,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 211.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1658,7 +1733,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 212.
 ##
 ## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1669,14 +1744,15 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 213.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1688,7 +1764,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 214.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1700,7 +1776,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE UNION
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 215.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## else_ -> ELSE . code_block [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1713,7 +1789,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE
 
 program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 220.
 ##
 ## list(located(stmt)) -> stmt . list(located(stmt)) [ RBRACE ]
 ##
@@ -1725,7 +1801,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 223.
 ##
 ## stmt -> expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1736,14 +1812,15 @@ program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 230.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -1755,7 +1832,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 231.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1766,14 +1843,16 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 241.
 ##
 ## fexpr -> TILDA . IDENT [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1785,7 +1864,7 @@ program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 243.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1798,7 +1877,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 244.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1811,7 +1890,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 245.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1824,7 +1903,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 252.
 ##
 ## fexpr -> LPAREN . struct_constructor RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> LPAREN . function_definition(nothing) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1837,7 +1916,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 253.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1849,7 +1928,7 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 254.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1859,22 +1938,9 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
-##
-## Ends in an error in state: 251.
-##
-## fexpr -> IDENT . [ LPAREN ]
-## type_expr -> IDENT . [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 258.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1887,7 +1953,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 259.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1900,7 +1966,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 267.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
@@ -1913,7 +1979,20 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 268.
+##
+## reference -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## reference -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: FN IDENT LPAREN RPAREN RARROW INT TYPE
+##
+## Ends in an error in state: 270.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1927,7 +2006,7 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 271.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -1940,7 +2019,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 273.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1952,7 +2031,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 274.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1963,14 +2042,16 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 277.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1982,7 +2063,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 278.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1993,14 +2074,16 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 281.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2014,7 +2097,7 @@ program: FN IDENT LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 282.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2027,7 +2110,7 @@ program: FN IDENT LPAREN RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 284.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2039,7 +2122,7 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 285.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2050,14 +2133,16 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 288.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2069,7 +2154,7 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 289.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2080,14 +2165,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 268, spurious reduction of production reference -> IDENT
+## In state 266, spurious reduction of production fexpr -> reference
+## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 292.
 ##
 ## expr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2100,7 +2187,7 @@ program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 295.
 ##
 ## expr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2113,7 +2200,7 @@ program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 296.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2127,14 +2214,15 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 297.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2148,7 +2236,7 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 314.
 ##
 ## expr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2161,7 +2249,7 @@ program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 317.
 ##
 ## expr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2174,7 +2262,7 @@ program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 318.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2188,14 +2276,15 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 319.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2209,7 +2298,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 323.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2222,7 +2311,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 324.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2235,7 +2324,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 327.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2247,7 +2336,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RB
 
 program: STRUCT UNION
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 328.
 ##
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2264,7 +2353,7 @@ program: STRUCT UNION
 
 program: STRUCT IDENT UNION
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 329.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2281,7 +2370,7 @@ program: STRUCT IDENT UNION
 
 program: STRUCT IDENT LPAREN UNION
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 330.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2296,7 +2385,7 @@ program: STRUCT IDENT LPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 332.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2309,7 +2398,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 333.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2322,7 +2411,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 336.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2334,7 +2423,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA R
 
 program: LET UNION
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 337.
 ##
 ## list(top_level_stmt) -> LET . IDENT EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2348,7 +2437,7 @@ program: LET UNION
 
 program: LET IDENT UNION
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 338.
 ##
 ## list(top_level_stmt) -> LET IDENT . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2362,7 +2451,7 @@ program: LET IDENT UNION
 
 program: LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 339.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2375,7 +2464,7 @@ program: LET IDENT LPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 341.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2387,7 +2476,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 342.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2399,7 +2488,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 343.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2410,14 +2499,15 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 344.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2429,7 +2519,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON 
 
 program: INTERFACE UNION
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 345.
 ##
 ## list(top_level_stmt) -> INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2443,7 +2533,7 @@ program: INTERFACE UNION
 
 program: INTERFACE IDENT UNION
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 346.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2457,7 +2547,7 @@ program: INTERFACE IDENT UNION
 
 program: INTERFACE IDENT LPAREN UNION
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 347.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2470,7 +2560,7 @@ program: INTERFACE IDENT LPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 349.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2482,7 +2572,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 350.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2494,7 +2584,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 352.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2506,7 +2596,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYP
 
 program: ENUM UNION
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 353.
 ##
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2523,7 +2613,7 @@ program: ENUM UNION
 
 program: ENUM IDENT UNION
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 354.
 ##
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2540,7 +2630,7 @@ program: ENUM IDENT UNION
 
 program: ENUM IDENT LPAREN UNION
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 355.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2555,7 +2645,7 @@ program: ENUM IDENT LPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 357.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2568,7 +2658,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 358.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2581,7 +2671,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 361.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2593,7 +2683,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBR
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 363.
 ##
 ## list(top_level_stmt) -> function_definition(located_ident_with_params) . list(top_level_stmt) [ EOF ]
 ##
@@ -2604,16 +2694,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 282, spurious reduction of production option(code_block) ->
-## In state 283, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 288, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 289, spurious reduction of production option(code_block) ->
+## In state 290, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 365.
 ##
 ## list(top_level_stmt) -> function_definition(located(ident)) . list(top_level_stmt) [ EOF ]
 ##
@@ -2624,16 +2714,16 @@ program: FN IDENT LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 224, spurious reduction of production option(code_block) ->
-## In state 225, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 231, spurious reduction of production option(code_block) ->
+## In state 232, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 369.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2645,7 +2735,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 372.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2658,7 +2748,7 @@ program: ENUM IDENT LPAREN RPAREN UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 373.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2671,7 +2761,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 376.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2683,7 +2773,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 380.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2695,7 +2785,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LBRACE UNION
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 382.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2708,7 +2798,7 @@ program: ENUM IDENT LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 378.
+## Ends in an error in state: 385.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2720,7 +2810,7 @@ program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 389.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2732,7 +2822,7 @@ program: ENUM IDENT LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 393.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2744,7 +2834,7 @@ program: INTERFACE IDENT LPAREN RPAREN UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 394.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2756,7 +2846,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 396.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2768,7 +2858,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LBRACE UNION
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 398.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2780,7 +2870,7 @@ program: INTERFACE IDENT LBRACE UNION
 
 program: INTERFACE IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 400.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2792,7 +2882,7 @@ program: INTERFACE IDENT LBRACE RBRACE TYPE
 
 program: LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 404.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2804,7 +2894,7 @@ program: LET IDENT LPAREN RPAREN UNION
 
 program: LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 405.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2816,7 +2906,7 @@ program: LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 406.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2827,14 +2917,15 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 407.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2846,7 +2937,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 
 program: LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 409.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2858,7 +2949,7 @@ program: LET IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 410.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2869,14 +2960,15 @@ program: LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production reference -> IDENT
+## In state 87, spurious reduction of production expr -> reference
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 411.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2888,7 +2980,7 @@ program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 416.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2900,7 +2992,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 419.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2913,7 +3005,7 @@ program: STRUCT IDENT LPAREN RPAREN UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 420.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2926,7 +3018,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 423.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2938,7 +3030,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 427.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2950,7 +3042,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 429.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2963,7 +3055,7 @@ program: STRUCT IDENT LBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 432.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2975,7 +3067,7 @@ program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 436.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2987,7 +3079,7 @@ program: STRUCT IDENT LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 441.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2999,7 +3091,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 444.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3012,7 +3104,7 @@ program: UNION IDENT LPAREN RPAREN UNION
 
 program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 445.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3025,7 +3117,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 448.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3037,7 +3129,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 452.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3049,7 +3141,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LBRACE TYPE
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 454.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3062,7 +3154,7 @@ program: UNION IDENT LBRACE TYPE
 
 program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 457.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3074,7 +3166,7 @@ program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 461.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -219,9 +219,35 @@ program: STRUCT IDENT LBRACE IDENT COLON TYPE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS STRUCT UNION
+program: LET IDENT EQUALS TILDA UNION
 ##
 ## Ends in an error in state: 17.
+##
+## expr -> TILDA . IDENT [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## fexpr -> TILDA . IDENT [ LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## TILDA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS TILDA IDENT UNION
+##
+## Ends in an error in state: 18.
+##
+## expr -> TILDA IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## fexpr -> TILDA IDENT . [ LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## TILDA IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS STRUCT UNION
+##
+## Ends in an error in state: 19.
 ##
 ## expr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -236,7 +262,7 @@ program: LET IDENT EQUALS STRUCT UNION
 
 program: LET IDENT EQUALS STRUCT LPAREN UNION
 ##
-## Ends in an error in state: 18.
+## Ends in an error in state: 20.
 ##
 ## option(params) -> LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN [ LBRACE ]
 ## option(params) -> LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN [ LBRACE ]
@@ -249,7 +275,7 @@ program: LET IDENT EQUALS STRUCT LPAREN UNION
 
 program: LET IDENT EQUALS STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 24.
+## Ends in an error in state: 26.
 ##
 ## expr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -264,7 +290,7 @@ program: LET IDENT EQUALS STRUCT LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 25.
+## Ends in an error in state: 27.
 ##
 ## expr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -279,7 +305,7 @@ program: LET IDENT EQUALS STRUCT LBRACE UNION
 
 program: FN UNION
 ##
-## Ends in an error in state: 28.
+## Ends in an error in state: 30.
 ##
 ## function_definition(located(ident)) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located(ident)) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -296,7 +322,7 @@ program: FN UNION
 
 program: FN IDENT UNION
 ##
-## Ends in an error in state: 29.
+## Ends in an error in state: 31.
 ##
 ## function_definition(located(ident)) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located(ident)) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -313,7 +339,7 @@ program: FN IDENT UNION
 
 program: FN IDENT LPAREN UNION
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 32.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located(ident)) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -330,7 +356,7 @@ program: FN IDENT LPAREN UNION
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 32.
+## Ends in an error in state: 34.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -344,7 +370,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW TYPE
 ##
-## Ends in an error in state: 33.
+## Ends in an error in state: 35.
 ##
 ## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ UNION STRUCT SEMICOLON RPAREN RBRACE LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -356,7 +382,7 @@ program: FN IDENT LPAREN RPAREN RARROW TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW UNION UNION
 ##
-## Ends in an error in state: 34.
+## Ends in an error in state: 36.
 ##
 ## fexpr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -369,7 +395,7 @@ program: FN IDENT LPAREN RPAREN RARROW UNION UNION
 
 program: FN IDENT LPAREN RPAREN RARROW UNION LBRACE TYPE
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 37.
 ##
 ## fexpr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -382,7 +408,7 @@ program: FN IDENT LPAREN RPAREN RARROW UNION LBRACE TYPE
 
 program: UNION IDENT LBRACE INTERFACE UNION
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 38.
 ##
 ## union_member -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ RBRACE FN COMMA ]
 ##
@@ -394,7 +420,7 @@ program: UNION IDENT LBRACE INTERFACE UNION
 
 program: UNION IDENT LBRACE INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 39.
 ##
 ## union_member -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ RBRACE FN COMMA ]
 ##
@@ -406,7 +432,7 @@ program: UNION IDENT LBRACE INTERFACE LBRACE UNION
 
 program: INTERFACE IDENT LBRACE FN UNION
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 40.
 ##
 ## function_definition(located(ident)) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located(ident)) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -419,7 +445,7 @@ program: INTERFACE IDENT LBRACE FN UNION
 
 program: INTERFACE IDENT LBRACE FN IDENT UNION
 ##
-## Ends in an error in state: 39.
+## Ends in an error in state: 41.
 ##
 ## function_definition(located(ident)) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located(ident)) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -432,7 +458,7 @@ program: INTERFACE IDENT LBRACE FN IDENT UNION
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN UNION
 ##
-## Ends in an error in state: 40.
+## Ends in an error in state: 42.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located(ident)) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -445,7 +471,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN UNION
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 42.
+## Ends in an error in state: 44.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -457,7 +483,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN U
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 45.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -468,16 +494,16 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 46.
 ##
-## code_block -> LBRACE . list(located(stmt)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ELSE COMMA ]
+## code_block -> LBRACE . list(located(stmt)) RBRACE [ UNION TILDA STRUCT SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ELSE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE
@@ -487,9 +513,9 @@ program: FN IDENT LPAREN RPAREN LBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE RETURN TYPE
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 47.
 ##
-## stmt -> RETURN . expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> RETURN . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETURN
@@ -499,7 +525,7 @@ program: FN IDENT LPAREN RPAREN LBRACE RETURN TYPE
 
 program: LET IDENT EQUALS LPAREN TYPE
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 48.
 ##
 ## fexpr -> LPAREN . struct_constructor RPAREN [ LPAREN ]
 ## fexpr -> LPAREN . function_definition(nothing) RPAREN [ LPAREN ]
@@ -513,6 +539,7 @@ program: LET IDENT EQUALS LPAREN TYPE
 ## type_expr -> LPAREN . IDENT RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . function_call RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . INT RPAREN [ LBRACE ]
+## type_expr -> LPAREN . TILDA IDENT RPAREN [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -522,7 +549,7 @@ program: LET IDENT EQUALS LPAREN TYPE
 
 program: LET IDENT EQUALS LPAREN UNION UNION
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 49.
 ##
 ## fexpr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -537,7 +564,7 @@ program: LET IDENT EQUALS LPAREN UNION UNION
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE TYPE
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 50.
 ##
 ## fexpr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -552,7 +579,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE TYPE
 
 program: UNION IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 49.
+## Ends in an error in state: 51.
 ##
 ## union_member -> IDENT . [ RBRACE FN COMMA ]
 ## union_member -> IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN COMMA ]
@@ -566,7 +593,7 @@ program: UNION IDENT LBRACE IDENT UNION
 
 program: UNION IDENT LBRACE IDENT LPAREN TYPE
 ##
-## Ends in an error in state: 50.
+## Ends in an error in state: 52.
 ##
 ## union_member -> IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN COMMA ]
 ## union_member -> IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN COMMA ]
@@ -579,7 +606,7 @@ program: UNION IDENT LBRACE IDENT LPAREN TYPE
 
 program: LET IDENT EQUALS INTERFACE UNION
 ##
-## Ends in an error in state: 51.
+## Ends in an error in state: 53.
 ##
 ## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -592,7 +619,7 @@ program: LET IDENT EQUALS INTERFACE UNION
 
 program: LET IDENT EQUALS INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 52.
+## Ends in an error in state: 54.
 ##
 ## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -605,7 +632,7 @@ program: LET IDENT EQUALS INTERFACE LBRACE UNION
 
 program: LET IDENT EQUALS INTERFACE LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 56.
 ##
 ## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
@@ -618,7 +645,7 @@ program: LET IDENT EQUALS INTERFACE LBRACE RBRACE UNION
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 55.
+## Ends in an error in state: 57.
 ##
 ## list(located(function_signature_binding)) -> function_definition(located(ident)) . list(located(function_signature_binding)) [ RBRACE ]
 ##
@@ -630,7 +657,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: LET IDENT EQUALS INT UNION
 ##
-## Ends in an error in state: 57.
+## Ends in an error in state: 59.
 ##
 ## expr -> INT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> INT . [ LPAREN ]
@@ -643,7 +670,7 @@ program: LET IDENT EQUALS INT UNION
 
 program: LET IDENT EQUALS IDENT UNION
 ##
-## Ends in an error in state: 58.
+## Ends in an error in state: 60.
 ##
 ## expr -> IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> IDENT . [ LPAREN ]
@@ -657,7 +684,7 @@ program: LET IDENT EQUALS IDENT UNION
 
 program: LET IDENT EQUALS FN UNION
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 61.
 ##
 ## function_definition(nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## function_definition(nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -670,7 +697,7 @@ program: LET IDENT EQUALS FN UNION
 
 program: LET IDENT EQUALS FN LPAREN UNION
 ##
-## Ends in an error in state: 60.
+## Ends in an error in state: 62.
 ##
 ## function_definition(nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## function_definition(nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -683,7 +710,7 @@ program: LET IDENT EQUALS FN LPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 62.
+## Ends in an error in state: 64.
 ##
 ## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -695,7 +722,7 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 63.
+## Ends in an error in state: 65.
 ##
 ## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -706,14 +733,14 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 67.
+## Ends in an error in state: 69.
 ##
 ## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -725,7 +752,7 @@ program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 70.
 ##
 ## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ##
@@ -736,14 +763,14 @@ program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM UNION
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 72.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -758,7 +785,7 @@ program: LET IDENT EQUALS ENUM UNION
 
 program: LET IDENT EQUALS ENUM LBRACE UNION
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 73.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -773,7 +800,7 @@ program: LET IDENT EQUALS ENUM LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 74.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN ]
@@ -792,7 +819,7 @@ program: ENUM IDENT LBRACE IDENT UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 73.
+## Ends in an error in state: 75.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -807,7 +834,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 76.
 ##
 ## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -820,7 +847,7 @@ program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 
 program: LET IDENT EQUALS IDENT LBRACE UNION
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 77.
 ##
 ## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
@@ -833,7 +860,7 @@ program: LET IDENT EQUALS IDENT LBRACE UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 78.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -848,7 +875,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 ##
-## Ends in an error in state: 77.
+## Ends in an error in state: 79.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -863,7 +890,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 82.
 ##
 ## expr -> function_call . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -877,7 +904,7 @@ program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN INT UNION
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 83.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
@@ -890,7 +917,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN INT UNION
 
 program: LET IDENT EQUALS IDENT LPAREN TYPE
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 84.
 ##
 ## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -903,7 +930,7 @@ program: LET IDENT EQUALS IDENT LPAREN TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 90.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -917,14 +944,14 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 91.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -938,7 +965,7 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 92.
+## Ends in an error in state: 94.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -952,14 +979,14 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 95.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -973,7 +1000,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 103.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -987,14 +1014,14 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 104.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1008,7 +1035,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA UNION
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 107.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1022,7 +1049,7 @@ program: ENUM IDENT LBRACE IDENT COMMA UNION
 
 program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 113.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -1035,7 +1062,7 @@ program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 114.
 ##
 ## list(sugared_function_definition) -> function_definition(located_ident_with_params) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1046,16 +1073,16 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 275, spurious reduction of production option(code_block) ->
-## In state 276, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 282, spurious reduction of production option(code_block) ->
+## In state 283, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 116.
 ##
 ## list(sugared_function_definition) -> function_definition(located(ident)) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1066,16 +1093,16 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 267, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 219, spurious reduction of production option(code_block) ->
-## In state 220, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 224, spurious reduction of production option(code_block) ->
+## In state 225, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 120.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -1088,7 +1115,7 @@ program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE ENUM UNION
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 125.
 ##
 ## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1101,7 +1128,7 @@ program: UNION IDENT LBRACE ENUM UNION
 
 program: UNION IDENT LBRACE ENUM LBRACE UNION
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 126.
 ##
 ## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1114,7 +1141,7 @@ program: UNION IDENT LBRACE ENUM LBRACE UNION
 
 program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 131.
+## Ends in an error in state: 133.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1129,7 +1156,7 @@ program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE IDENT COMMA TYPE
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 134.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1143,7 +1170,7 @@ program: UNION IDENT LBRACE IDENT COMMA TYPE
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 140.
 ##
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1156,7 +1183,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 142.
+## Ends in an error in state: 144.
 ##
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1167,9 +1194,35 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: LET IDENT EQUALS LPAREN TILDA UNION
+##
+## Ends in an error in state: 146.
+##
+## fexpr -> TILDA . IDENT [ LPAREN ]
+## type_expr -> LPAREN TILDA . IDENT RPAREN [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN TILDA
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS LPAREN TILDA IDENT UNION
+##
+## Ends in an error in state: 147.
+##
+## fexpr -> TILDA IDENT . [ LPAREN ]
+## type_expr -> LPAREN TILDA IDENT . RPAREN [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN TILDA IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: LET IDENT EQUALS LPAREN STRUCT UNION
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 149.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1184,7 +1237,7 @@ program: LET IDENT EQUALS LPAREN STRUCT UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 150.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1199,7 +1252,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 151.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1214,7 +1267,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 149.
+## Ends in an error in state: 154.
 ##
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1227,7 +1280,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 158.
 ##
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1240,7 +1293,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE UNION
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 160.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1253,7 +1306,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 161.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1266,7 +1319,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 163.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE ]
@@ -1279,7 +1332,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INT UNION
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 165.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE ]
@@ -1292,7 +1345,7 @@ program: LET IDENT EQUALS LPAREN INT UNION
 
 program: LET IDENT EQUALS LPAREN IDENT UNION
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 167.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
 ## type_expr -> LPAREN IDENT . RPAREN [ LBRACE ]
@@ -1306,7 +1359,7 @@ program: LET IDENT EQUALS LPAREN IDENT UNION
 
 program: LET IDENT EQUALS LPAREN ENUM UNION
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 169.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1321,7 +1374,7 @@ program: LET IDENT EQUALS LPAREN ENUM UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 170.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1336,7 +1389,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 173.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1349,7 +1402,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 177.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1362,7 +1415,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 179.
 ##
 ## fexpr -> LPAREN struct_constructor . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1374,7 +1427,7 @@ program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 181.
 ##
 ## fexpr -> LPAREN function_definition(nothing) . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1385,16 +1438,16 @@ program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 67, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 68, spurious reduction of production option(code_block) ->
-## In state 69, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 69, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 70, spurious reduction of production option(code_block) ->
+## In state 71, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 183.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE ]
@@ -1408,9 +1461,9 @@ program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 185.
 ##
-## stmt -> RETURN expr . SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> RETURN expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETURN expr
@@ -1419,18 +1472,18 @@ program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 187.
 ##
-## stmt -> LET . IDENT EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## stmt -> LET . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET . IDENT EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET
@@ -1440,11 +1493,11 @@ program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 188.
 ##
-## stmt -> LET IDENT . EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## stmt -> LET IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT
@@ -1454,10 +1507,10 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 189.
 ##
-## stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN
@@ -1467,9 +1520,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 191.
 ##
-## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
@@ -1479,9 +1532,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 192.
 ##
-## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS
@@ -1491,9 +1544,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 193.
 ##
-## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr
@@ -1502,16 +1555,16 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 196.
 ##
-## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
@@ -1521,9 +1574,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 197.
 ##
-## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS
@@ -1533,9 +1586,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 198.
 ##
-## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr
@@ -1544,16 +1597,16 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 200.
 ##
-## stmt -> LET IDENT EQUALS . expr SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT EQUALS
@@ -1563,9 +1616,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 201.
 ##
-## stmt -> LET IDENT EQUALS expr . SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> LET IDENT EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## LET IDENT EQUALS expr
@@ -1574,16 +1627,16 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 203.
 ##
-## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF
@@ -1593,9 +1646,9 @@ program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 204.
 ##
-## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN
@@ -1605,9 +1658,9 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 200.
+## Ends in an error in state: 205.
 ##
-## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr
@@ -1616,16 +1669,16 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 206.
 ##
-## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr RPAREN
@@ -1635,9 +1688,9 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 207.
 ##
-## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr RPAREN code_block
@@ -1647,10 +1700,10 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE UNION
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 208.
 ##
-## else_ -> ELSE . if_ [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
-## else_ -> ELSE . code_block [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## else_ -> ELSE . if_ [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## else_ -> ELSE . code_block [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## ELSE
@@ -1660,7 +1713,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE
 
 program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 213.
 ##
 ## list(located(stmt)) -> stmt . list(located(stmt)) [ RBRACE ]
 ##
@@ -1672,9 +1725,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 216.
 ##
-## stmt -> expr . SEMICOLON [ UNION STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
+## stmt -> expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr
@@ -1683,14 +1736,14 @@ program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 223.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -1702,7 +1755,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 224.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1713,14 +1766,26 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
+##
+## Ends in an error in state: 234.
+##
+## fexpr -> TILDA . IDENT [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+##
+## The known suffix of the stack is as follows:
+## TILDA
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 236.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1733,7 +1798,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 237.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1746,7 +1811,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 238.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1759,7 +1824,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 245.
 ##
 ## fexpr -> LPAREN . struct_constructor RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> LPAREN . function_definition(nothing) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1772,7 +1837,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 246.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1784,7 +1849,7 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 247.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1796,7 +1861,7 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 251.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
 ## type_expr -> IDENT . [ LBRACE ]
@@ -1809,7 +1874,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 252.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1822,7 +1887,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 253.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1835,7 +1900,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 260.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
@@ -1848,7 +1913,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 263.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1862,7 +1927,7 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 264.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -1875,7 +1940,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 266.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1887,7 +1952,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 267.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1898,14 +1963,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 270.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1917,7 +1982,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 271.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1928,14 +1993,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 274.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -1949,7 +2014,7 @@ program: FN IDENT LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 275.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -1962,7 +2027,7 @@ program: FN IDENT LPAREN RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 277.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1974,7 +2039,7 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 278.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1985,14 +2050,14 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 281.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2004,7 +2069,7 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 282.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2015,14 +2080,14 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 256, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 263, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 285.
 ##
 ## expr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2035,7 +2100,7 @@ program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 288.
 ##
 ## expr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2048,7 +2113,7 @@ program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 289.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2062,14 +2127,14 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 290.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2083,7 +2148,7 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 307.
 ##
 ## expr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2096,7 +2161,7 @@ program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 310.
 ##
 ## expr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2109,7 +2174,7 @@ program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 311.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2123,14 +2188,14 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 312.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2144,7 +2209,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 316.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2157,7 +2222,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 317.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2170,7 +2235,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 320.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2182,7 +2247,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RB
 
 program: STRUCT UNION
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 321.
 ##
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2199,7 +2264,7 @@ program: STRUCT UNION
 
 program: STRUCT IDENT UNION
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 322.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2216,7 +2281,7 @@ program: STRUCT IDENT UNION
 
 program: STRUCT IDENT LPAREN UNION
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 323.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2231,7 +2296,7 @@ program: STRUCT IDENT LPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 325.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2244,7 +2309,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 326.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2257,7 +2322,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 329.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2269,7 +2334,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA R
 
 program: LET UNION
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 330.
 ##
 ## list(top_level_stmt) -> LET . IDENT EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2283,7 +2348,7 @@ program: LET UNION
 
 program: LET IDENT UNION
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 331.
 ##
 ## list(top_level_stmt) -> LET IDENT . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2297,7 +2362,7 @@ program: LET IDENT UNION
 
 program: LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 332.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2310,7 +2375,7 @@ program: LET IDENT LPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 334.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2322,7 +2387,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 335.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2334,7 +2399,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 336.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2345,14 +2410,14 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 337.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2364,7 +2429,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON 
 
 program: INTERFACE UNION
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 338.
 ##
 ## list(top_level_stmt) -> INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2378,7 +2443,7 @@ program: INTERFACE UNION
 
 program: INTERFACE IDENT UNION
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 339.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2392,7 +2457,7 @@ program: INTERFACE IDENT UNION
 
 program: INTERFACE IDENT LPAREN UNION
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 340.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2405,7 +2470,7 @@ program: INTERFACE IDENT LPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 342.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2417,7 +2482,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 343.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2429,7 +2494,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 345.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2441,7 +2506,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYP
 
 program: ENUM UNION
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 346.
 ##
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2458,7 +2523,7 @@ program: ENUM UNION
 
 program: ENUM IDENT UNION
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 347.
 ##
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2475,7 +2540,7 @@ program: ENUM IDENT UNION
 
 program: ENUM IDENT LPAREN UNION
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 348.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2490,7 +2555,7 @@ program: ENUM IDENT LPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 350.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2503,7 +2568,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 351.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2516,7 +2581,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 354.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2528,7 +2593,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBR
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 356.
 ##
 ## list(top_level_stmt) -> function_definition(located_ident_with_params) . list(top_level_stmt) [ EOF ]
 ##
@@ -2539,16 +2604,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 275, spurious reduction of production option(code_block) ->
-## In state 276, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 282, spurious reduction of production option(code_block) ->
+## In state 283, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 358.
 ##
 ## list(top_level_stmt) -> function_definition(located(ident)) . list(top_level_stmt) [ EOF ]
 ##
@@ -2559,16 +2624,16 @@ program: FN IDENT LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 267, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 219, spurious reduction of production option(code_block) ->
-## In state 220, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 274, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 224, spurious reduction of production option(code_block) ->
+## In state 225, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 362.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2580,7 +2645,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 365.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2593,7 +2658,7 @@ program: ENUM IDENT LPAREN RPAREN UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 366.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2606,7 +2671,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 369.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2618,7 +2683,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 373.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2630,7 +2695,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LBRACE UNION
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 375.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2643,7 +2708,7 @@ program: ENUM IDENT LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 378.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2655,7 +2720,7 @@ program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 382.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2667,7 +2732,7 @@ program: ENUM IDENT LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 386.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2679,7 +2744,7 @@ program: INTERFACE IDENT LPAREN RPAREN UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 387.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2691,7 +2756,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 389.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2703,7 +2768,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LBRACE UNION
 ##
-## Ends in an error in state: 384.
+## Ends in an error in state: 391.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2715,7 +2780,7 @@ program: INTERFACE IDENT LBRACE UNION
 
 program: INTERFACE IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 393.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2727,7 +2792,7 @@ program: INTERFACE IDENT LBRACE RBRACE TYPE
 
 program: LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 397.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2739,7 +2804,7 @@ program: LET IDENT LPAREN RPAREN UNION
 
 program: LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 398.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2751,7 +2816,7 @@ program: LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 399.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2762,14 +2827,14 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 400.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2781,7 +2846,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 
 program: LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 402.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2793,7 +2858,7 @@ program: LET IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 403.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2804,14 +2869,14 @@ program: LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 58, spurious reduction of production expr -> IDENT
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 404.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2823,7 +2888,7 @@ program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 409.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2835,7 +2900,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 412.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2848,7 +2913,7 @@ program: STRUCT IDENT LPAREN RPAREN UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 413.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2861,7 +2926,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 416.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2873,7 +2938,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 420.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2885,7 +2950,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 422.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2898,7 +2963,7 @@ program: STRUCT IDENT LBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 425.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2910,7 +2975,7 @@ program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 429.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2922,7 +2987,7 @@ program: STRUCT IDENT LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 434.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2934,7 +2999,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 437.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2947,7 +3012,7 @@ program: UNION IDENT LPAREN RPAREN UNION
 
 program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 438.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2960,7 +3025,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 441.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2972,7 +3037,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 445.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2984,7 +3049,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LBRACE TYPE
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 447.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2997,7 +3062,7 @@ program: UNION IDENT LBRACE TYPE
 
 program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 450.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3009,7 +3074,7 @@ program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 454.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -494,9 +494,8 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -538,7 +537,8 @@ program: LET IDENT EQUALS LPAREN TYPE
 ## type_expr -> LPAREN . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
-## type_expr -> LPAREN . reference RPAREN [ LBRACE ]
+## type_expr -> LPAREN . IDENT RPAREN [ LBRACE ]
+## type_expr -> LPAREN . field_access RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . function_call RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . INT RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . TILDA IDENT RPAREN [ LBRACE ]
@@ -674,8 +674,9 @@ program: LET IDENT EQUALS IDENT UNION
 ##
 ## Ends in an error in state: 60.
 ##
-## reference -> IDENT . [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
-## reference -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
+## expr -> IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## fexpr -> IDENT . [ LPAREN ]
+## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
 ## type_expr -> IDENT . [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
@@ -688,7 +689,7 @@ program: LET IDENT EQUALS IDENT DOT TYPE
 ##
 ## Ends in an error in state: 61.
 ##
-## reference -> IDENT DOT . loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## field_access -> IDENT DOT . loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENT DOT
@@ -772,9 +773,8 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -804,9 +804,8 @@ program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -931,29 +930,9 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS IDENT DOT UNION
-##
-## Ends in an error in state: 87.
-##
-## expr -> reference . [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## fexpr -> reference . [ LPAREN ]
-##
-## The known suffix of the stack is as follows:
-## reference
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
-## In state 66, spurious reduction of production reference -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 88.
 ##
 ## expr -> function_call . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -961,6 +940,26 @@ program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 ##
 ## The known suffix of the stack is as follows:
 ## function_call
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS IDENT DOT UNION
+##
+## Ends in an error in state: 89.
+##
+## expr -> field_access . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## fexpr -> field_access . [ LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## field_access
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
+## In state 66, spurious reduction of production field_access -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1007,8 +1006,7 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1043,8 +1041,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1079,8 +1076,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1139,9 +1135,9 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 288, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 289, spurious reduction of production option(code_block) ->
-## In state 290, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 291, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 292, spurious reduction of production option(code_block) ->
+## In state 293, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1159,9 +1155,9 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 231, spurious reduction of production option(code_block) ->
-## In state 232, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 284, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 233, spurious reduction of production option(code_block) ->
+## In state 234, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1409,9 +1405,24 @@ program: LET IDENT EQUALS LPAREN INT UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS LPAREN ENUM UNION
+program: LET IDENT EQUALS LPAREN IDENT UNION
 ##
 ## Ends in an error in state: 174.
+##
+## fexpr -> IDENT . [ LPAREN ]
+## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ RPAREN LPAREN ]
+## type_expr -> LPAREN IDENT . RPAREN [ LBRACE ]
+## type_expr -> IDENT . [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: LET IDENT EQUALS LPAREN ENUM UNION
+##
+## Ends in an error in state: 176.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1426,7 +1437,7 @@ program: LET IDENT EQUALS LPAREN ENUM UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 177.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1441,7 +1452,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 180.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1454,7 +1465,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 184.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1467,31 +1478,12 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 186.
 ##
 ## fexpr -> LPAREN struct_constructor . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN struct_constructor
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: LET IDENT EQUALS LPAREN IDENT SEMICOLON
-##
-## Ends in an error in state: 186.
-##
-## fexpr -> reference . [ LPAREN ]
-## type_expr -> LPAREN reference . RPAREN [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN reference
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1530,9 +1522,29 @@ program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
+program: LET IDENT EQUALS LPAREN IDENT DOT UNION
 ##
 ## Ends in an error in state: 192.
+##
+## fexpr -> field_access . [ LPAREN ]
+## type_expr -> LPAREN field_access . RPAREN [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN field_access
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
+## In state 66, spurious reduction of production field_access -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
+##
+## Ends in an error in state: 194.
 ##
 ## stmt -> RETURN expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1543,15 +1555,14 @@ program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 196.
 ##
 ## stmt -> LET . IDENT EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1565,7 +1576,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 197.
 ##
 ## stmt -> LET IDENT . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1579,7 +1590,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 198.
 ##
 ## stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1592,7 +1603,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 200.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1604,7 +1615,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 201.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1616,7 +1627,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 200.
+## Ends in an error in state: 202.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1627,15 +1638,14 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 205.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1647,7 +1657,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 206.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1659,7 +1669,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 207.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1670,15 +1680,14 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAR
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 209.
 ##
 ## stmt -> LET IDENT EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1690,7 +1699,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 210.
 ##
 ## stmt -> LET IDENT EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1701,15 +1710,14 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 212.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1721,7 +1729,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 213.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1733,7 +1741,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 214.
 ##
 ## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1744,15 +1752,14 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 215.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1764,7 +1771,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 216.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1776,7 +1783,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE UNION
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 217.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## else_ -> ELSE . code_block [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1789,7 +1796,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE
 
 program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 222.
 ##
 ## list(located(stmt)) -> stmt . list(located(stmt)) [ RBRACE ]
 ##
@@ -1801,7 +1808,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 225.
 ##
 ## stmt -> expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1812,15 +1819,14 @@ program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 232.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -1832,7 +1838,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 233.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1843,16 +1849,15 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 243.
 ##
 ## fexpr -> TILDA . IDENT [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1864,7 +1869,7 @@ program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 245.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1877,7 +1882,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 246.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1890,7 +1895,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 247.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1903,7 +1908,7 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 254.
 ##
 ## fexpr -> LPAREN . struct_constructor RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> LPAREN . function_definition(nothing) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1916,7 +1921,7 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 255.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1928,7 +1933,7 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 256.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
@@ -1938,9 +1943,23 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
+##
+## Ends in an error in state: 260.
+##
+## fexpr -> IDENT . [ LPAREN ]
+## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ LPAREN ]
+## type_expr -> IDENT . [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 261.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1953,7 +1972,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 262.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -1966,7 +1985,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 269.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
@@ -1979,10 +1998,10 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 271.
 ##
-## reference -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## reference -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENT
@@ -1992,7 +2011,7 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW INT TYPE
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 273.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
@@ -2006,7 +2025,7 @@ program: FN IDENT LPAREN RPAREN RARROW INT TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 274.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2019,7 +2038,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 276.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2031,7 +2050,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 277.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2042,16 +2061,15 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 280.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2063,7 +2081,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 281.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2074,16 +2092,15 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 284.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2097,7 +2114,7 @@ program: FN IDENT LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 285.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2110,7 +2127,7 @@ program: FN IDENT LPAREN RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 287.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2122,7 +2139,7 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 288.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2133,16 +2150,15 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 291.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2154,7 +2170,7 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 292.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2165,16 +2181,15 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 268, spurious reduction of production reference -> IDENT
-## In state 266, spurious reduction of production fexpr -> reference
-## In state 270, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 271, spurious reduction of production fexpr -> IDENT
+## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 295.
 ##
 ## expr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2187,7 +2202,7 @@ program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 298.
 ##
 ## expr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2200,7 +2215,7 @@ program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 299.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2214,15 +2229,14 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 297.
+## Ends in an error in state: 300.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2236,7 +2250,7 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 317.
 ##
 ## expr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2249,7 +2263,7 @@ program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 320.
 ##
 ## expr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
@@ -2262,7 +2276,7 @@ program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 321.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2276,15 +2290,14 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 322.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2298,7 +2311,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 326.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2311,7 +2324,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 327.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2324,7 +2337,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 330.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2336,7 +2349,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RB
 
 program: STRUCT UNION
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 331.
 ##
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2353,7 +2366,7 @@ program: STRUCT UNION
 
 program: STRUCT IDENT UNION
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 332.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2370,7 +2383,7 @@ program: STRUCT IDENT UNION
 
 program: STRUCT IDENT LPAREN UNION
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 333.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2385,7 +2398,7 @@ program: STRUCT IDENT LPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 335.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2398,7 +2411,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 336.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2411,7 +2424,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 339.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2423,7 +2436,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA R
 
 program: LET UNION
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 340.
 ##
 ## list(top_level_stmt) -> LET . IDENT EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2437,7 +2450,7 @@ program: LET UNION
 
 program: LET IDENT UNION
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 341.
 ##
 ## list(top_level_stmt) -> LET IDENT . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2451,7 +2464,7 @@ program: LET IDENT UNION
 
 program: LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 342.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2464,7 +2477,7 @@ program: LET IDENT LPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 344.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2476,7 +2489,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 345.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2488,7 +2501,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 346.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2499,15 +2512,14 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 347.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2519,7 +2531,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON 
 
 program: INTERFACE UNION
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 348.
 ##
 ## list(top_level_stmt) -> INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2533,7 +2545,7 @@ program: INTERFACE UNION
 
 program: INTERFACE IDENT UNION
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 349.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2547,7 +2559,7 @@ program: INTERFACE IDENT UNION
 
 program: INTERFACE IDENT LPAREN UNION
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 350.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2560,7 +2572,7 @@ program: INTERFACE IDENT LPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 352.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2572,7 +2584,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 353.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2584,7 +2596,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 355.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2596,7 +2608,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYP
 
 program: ENUM UNION
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 356.
 ##
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2613,7 +2625,7 @@ program: ENUM UNION
 
 program: ENUM IDENT UNION
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 357.
 ##
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2630,7 +2642,7 @@ program: ENUM IDENT UNION
 
 program: ENUM IDENT LPAREN UNION
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 358.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2645,7 +2657,7 @@ program: ENUM IDENT LPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 360.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2658,7 +2670,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 361.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2671,7 +2683,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 364.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2683,7 +2695,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBR
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 366.
 ##
 ## list(top_level_stmt) -> function_definition(located_ident_with_params) . list(top_level_stmt) [ EOF ]
 ##
@@ -2694,16 +2706,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 288, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 289, spurious reduction of production option(code_block) ->
-## In state 290, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 291, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 292, spurious reduction of production option(code_block) ->
+## In state 293, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 368.
 ##
 ## list(top_level_stmt) -> function_definition(located(ident)) . list(top_level_stmt) [ EOF ]
 ##
@@ -2714,16 +2726,16 @@ program: FN IDENT LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 281, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 231, spurious reduction of production option(code_block) ->
-## In state 232, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 284, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 233, spurious reduction of production option(code_block) ->
+## In state 234, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 372.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2735,7 +2747,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 375.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2748,7 +2760,7 @@ program: ENUM IDENT LPAREN RPAREN UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 376.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2761,7 +2773,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 379.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2773,7 +2785,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 383.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2785,7 +2797,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LBRACE UNION
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 385.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2798,7 +2810,7 @@ program: ENUM IDENT LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 388.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2810,7 +2822,7 @@ program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 392.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2822,7 +2834,7 @@ program: ENUM IDENT LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 396.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2834,7 +2846,7 @@ program: INTERFACE IDENT LPAREN RPAREN UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 397.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2846,7 +2858,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 399.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2858,7 +2870,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LBRACE UNION
 ##
-## Ends in an error in state: 398.
+## Ends in an error in state: 401.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2870,7 +2882,7 @@ program: INTERFACE IDENT LBRACE UNION
 
 program: INTERFACE IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 403.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2882,7 +2894,7 @@ program: INTERFACE IDENT LBRACE RBRACE TYPE
 
 program: LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 407.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2894,7 +2906,7 @@ program: LET IDENT LPAREN RPAREN UNION
 
 program: LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 408.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2906,7 +2918,7 @@ program: LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 409.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2917,15 +2929,14 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 410.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2937,7 +2948,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 
 program: LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 412.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2949,7 +2960,7 @@ program: LET IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 413.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2960,15 +2971,14 @@ program: LET IDENT EQUALS IDENT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 60, spurious reduction of production reference -> IDENT
-## In state 87, spurious reduction of production expr -> reference
+## In state 60, spurious reduction of production expr -> IDENT
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 414.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2980,7 +2990,7 @@ program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 419.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2992,7 +3002,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 422.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3005,7 +3015,7 @@ program: STRUCT IDENT LPAREN RPAREN UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 423.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3018,7 +3028,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 426.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3030,7 +3040,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 430.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3042,7 +3052,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 432.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3055,7 +3065,7 @@ program: STRUCT IDENT LBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 435.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3067,7 +3077,7 @@ program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 439.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3079,7 +3089,7 @@ program: STRUCT IDENT LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 444.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3091,7 +3101,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 447.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3104,7 +3114,7 @@ program: UNION IDENT LPAREN RPAREN UNION
 
 program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 448.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3117,7 +3127,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 451.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3129,7 +3139,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 455.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3141,7 +3151,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LBRACE TYPE
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 457.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3154,7 +3164,7 @@ program: UNION IDENT LBRACE TYPE
 
 program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 460.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3166,7 +3176,7 @@ program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 464.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -93,8 +93,8 @@ program: LET IDENT EQUALS UNION UNION
 ##
 ## Ends in an error in state: 6.
 ##
-## expr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -108,8 +108,8 @@ program: LET IDENT EQUALS UNION LBRACE TYPE
 ##
 ## Ends in an error in state: 7.
 ##
-## expr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -223,7 +223,7 @@ program: LET IDENT EQUALS TILDA UNION
 ##
 ## Ends in an error in state: 17.
 ##
-## expr -> TILDA . IDENT [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> TILDA . IDENT [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> TILDA . IDENT [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -236,7 +236,7 @@ program: LET IDENT EQUALS TILDA IDENT UNION
 ##
 ## Ends in an error in state: 18.
 ##
-## expr -> TILDA IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> TILDA IDENT . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> TILDA IDENT . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -249,8 +249,8 @@ program: LET IDENT EQUALS STRUCT UNION
 ##
 ## Ends in an error in state: 19.
 ##
-## expr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -277,8 +277,8 @@ program: LET IDENT EQUALS STRUCT LPAREN RPAREN UNION
 ##
 ## Ends in an error in state: 26.
 ##
-## expr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -292,8 +292,8 @@ program: LET IDENT EQUALS STRUCT LBRACE UNION
 ##
 ## Ends in an error in state: 27.
 ##
-## expr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -372,7 +372,7 @@ program: FN IDENT LPAREN RPAREN RARROW TYPE
 ##
 ## Ends in an error in state: 35.
 ##
-## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ UNION STRUCT SEMICOLON RPAREN RBRACE LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ UNION STRUCT SEMICOLON RPAREN RBRACE LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## RARROW
@@ -384,8 +384,8 @@ program: FN IDENT LPAREN RPAREN RARROW UNION UNION
 ##
 ## Ends in an error in state: 36.
 ##
-## fexpr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> UNION . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> UNION . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION
@@ -397,8 +397,8 @@ program: FN IDENT LPAREN RPAREN RARROW UNION LBRACE TYPE
 ##
 ## Ends in an error in state: 37.
 ##
-## fexpr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> UNION LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> UNION LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION LBRACE
@@ -494,8 +494,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -504,7 +503,7 @@ program: FN IDENT LPAREN RPAREN LBRACE TYPE
 ##
 ## Ends in an error in state: 46.
 ##
-## code_block -> LBRACE . list(located(stmt)) RBRACE [ UNION TILDA STRUCT SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ELSE COMMA ]
+## code_block -> LBRACE . list(located(stmt)) RBRACE [ UNION TILDA STRUCT SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ELSE DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE
@@ -538,7 +537,6 @@ program: LET IDENT EQUALS LPAREN TYPE
 ## type_expr -> LPAREN . UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . IDENT RPAREN [ LBRACE ]
-## type_expr -> LPAREN . field_access RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . function_call RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . INT RPAREN [ LBRACE ]
 ## type_expr -> LPAREN . TILDA IDENT RPAREN [ LBRACE ]
@@ -610,7 +608,7 @@ program: LET IDENT EQUALS INTERFACE UNION
 ##
 ## Ends in an error in state: 53.
 ##
-## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -623,7 +621,7 @@ program: LET IDENT EQUALS INTERFACE LBRACE UNION
 ##
 ## Ends in an error in state: 54.
 ##
-## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -636,7 +634,7 @@ program: LET IDENT EQUALS INTERFACE LBRACE RBRACE UNION
 ##
 ## Ends in an error in state: 56.
 ##
-## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -661,7 +659,7 @@ program: LET IDENT EQUALS INT UNION
 ##
 ## Ends in an error in state: 59.
 ##
-## expr -> INT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> INT . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> INT . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -674,9 +672,8 @@ program: LET IDENT EQUALS IDENT UNION
 ##
 ## Ends in an error in state: 60.
 ##
-## expr -> IDENT . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> IDENT . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> IDENT . [ LPAREN ]
-## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ SEMICOLON RPAREN RBRACE LPAREN FN COMMA ]
 ## type_expr -> IDENT . [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
@@ -685,49 +682,12 @@ program: LET IDENT EQUALS IDENT UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS IDENT DOT TYPE
+program: LET IDENT EQUALS FN UNION
 ##
 ## Ends in an error in state: 61.
 ##
-## field_access -> IDENT DOT . loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-##
-## The known suffix of the stack is as follows:
-## IDENT DOT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: LET IDENT EQUALS IDENT DOT IDENT TYPE
-##
-## Ends in an error in state: 62.
-##
-## separated_nonempty_list(DOT,located(ident)) -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## separated_nonempty_list(DOT,located(ident)) -> IDENT . DOT separated_nonempty_list(DOT,located(ident)) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: LET IDENT EQUALS IDENT DOT IDENT DOT UNION
-##
-## Ends in an error in state: 63.
-##
-## separated_nonempty_list(DOT,located(ident)) -> IDENT DOT . separated_nonempty_list(DOT,located(ident)) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-##
-## The known suffix of the stack is as follows:
-## IDENT DOT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: LET IDENT EQUALS FN UNION
-##
-## Ends in an error in state: 67.
-##
-## function_definition(nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## function_definition(nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## function_definition(nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN
@@ -737,10 +697,10 @@ program: LET IDENT EQUALS FN UNION
 
 program: LET IDENT EQUALS FN LPAREN UNION
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 62.
 ##
-## function_definition(nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## function_definition(nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## function_definition(nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN LPAREN
@@ -750,9 +710,9 @@ program: LET IDENT EQUALS FN LPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 64.
 ##
-## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
@@ -762,9 +722,9 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 65.
 ##
-## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
@@ -773,17 +733,16 @@ program: LET IDENT EQUALS FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 69.
 ##
-## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
@@ -793,9 +752,9 @@ program: LET IDENT EQUALS FN LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 70.
 ##
-## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
@@ -804,18 +763,17 @@ program: LET IDENT EQUALS FN LPAREN RPAREN RARROW IDENT UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM UNION
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 72.
 ##
-## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -827,10 +785,10 @@ program: LET IDENT EQUALS ENUM UNION
 
 program: LET IDENT EQUALS ENUM LBRACE UNION
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 73.
 ##
-## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ##
@@ -842,7 +800,7 @@ program: LET IDENT EQUALS ENUM LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 74.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN ]
@@ -861,7 +819,7 @@ program: ENUM IDENT LBRACE IDENT UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 75.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -876,10 +834,10 @@ program: ENUM IDENT LBRACE IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 76.
 ##
-## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_expr
@@ -889,10 +847,10 @@ program: LET IDENT EQUALS LPAREN IDENT RPAREN UNION
 
 program: LET IDENT EQUALS IDENT LBRACE UNION
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 77.
 ##
-## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_expr LBRACE
@@ -902,7 +860,7 @@ program: LET IDENT EQUALS IDENT LBRACE UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 78.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -917,7 +875,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT UNION
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 79.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -932,9 +890,9 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 82.
 ##
-## expr -> function_call . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> function_call . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
 ##
@@ -944,32 +902,12 @@ program: LET IDENT EQUALS IDENT LPAREN RPAREN UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS IDENT DOT UNION
+program: FN IDENT LPAREN RPAREN RARROW LPAREN INT UNION
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 83.
 ##
-## expr -> field_access . [ SEMICOLON RPAREN RBRACE FN COMMA ]
-## fexpr -> field_access . [ LPAREN ]
-##
-## The known suffix of the stack is as follows:
-## field_access
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
-## In state 66, spurious reduction of production field_access -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: FN IDENT LPAREN RPAREN RARROW LPAREN INT TYPE
-##
-## Ends in an error in state: 90.
-##
-## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
-## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN COMMA ]
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN DOT COMMA ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RPAREN RBRACE LPAREN LBRACE FN DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr
@@ -979,10 +917,10 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN INT TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN TYPE
 ##
-## Ends in an error in state: 91.
+## Ends in an error in state: 84.
 ##
-## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr LPAREN
@@ -992,8 +930,9 @@ program: LET IDENT EQUALS IDENT LPAREN TYPE
 
 program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 90.
 ##
+## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
 ## separated_nonempty_list(COMMA,located(expr)) -> expr . [ RPAREN ]
@@ -1011,9 +950,21 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT SEMICOLON
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: LET IDENT EQUALS IDENT DOT UNION
+##
+## Ends in an error in state: 91.
+##
+## expr -> expr DOT . IDENT [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 93.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -1027,8 +978,9 @@ program: LET IDENT EQUALS IDENT LPAREN IDENT COMMA TYPE
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 96.
 ##
+## expr -> expr . DOT IDENT [ RBRACE DOT COMMA ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
 ## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . [ RBRACE ]
@@ -1048,7 +1000,7 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT SEMICOLON
 
 program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 97.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1062,8 +1014,9 @@ program: LET IDENT EQUALS IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 105.
 ##
+## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
 ## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . [ RBRACE FN ]
@@ -1083,7 +1036,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT SEMICOLON
 
 program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 106.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1097,7 +1050,7 @@ program: ENUM IDENT LBRACE IDENT EQUALS IDENT COMMA UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA UNION
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 109.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -1111,9 +1064,9 @@ program: ENUM IDENT LBRACE IDENT COMMA UNION
 
 program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 115.
 ##
-## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1124,7 +1077,7 @@ program: LET IDENT EQUALS ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 121.
+## Ends in an error in state: 116.
 ##
 ## list(sugared_function_definition) -> function_definition(located_ident_with_params) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1135,16 +1088,16 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 292, spurious reduction of production option(code_block) ->
-## In state 293, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 283, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 284, spurious reduction of production option(code_block) ->
+## In state 285, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 123.
+## Ends in an error in state: 118.
 ##
 ## list(sugared_function_definition) -> function_definition(located(ident)) . list(sugared_function_definition) [ RBRACE ]
 ##
@@ -1155,18 +1108,18 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 284, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 233, spurious reduction of production option(code_block) ->
-## In state 234, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 276, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 226, spurious reduction of production option(code_block) ->
+## In state 227, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 122.
 ##
-## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1177,7 +1130,7 @@ program: LET IDENT EQUALS ENUM LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE ENUM UNION
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 127.
 ##
 ## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1190,7 +1143,7 @@ program: UNION IDENT LBRACE ENUM UNION
 
 program: UNION IDENT LBRACE ENUM LBRACE UNION
 ##
-## Ends in an error in state: 133.
+## Ends in an error in state: 128.
 ##
 ## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
 ## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ RBRACE FN COMMA ]
@@ -1203,7 +1156,7 @@ program: UNION IDENT LBRACE ENUM LBRACE UNION
 
 program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 140.
+## Ends in an error in state: 135.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member . COMMA nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1218,7 +1171,7 @@ program: UNION IDENT LBRACE UNION LBRACE RBRACE UNION
 
 program: UNION IDENT LBRACE IDENT COMMA TYPE
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 136.
 ##
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(located(union_member),COMMA)) -> union_member COMMA . nonempty_list(terminated(located(union_member),COMMA)) [ RBRACE FN ]
@@ -1232,7 +1185,7 @@ program: UNION IDENT LBRACE IDENT COMMA TYPE
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 142.
 ##
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1245,7 +1198,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 146.
 ##
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1258,7 +1211,7 @@ program: LET IDENT EQUALS LPAREN UNION LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN TILDA UNION
 ##
-## Ends in an error in state: 153.
+## Ends in an error in state: 148.
 ##
 ## fexpr -> TILDA . IDENT [ LPAREN ]
 ## type_expr -> LPAREN TILDA . IDENT RPAREN [ LBRACE ]
@@ -1271,7 +1224,7 @@ program: LET IDENT EQUALS LPAREN TILDA UNION
 
 program: LET IDENT EQUALS LPAREN TILDA IDENT UNION
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 149.
 ##
 ## fexpr -> TILDA IDENT . [ LPAREN ]
 ## type_expr -> LPAREN TILDA IDENT . RPAREN [ LBRACE ]
@@ -1284,7 +1237,7 @@ program: LET IDENT EQUALS LPAREN TILDA IDENT UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT UNION
 ##
-## Ends in an error in state: 156.
+## Ends in an error in state: 151.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1299,7 +1252,7 @@ program: LET IDENT EQUALS LPAREN STRUCT UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 157.
+## Ends in an error in state: 152.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1314,7 +1267,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LPAREN RPAREN UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 158.
+## Ends in an error in state: 153.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1329,7 +1282,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 156.
 ##
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1342,7 +1295,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 165.
+## Ends in an error in state: 160.
 ##
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1355,7 +1308,7 @@ program: LET IDENT EQUALS LPAREN STRUCT LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE UNION
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 162.
 ##
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1368,7 +1321,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 163.
 ##
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE ]
@@ -1381,7 +1334,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 165.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE ]
@@ -1394,7 +1347,7 @@ program: LET IDENT EQUALS LPAREN INTERFACE LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN INT UNION
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 167.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE ]
@@ -1407,10 +1360,9 @@ program: LET IDENT EQUALS LPAREN INT UNION
 
 program: LET IDENT EQUALS LPAREN IDENT UNION
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 169.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
-## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ RPAREN LPAREN ]
 ## type_expr -> LPAREN IDENT . RPAREN [ LBRACE ]
 ## type_expr -> IDENT . [ LBRACE ]
 ##
@@ -1422,7 +1374,7 @@ program: LET IDENT EQUALS LPAREN IDENT UNION
 
 program: LET IDENT EQUALS LPAREN ENUM UNION
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 171.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1437,7 +1389,7 @@ program: LET IDENT EQUALS LPAREN ENUM UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 172.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ LPAREN ]
@@ -1452,7 +1404,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 175.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1465,7 +1417,7 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 179.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . RPAREN [ LBRACE ]
@@ -1478,9 +1430,9 @@ program: LET IDENT EQUALS LPAREN ENUM LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 181.
 ##
-## fexpr -> LPAREN struct_constructor . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> LPAREN struct_constructor . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN struct_constructor
@@ -1490,9 +1442,9 @@ program: LET IDENT EQUALS LPAREN IDENT LBRACE RBRACE UNION
 
 program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 183.
 ##
-## fexpr -> LPAREN function_definition(nothing) . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> LPAREN function_definition(nothing) . RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN function_definition(nothing)
@@ -1501,16 +1453,16 @@ program: LET IDENT EQUALS LPAREN FN LPAREN RPAREN SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 75, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 76, spurious reduction of production option(code_block) ->
-## In state 77, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 69, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 70, spurious reduction of production option(code_block) ->
+## In state 71, spurious reduction of production function_definition(nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 185.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE ]
@@ -1522,30 +1474,11 @@ program: LET IDENT EQUALS LPAREN IDENT LPAREN RPAREN UNION
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: LET IDENT EQUALS LPAREN IDENT DOT UNION
-##
-## Ends in an error in state: 192.
-##
-## fexpr -> field_access . [ LPAREN ]
-## type_expr -> LPAREN field_access . RPAREN [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN field_access
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 61, spurious reduction of production loption(separated_nonempty_list(DOT,located(ident))) ->
-## In state 66, spurious reduction of production field_access -> IDENT DOT loption(separated_nonempty_list(DOT,located(ident)))
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
 program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 187.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## stmt -> RETURN expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1562,7 +1495,7 @@ program: FN IDENT LPAREN RPAREN LBRACE RETURN IDENT RPAREN
 
 program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 ##
-## Ends in an error in state: 196.
+## Ends in an error in state: 189.
 ##
 ## stmt -> LET . IDENT EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1576,7 +1509,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 190.
 ##
 ## stmt -> LET IDENT . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1590,7 +1523,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 191.
 ##
 ## stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1603,7 +1536,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 200.
+## Ends in an error in state: 193.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1615,7 +1548,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 194.
 ##
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1627,8 +1560,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 195.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1645,7 +1579,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN IDENT COLON IDENT COMMA 
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 198.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1657,7 +1591,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 199.
 ##
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1669,8 +1603,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 200.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1687,7 +1622,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT LPAREN RPAREN EQUALS IDENT RPAR
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 202.
 ##
 ## stmt -> LET IDENT EQUALS . expr SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1699,8 +1634,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 203.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## stmt -> LET IDENT EQUALS expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1717,7 +1653,7 @@ program: FN IDENT LPAREN RPAREN LBRACE LET IDENT EQUALS IDENT RPAREN
 
 program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 205.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1729,7 +1665,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 206.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1741,8 +1677,9 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 207.
 ##
+## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1759,7 +1696,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT SEMICOLON
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 208.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1771,7 +1708,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 209.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
@@ -1783,7 +1720,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE UNION
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 210.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ## else_ -> ELSE . code_block [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
@@ -1796,7 +1733,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE
 
 program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 215.
 ##
 ## list(located(stmt)) -> stmt . list(located(stmt)) [ RBRACE ]
 ##
@@ -1808,8 +1745,9 @@ program: FN IDENT LPAREN RPAREN LBRACE LBRACE RBRACE TYPE
 
 program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 218.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## stmt -> expr . SEMICOLON [ UNION TILDA STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1826,7 +1764,7 @@ program: FN IDENT LPAREN RPAREN LBRACE IDENT RPAREN
 
 program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 225.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -1838,7 +1776,7 @@ program: INTERFACE IDENT LBRACE FN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 226.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -1849,17 +1787,16 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 236.
 ##
-## fexpr -> TILDA . IDENT [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> TILDA . IDENT [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## TILDA
@@ -1869,10 +1806,10 @@ program: FN IDENT LPAREN RPAREN RARROW TILDA UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 238.
 ##
-## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> STRUCT . option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> STRUCT . option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## STRUCT
@@ -1882,10 +1819,10 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 239.
 ##
-## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> STRUCT option(params) . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> STRUCT option(params) . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## STRUCT option(params)
@@ -1895,10 +1832,10 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 240.
 ##
-## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> STRUCT option(params) LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> STRUCT option(params) LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## STRUCT option(params) LBRACE
@@ -1908,10 +1845,10 @@ program: FN IDENT LPAREN RPAREN RARROW STRUCT LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 247.
 ##
-## fexpr -> LPAREN . struct_constructor RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> LPAREN . function_definition(nothing) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> LPAREN . struct_constructor RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> LPAREN . function_definition(nothing) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN
@@ -1921,9 +1858,9 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 248.
 ##
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## INTERFACE
@@ -1933,9 +1870,9 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 ##
-## Ends in an error in state: 256.
+## Ends in an error in state: 249.
 ##
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## INTERFACE LBRACE
@@ -1945,10 +1882,9 @@ program: FN IDENT LPAREN RPAREN RARROW INTERFACE LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 253.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
-## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ LPAREN ]
 ## type_expr -> IDENT . [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1959,10 +1895,10 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 254.
 ##
-## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM
@@ -1972,10 +1908,10 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM UNION
 
 program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 255.
 ##
-## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM LBRACE
@@ -1985,7 +1921,7 @@ program: FN IDENT LPAREN RPAREN RARROW ENUM LBRACE UNION
 
 program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 262.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
@@ -1998,24 +1934,11 @@ program: FN IDENT LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN UNION
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT TYPE
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 265.
 ##
-## fexpr -> IDENT . [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## field_access -> IDENT . DOT loption(separated_nonempty_list(DOT,located(ident))) [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-<YOUR SYNTAX ERROR MESSAGE HERE>
-
-program: FN IDENT LPAREN RPAREN RARROW INT TYPE
-##
-## Ends in an error in state: 273.
-##
-## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM COMMA ]
-## option(preceded(RARROW,located(fexpr))) -> RARROW fexpr . [ UNION STRUCT SEMICOLON RPAREN RBRACE LET LBRACE INTERFACE FN EOF ENUM COMMA ]
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ UNION STRUCT SEMICOLON RPAREN RBRACE LPAREN LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
+## option(preceded(RARROW,located(fexpr))) -> RARROW fexpr . [ UNION STRUCT SEMICOLON RPAREN RBRACE LET LBRACE INTERFACE FN EOF ENUM DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## RARROW fexpr
@@ -2025,7 +1948,7 @@ program: FN IDENT LPAREN RPAREN RARROW INT TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 274.
+## Ends in an error in state: 266.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2038,7 +1961,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 268.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2050,7 +1973,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 269.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2061,15 +1984,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 272.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2081,7 +2003,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 273.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2092,15 +2014,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 284.
+## Ends in an error in state: 276.
 ##
 ## function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2114,7 +2035,7 @@ program: FN IDENT LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN UNION
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 277.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
@@ -2127,7 +2048,7 @@ program: FN IDENT LPAREN RPAREN LPAREN UNION
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 ##
-## Ends in an error in state: 287.
+## Ends in an error in state: 279.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2139,7 +2060,7 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 280.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2150,15 +2071,14 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 283.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2170,7 +2090,7 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN TYPE
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 284.
 ##
 ## function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ UNION STRUCT RBRACE LET INTERFACE FN EOF ENUM ]
 ##
@@ -2181,17 +2101,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 271, spurious reduction of production fexpr -> IDENT
-## In state 273, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 265, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 287.
 ##
-## expr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2202,9 +2121,9 @@ program: LET IDENT EQUALS STRUCT LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 290.
 ##
-## expr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2215,8 +2134,9 @@ program: LET IDENT EQUALS STRUCT LBRACE RBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 291.
 ##
+## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
 ## separated_nonempty_list(COMMA,struct_fields) -> IDENT COLON expr . [ RBRACE FN ]
@@ -2236,7 +2156,7 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT SEMICOLON
 
 program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 292.
 ##
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(struct_fields,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(struct_fields,COMMA)) [ RBRACE FN ]
@@ -2250,9 +2170,9 @@ program: STRUCT IDENT LBRACE IDENT COLON IDENT COMMA UNION
 
 program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 309.
 ##
-## expr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> UNION LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2263,9 +2183,9 @@ program: LET IDENT EQUALS UNION LBRACE IDENT COMMA RBRACE UNION
 
 program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 312.
 ##
-## expr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN COMMA ]
+## expr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ SEMICOLON RPAREN RBRACE FN DOT COMMA ]
 ## fexpr -> UNION LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2276,8 +2196,9 @@ program: LET IDENT EQUALS UNION LBRACE RBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 313.
 ##
+## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
 ## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . [ RPAREN ]
@@ -2297,7 +2218,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT SEMICOLON
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 ##
-## Ends in an error in state: 322.
+## Ends in an error in state: 314.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2311,7 +2232,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 318.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2324,7 +2245,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 319.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2337,7 +2258,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 322.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2349,7 +2270,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RB
 
 program: STRUCT UNION
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 323.
 ##
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT . IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2366,7 +2287,7 @@ program: STRUCT UNION
 
 program: STRUCT IDENT UNION
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 324.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2383,7 +2304,7 @@ program: STRUCT IDENT UNION
 
 program: STRUCT IDENT LPAREN UNION
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 325.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2398,7 +2319,7 @@ program: STRUCT IDENT LPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 327.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2411,7 +2332,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 328.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2424,7 +2345,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 339.
+## Ends in an error in state: 331.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2436,7 +2357,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA R
 
 program: LET UNION
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 332.
 ##
 ## list(top_level_stmt) -> LET . IDENT EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2450,7 +2371,7 @@ program: LET UNION
 
 program: LET IDENT UNION
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 333.
 ##
 ## list(top_level_stmt) -> LET IDENT . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2464,7 +2385,7 @@ program: LET IDENT UNION
 
 program: LET IDENT LPAREN UNION
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 334.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
@@ -2477,7 +2398,7 @@ program: LET IDENT LPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 344.
+## Ends in an error in state: 336.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2489,7 +2410,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 337.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2501,8 +2422,9 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 338.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2519,7 +2441,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT RPAREN
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 339.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2531,7 +2453,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT SEMICOLON 
 
 program: INTERFACE UNION
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 340.
 ##
 ## list(top_level_stmt) -> INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2545,7 +2467,7 @@ program: INTERFACE UNION
 
 program: INTERFACE IDENT UNION
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 341.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2559,7 +2481,7 @@ program: INTERFACE IDENT UNION
 
 program: INTERFACE IDENT LPAREN UNION
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 342.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
@@ -2572,7 +2494,7 @@ program: INTERFACE IDENT LPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 344.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2584,7 +2506,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 345.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2596,7 +2518,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 347.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2608,7 +2530,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYP
 
 program: ENUM UNION
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 348.
 ##
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2625,7 +2547,7 @@ program: ENUM UNION
 
 program: ENUM IDENT UNION
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 349.
 ##
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2642,7 +2564,7 @@ program: ENUM IDENT UNION
 
 program: ENUM IDENT LPAREN UNION
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 350.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2657,7 +2579,7 @@ program: ENUM IDENT LPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 ##
-## Ends in an error in state: 360.
+## Ends in an error in state: 352.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2670,7 +2592,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 353.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2683,7 +2605,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 356.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2695,7 +2617,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE IDENT COMMA RBR
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 358.
 ##
 ## list(top_level_stmt) -> function_definition(located_ident_with_params) . list(top_level_stmt) [ EOF ]
 ##
@@ -2706,16 +2628,16 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 291, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 292, spurious reduction of production option(code_block) ->
-## In state 293, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 283, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 284, spurious reduction of production option(code_block) ->
+## In state 285, spurious reduction of production function_definition(located_ident_with_params) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RBRACE
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 360.
 ##
 ## list(top_level_stmt) -> function_definition(located(ident)) . list(top_level_stmt) [ EOF ]
 ##
@@ -2726,16 +2648,16 @@ program: FN IDENT LPAREN RPAREN RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 284, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 233, spurious reduction of production option(code_block) ->
-## In state 234, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 276, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 226, spurious reduction of production option(code_block) ->
+## In state 227, spurious reduction of production function_definition(located(ident)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 364.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2747,7 +2669,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 367.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2760,7 +2682,7 @@ program: ENUM IDENT LPAREN RPAREN UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 368.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2773,7 +2695,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE UNION
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 371.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2785,7 +2707,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 375.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2797,7 +2719,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: ENUM IDENT LBRACE UNION
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 377.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -2810,7 +2732,7 @@ program: ENUM IDENT LBRACE UNION
 
 program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 380.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2822,7 +2744,7 @@ program: ENUM IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: ENUM IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 384.
 ##
 ## list(top_level_stmt) -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2834,7 +2756,7 @@ program: ENUM IDENT LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 388.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2846,7 +2768,7 @@ program: INTERFACE IDENT LPAREN RPAREN UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 389.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2858,7 +2780,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE UNION
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 399.
+## Ends in an error in state: 391.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2870,7 +2792,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: INTERFACE IDENT LBRACE UNION
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 393.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE list(top_level_stmt) [ EOF ]
 ##
@@ -2882,7 +2804,7 @@ program: INTERFACE IDENT LBRACE UNION
 
 program: INTERFACE IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 395.
 ##
 ## list(top_level_stmt) -> INTERFACE IDENT LBRACE list(located(function_signature_binding)) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -2894,7 +2816,7 @@ program: INTERFACE IDENT LBRACE RBRACE TYPE
 
 program: LET IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 399.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2906,7 +2828,7 @@ program: LET IDENT LPAREN RPAREN UNION
 
 program: LET IDENT LPAREN RPAREN EQUALS TYPE
 ##
-## Ends in an error in state: 408.
+## Ends in an error in state: 400.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2918,8 +2840,9 @@ program: LET IDENT LPAREN RPAREN EQUALS TYPE
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 401.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2936,7 +2859,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT RPAREN
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 402.
 ##
 ## list(top_level_stmt) -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2948,7 +2871,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT SEMICOLON TYPE
 
 program: LET IDENT EQUALS TYPE
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 404.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS . expr SEMICOLON list(top_level_stmt) [ EOF ]
 ##
@@ -2960,8 +2883,9 @@ program: LET IDENT EQUALS TYPE
 
 program: LET IDENT EQUALS IDENT RPAREN
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 405.
 ##
+## expr -> expr . DOT IDENT [ SEMICOLON DOT ]
 ## list(top_level_stmt) -> LET IDENT EQUALS expr . SEMICOLON list(top_level_stmt) [ EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2978,7 +2902,7 @@ program: LET IDENT EQUALS IDENT RPAREN
 
 program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 406.
 ##
 ## list(top_level_stmt) -> LET IDENT EQUALS expr SEMICOLON . list(top_level_stmt) [ EOF ]
 ##
@@ -2990,7 +2914,7 @@ program: LET IDENT EQUALS IDENT SEMICOLON TYPE
 
 program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 411.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3002,7 +2926,7 @@ program: STRUCT IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 422.
+## Ends in an error in state: 414.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3015,7 +2939,7 @@ program: STRUCT IDENT LPAREN RPAREN UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 415.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3028,7 +2952,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 426.
+## Ends in an error in state: 418.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3040,7 +2964,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 430.
+## Ends in an error in state: 422.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3052,7 +2976,7 @@ program: STRUCT IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 432.
+## Ends in an error in state: 424.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE . loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3065,7 +2989,7 @@ program: STRUCT IDENT LBRACE UNION
 
 program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 427.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE nonempty_list(terminated(struct_fields,COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3077,7 +3001,7 @@ program: STRUCT IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: STRUCT IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 431.
 ##
 ## list(top_level_stmt) -> STRUCT IDENT LBRACE loption(separated_nonempty_list(COMMA,struct_fields)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3089,7 +3013,7 @@ program: STRUCT IDENT LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 436.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3101,7 +3025,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 439.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3114,7 +3038,7 @@ program: UNION IDENT LPAREN RPAREN UNION
 
 program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 440.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3127,7 +3051,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 443.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3139,7 +3063,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 455.
+## Ends in an error in state: 447.
 ##
 ## list(top_level_stmt) -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3151,7 +3075,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE RBRACE TYPE
 
 program: UNION IDENT LBRACE TYPE
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 449.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE . nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
 ## list(top_level_stmt) -> UNION IDENT LBRACE . loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE list(top_level_stmt) [ EOF ]
@@ -3164,7 +3088,7 @@ program: UNION IDENT LBRACE TYPE
 
 program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 452.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE nonempty_list(terminated(located(union_member),COMMA)) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##
@@ -3176,7 +3100,7 @@ program: UNION IDENT LBRACE IDENT COMMA RBRACE TYPE
 
 program: UNION IDENT LBRACE RBRACE TYPE
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 456.
 ##
 ## list(top_level_stmt) -> UNION IDENT LBRACE loption(separated_nonempty_list(COMMA,located(union_member))) list(sugared_function_definition) RBRACE . list(top_level_stmt) [ EOF ]
 ##

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -40,7 +40,7 @@ module type T = sig
     | Enum of enum_definition
     | Union of union_definition
     | Reference of ident
-    | FieldAccess of path
+    | FieldAccess of field_access
     | FunctionCall of function_call
     | Function of function_definition
     | Int of zt
@@ -72,7 +72,7 @@ module type T = sig
       body : expr located list;
       else_ : expr located option }
 
-  and path = {first_elem : ident located; last_elems : ident located list}
+  and field_access = {from_expr : expr located; to_field : ident located}
 
   and program = {bindings : binding located list}
   [@@deriving show, make, sexp_of]
@@ -119,7 +119,7 @@ functor
       | Enum of enum_definition
       | Union of union_definition
       | Reference of ident
-      | FieldAccess of path
+      | FieldAccess of field_access
       | FunctionCall of function_call
       | Function of function_definition
       | Int of zt
@@ -152,7 +152,7 @@ functor
         body : expr located list; [@sexp.list]
         else_ : expr located option [@sexp.option] }
 
-    and path = {first_elem : ident located; last_elems : ident located list}
+    and field_access = {from_expr : expr located; to_field : ident located}
 
     and program = {bindings : binding located list [@sexp.list]}
     [@@deriving show {with_path = false}, make, sexp_of]

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -46,6 +46,7 @@ module type T = sig
     | CodeBlock of code_block
     | If of if_
     | Return of expr
+    | MutRef of ident located
 
   and struct_constructor =
     { constructor_id : expr located option;
@@ -121,6 +122,7 @@ functor
       | CodeBlock of code_block
       | If of if_
       | Return of expr
+      | MutRef of ident located
 
     and struct_constructor =
       { constructor_id : expr located option; [@sexp.option]

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -40,6 +40,7 @@ module type T = sig
     | Enum of enum_definition
     | Union of union_definition
     | Reference of ident
+    | FieldAccess of path
     | FunctionCall of function_call
     | Function of function_definition
     | Int of zt
@@ -70,6 +71,8 @@ module type T = sig
     { condition : expr located;
       body : expr located list;
       else_ : expr located option }
+
+  and path = {first_elem : ident located; last_elems : ident located list}
 
   and program = {bindings : binding located list}
   [@@deriving show, make, sexp_of]
@@ -116,6 +119,7 @@ functor
       | Enum of enum_definition
       | Union of union_definition
       | Reference of ident
+      | FieldAccess of path
       | FunctionCall of function_call
       | Function of function_definition
       | Int of zt
@@ -147,6 +151,8 @@ functor
       { condition : expr located;
         body : expr located list; [@sexp.list]
         else_ : expr located option [@sexp.option] }
+
+    and path = {first_elem : ident located; last_elems : ident located list}
 
     and program = {bindings : binding located list [@sexp.list]}
     [@@deriving show {with_path = false}, make, sexp_of]

--- a/lib/tokens.mly
+++ b/lib/tokens.mly
@@ -6,6 +6,7 @@
 %token RBRACE RPAREN
 %token COMMA
 %token COLON RARROW SEMICOLON
+%token TILDA
 %token <Z.t> INT
 
 %%

--- a/lib/tokens.mly
+++ b/lib/tokens.mly
@@ -6,7 +6,7 @@
 %token RBRACE RPAREN
 %token COMMA
 %token COLON RARROW SEMICOLON
-%token TILDA
+%token TILDA DOT
 %token <Z.t> INT
 
 %%

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -490,15 +490,34 @@ let%expect_test "struct construction over an anonymous type's function call" =
               (arguments ((Reference (Ident X)))))))
            (fields_construction (((Ident field) (Reference (Ident value)))))))))))) |}]
 
-let%expect_test "mut var" =
+let%expect_test "tilda syntax" =
   let source = {|
     fn test() -> A {
       ~var;
     }
     |} in
-  pp source ; [%expect {|
+  pp source ;
+  [%expect
+    {|
     ((bindings
       (((binding_name (Ident test))
         (binding_expr
          (Function
           ((returns (Reference (Ident A))) (exprs ((MutRef (Ident var))))))))))) |}]
+
+let%expect_test "field access syntax" =
+  let source = {|
+    fn test() -> A {
+      foo.bar;
+    }
+    |} in
+  pp source ;
+  [%expect
+    {|
+    ((bindings
+      (((binding_name (Ident test))
+        (binding_expr
+         (Function
+          ((returns (Reference (Ident A)))
+           (exprs
+            ((FieldAccess ((first_elem (Ident foo)) (last_elems ((Ident bar)))))))))))))) |}]

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -489,3 +489,16 @@ let%expect_test "struct construction over an anonymous type's function call" =
                         (field_type (Reference (Ident T)))))))))))))
               (arguments ((Reference (Ident X)))))))
            (fields_construction (((Ident field) (Reference (Ident value)))))))))))) |}]
+
+let%expect_test "mut var" =
+  let source = {|
+    fn test() -> A {
+      ~var;
+    }
+    |} in
+  pp source ; [%expect {|
+    ((bindings
+      (((binding_name (Ident test))
+        (binding_expr
+         (Function
+          ((returns (Reference (Ident A))) (exprs ((MutRef (Ident var))))))))))) |}]

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -520,4 +520,34 @@ let%expect_test "field access syntax" =
          (Function
           ((returns (Reference (Ident A)))
            (exprs
-            ((FieldAccess ((first_elem (Ident foo)) (last_elems ((Ident bar)))))))))))))) |}]
+            ((FieldAccess
+              ((from_expr (Reference (Ident foo))) (to_field (Ident bar))))))))))))) |}]
+
+let%expect_test "field access over other expressions" =
+  let source =
+    {|
+    fn test() -> A {
+      ~foo.bar;
+      Struct{field: value}.field.other_field;
+    }
+    |}
+  in
+  pp source ; [%expect {|
+    ((bindings
+      (((binding_name (Ident test))
+        (binding_expr
+         (Function
+          ((returns (Reference (Ident A)))
+           (exprs
+            ((FieldAccess
+              ((from_expr (MutRef (Ident foo))) (to_field (Ident bar))))
+             (FieldAccess
+              ((from_expr
+                (FieldAccess
+                 ((from_expr
+                   (StructConstructor
+                    ((constructor_id (Reference (Ident Struct)))
+                     (fields_construction
+                      (((Ident field) (Reference (Ident value))))))))
+                  (to_field (Ident field)))))
+               (to_field (Ident other_field))))))))))))) |}]


### PR DESCRIPTION
Currently it is only possible to parse `ident "." ident` field access.