### PR TITLE
Re-enable CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
         ocaml-compiler:
           - 4.14.x
 


### PR DESCRIPTION
This is a tracking issue to try and fix the Windows build on GitHub Actions.