### PR TITLE
Introduce Int(bits) type instead of Int257

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -26,6 +26,7 @@
   zint
   errors
   lang_types
+  stdlib
   interpreter
   lang)
  (name tact))

--- a/lib/dune
+++ b/lib/dune
@@ -26,7 +26,7 @@
   zint
   errors
   lang_types
-  stdlib
+  builtin
   interpreter
   lang)
  (name tact))

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -13,11 +13,7 @@ functor
       [`DuplicateField of string * struct_ | `UnresolvedIdentifier of string]
     [@@deriving equal, sexp_of]
 
-    let default_bindings =
-      [ ("Int257", Value (Builtin "Int257"));
-        ("Bool", Value (Builtin "Bool"));
-        ("Type", Value (Builtin "Type"));
-        ("Void", Value Void) ]
+    include Stdlib
 
     class ['s] constructor ((bindings, errors) : expr named_map * _ errors) =
       object (s : 's)
@@ -28,9 +24,6 @@ functor
 
         (* Bindings that will available only in runtime *)
         val mutable runtime_bindings : type_ named_map list = []
-
-        (* Next structure definition will get this ID *)
-        val mutable next_struct_id = 0
 
         (* Are we inside of a function body? How deep? *)
         val mutable functions = 0
@@ -178,7 +171,7 @@ functor
             { struct_fields = fields;
               struct_methods = [];
               (* TODO: methods *)
-              struct_id = next_struct_id }
+              struct_id = !struct_counter }
           in
           (* Check for duplicate fields *)
           ( match
@@ -190,7 +183,7 @@ functor
           | None ->
               () ) ;
           (* Increment next struct's ID *)
-          next_struct_id <- next_struct_id + 1 ;
+          struct_counter := !struct_counter + 1 ;
           s'
 
         method build_struct_field _env field_name field_type =

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -10,10 +10,13 @@ functor
     open Interpreter
 
     type error =
-      [`DuplicateField of string * struct_ | `UnresolvedIdentifier of string]
+      [ `DuplicateField of string * struct_
+      | `UnresolvedIdentifier of string
+      | `MethodNotFound of expr * string
+      | `UnexpectedType of expr ]
     [@@deriving equal, sexp_of]
 
-    include Stdlib
+    include Builtin
 
     class ['s] constructor ((bindings, errors) : expr named_map * _ errors) =
       object (s : 's)
@@ -40,6 +43,8 @@ functor
         method build_Function _env fn = Value (Function (Fn fn))
 
         method build_FunctionCall _env fc = FunctionCall (fc, ref None)
+
+        method build_MethodCall _env mc = FunctionCall (mc, ref None)
 
         method build_Ident _env string_ = string_
 
@@ -84,7 +89,7 @@ functor
 
         method build_Struct _env s = Value (Struct s)
 
-        method build_StructConstructor _env _sc = InvalidExpr
+        method build_StructConstructor _env sc = Value (StructInstance sc)
 
         method build_Union _env _union = InvalidExpr
 
@@ -111,6 +116,42 @@ functor
 
         method build_function_call _env fn args =
           (Syntax.value fn, s#of_located_list args)
+
+        method build_method_call _env receiver fn args =
+          let receiver = Syntax.value receiver in
+          let fn = Syntax.value fn
+          and dummy : expr * expr list =
+            ( Value
+                (Function
+                   (BuiltinFn
+                      { function_params = [];
+                        function_returns = Value (Type VoidType);
+                        function_impl = (fun _ _ -> Void) } ) ),
+              [] )
+          in
+          (* TODO: check method signatures *)
+          match receiver with
+          | Value (Struct struct') -> (
+            match
+              List.Assoc.find struct'.struct_methods ~equal:String.equal fn
+            with
+            | Some fn' ->
+                (Value (Function fn'), s#of_located_list args)
+            | None ->
+                errors#report `Error (`MethodNotFound (receiver, fn)) () ;
+                dummy )
+          | Value (StructInstance (struct', _)) -> (
+            match
+              List.Assoc.find struct'.struct_methods ~equal:String.equal fn
+            with
+            | Some fn' ->
+                (Value (Function fn'), receiver :: s#of_located_list args)
+            | None ->
+                errors#report `Error (`MethodNotFound (receiver, fn)) () ;
+                dummy )
+          | receiver ->
+              errors#report `Error (`UnexpectedType receiver) () ;
+              dummy
 
         method! visit_function_definition env f =
           (* prepare parameter bindings *)
@@ -163,19 +204,32 @@ functor
           { stmts = s#of_located_list stmts;
             bindings = List.concat current_bindings }
 
-        method build_struct_constructor _env _id _fields = ()
+        method build_struct_constructor _env id _fields =
+          match Syntax.value id with
+          | Value (Struct struct') ->
+              (struct', []) (* TODO: handle fields *)
+          | e ->
+              errors#report `Error (`UnexpectedType e) () ;
+              ({struct_fields = []; struct_methods = []; struct_id = (0, 0)}, [])
 
-        method build_struct_definition _env struct_fields _bindings =
-          let fields = s#of_located_list struct_fields in
+        method build_struct_definition _env struct_fields bindings =
+          let struct_fields = s#of_located_list struct_fields
+          and struct_methods =
+            List.filter_map bindings ~f:(fun binding ->
+                let name, expr = Syntax.value binding in
+                match expr with
+                | Value (Function f) ->
+                    Some (name, f)
+                | _ ->
+                    None )
+          in
           let s' =
-            { struct_fields = fields;
-              struct_methods = [];
-              (* TODO: methods *)
-              struct_id = !struct_counter }
+            {struct_fields; struct_methods; struct_id = (0, !struct_counter)}
           in
           (* Check for duplicate fields *)
           ( match
-              List.find_a_dup fields ~compare:(fun (name1, _) (name2, _) ->
+              List.find_a_dup struct_fields
+                ~compare:(fun (name1, _) (name2, _) ->
                   String.compare name1 name2 )
             with
           | Some (name, _) ->

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -20,6 +20,8 @@ and expr =
 and value =
   | Void
   | Struct of struct_
+  (* Instance of a Struct *)
+  | StructInstance of (struct_ * value named_map)
   | Function of function_
   | Integer of (Zint.t[@visitors.name "z"])
   | Builtin of builtin
@@ -72,7 +74,9 @@ and function_call = expr * expr list
     visitors {variety = "map"; polymorphic = true; ancestors = ["base_map"]}]
 
 let rec expr_to_type = function
-  | Value (Struct struct_) ->
+  | Value (Struct _) ->
+      TypeType
+  | Value (StructInstance (struct_, _)) ->
       StructType struct_
   | Value (Function function_) ->
       FunctionType function_
@@ -115,3 +119,6 @@ let find_in_scope : 'a. string -> 'a named_map list -> 'a option =
       Option.map
         (List.find bindings ~f:(fun (s, _) -> String.equal ref s))
         ~f:(fun (_name, a) -> a) )
+
+(* We declare the struct counter here to count all structs *)
+let struct_counter = ref 0

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -49,7 +49,7 @@ and type_ =
 and struct_ =
   { struct_fields : struct_field named_map;
     struct_methods : function_ named_map;
-    struct_id : (int[@sexp.opaque]) }
+    struct_id : (int * int[@sexp.opaque]) }
 
 and struct_field = {field_type : expr}
 

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -215,6 +215,10 @@ let stmt_expr :=
  (* can be access to the field via dot *)
  | from_expr = located(expr); DOT; to_field = located(ident); 
     {FieldAccess (make_field_access ~from_expr ~to_field ())}
+| receiver = located(expr); DOT; 
+  receiver_fn = located(ident);
+  receiver_arguments = delimited_separated_trailing_list(LPAREN, located(expr), COMMA, RPAREN);
+    {MethodCall (make_method_call ~receiver ~receiver_fn ~receiver_arguments ())}
  (* can be a type constructor *)
  | struct_constructor
  (* can be a function definition *)
@@ -227,6 +231,10 @@ let expr :=
  (* can be access to the field via dot *)
  | from_expr = located(expr); DOT; to_field = located(ident); 
     {FieldAccess (make_field_access ~from_expr ~to_field ())}
+| receiver = located(expr); DOT; 
+  receiver_fn = located(ident);
+  receiver_arguments = delimited_separated_trailing_list(LPAREN, located(expr), COMMA, RPAREN);
+    {MethodCall (make_method_call ~receiver ~receiver_fn ~receiver_arguments ())}
  (* can be a type constructor *)
  | struct_constructor
  (* can be a function definition *)

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -685,8 +685,8 @@ program: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 339, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 349, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
@@ -1274,6 +1274,8 @@ program: IDENT LPAREN IDENT VAL
 ## Ends in an error in state: 156.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT COMMA ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr . COMMA nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
 ## separated_nonempty_list(COMMA,located(expr)) -> expr . [ RPAREN ]
@@ -1296,6 +1298,8 @@ program: RETURN IDENT DOT VAL
 ## Ends in an error in state: 157.
 ##
 ## expr -> expr DOT . IDENT [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+## expr -> expr DOT . IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT
@@ -1303,9 +1307,36 @@ program: RETURN IDENT DOT VAL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
-program: IDENT LPAREN IDENT COMMA VAL
+program: RETURN IDENT DOT IDENT UNION
+##
+## Ends in an error in state: 158.
+##
+## expr -> expr DOT IDENT . [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+## expr -> expr DOT IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT IDENT
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: RETURN IDENT DOT IDENT LPAREN VAL
 ##
 ## Ends in an error in state: 159.
+##
+## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT IDENT LPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: IDENT LPAREN IDENT COMMA VAL
+##
+## Ends in an error in state: 164.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -1319,9 +1350,11 @@ program: IDENT LPAREN IDENT COMMA VAL
 
 program: IDENT LBRACE IDENT COLON IDENT VAL
 ##
-## Ends in an error in state: 162.
+## Ends in an error in state: 167.
 ##
 ## expr -> expr . DOT IDENT [ RBRACE DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE DOT COMMA ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
 ## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . [ RBRACE ]
@@ -1341,7 +1374,7 @@ program: IDENT LBRACE IDENT COLON IDENT VAL
 
 program: IDENT LBRACE IDENT COLON IDENT COMMA VAL
 ##
-## Ends in an error in state: 163.
+## Ends in an error in state: 168.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1355,9 +1388,11 @@ program: IDENT LBRACE IDENT COLON IDENT COMMA VAL
 
 program: RETURN IDENT VAL
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 176.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF DOT ]
 ## semicolon_stmt -> RETURN expr . [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1374,7 +1409,7 @@ program: RETURN IDENT VAL
 
 program: LET VAL
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 178.
 ##
 ## semicolon_stmt -> LET . IDENT EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1388,7 +1423,7 @@ program: LET VAL
 
 program: LET IDENT VAL
 ##
-## Ends in an error in state: 174.
+## Ends in an error in state: 179.
 ##
 ## semicolon_stmt -> LET IDENT . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1402,7 +1437,7 @@ program: LET IDENT VAL
 
 program: LET IDENT LPAREN VAL
 ##
-## Ends in an error in state: 175.
+## Ends in an error in state: 180.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1415,7 +1450,7 @@ program: LET IDENT LPAREN VAL
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 182.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1427,7 +1462,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 183.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1439,9 +1474,11 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS VAL
 
 program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT VAL
 ##
-## Ends in an error in state: 179.
+## Ends in an error in state: 184.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF DOT ]
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr . [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1458,7 +1495,7 @@ program: LET IDENT LPAREN IDENT COLON IDENT COMMA RPAREN EQUALS IDENT VAL
 
 program: LET IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 186.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1470,7 +1507,7 @@ program: LET IDENT LPAREN RPAREN VAL
 
 program: LET IDENT LPAREN RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 187.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1482,9 +1519,11 @@ program: LET IDENT LPAREN RPAREN EQUALS VAL
 
 program: LET IDENT LPAREN RPAREN EQUALS IDENT VAL
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 188.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF DOT ]
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr . [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1501,7 +1540,7 @@ program: LET IDENT LPAREN RPAREN EQUALS IDENT VAL
 
 program: LET IDENT EQUALS VAL
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 189.
 ##
 ## semicolon_stmt -> LET IDENT EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1513,9 +1552,11 @@ program: LET IDENT EQUALS VAL
 
 program: LET IDENT EQUALS IDENT VAL
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 190.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF DOT ]
 ## semicolon_stmt -> LET IDENT EQUALS expr . [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1532,7 +1573,7 @@ program: LET IDENT EQUALS IDENT VAL
 
 program: INTERFACE VAL
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 191.
 ##
 ## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -1549,7 +1590,7 @@ program: INTERFACE VAL
 
 program: INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 192.
 ##
 ## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -1563,7 +1604,7 @@ program: INTERFACE LBRACE VAL
 
 program: INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 194.
 ##
 ## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ DOT ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
@@ -1577,7 +1618,7 @@ program: INTERFACE LBRACE RBRACE VAL
 
 program: INTERFACE IDENT VAL
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 195.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1591,7 +1632,7 @@ program: INTERFACE IDENT VAL
 
 program: INTERFACE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 196.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1604,7 +1645,7 @@ program: INTERFACE IDENT LPAREN VAL
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 198.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1616,7 +1657,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 199.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1628,7 +1669,7 @@ program: INTERFACE IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 
 program: INTERFACE IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 203.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1640,7 +1681,7 @@ program: INTERFACE IDENT LPAREN RPAREN VAL
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 204.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1652,7 +1693,7 @@ program: INTERFACE IDENT LPAREN RPAREN LBRACE VAL
 
 program: INTERFACE IDENT LBRACE VAL
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 207.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1664,7 +1705,7 @@ program: INTERFACE IDENT LBRACE VAL
 
 program: INT VAL
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 210.
 ##
 ## expr -> INT . [ DOT ]
 ## fexpr -> INT . [ LPAREN ]
@@ -1678,7 +1719,7 @@ program: INT VAL
 
 program: IF VAL
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 211.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1690,7 +1731,7 @@ program: IF VAL
 
 program: IF LPAREN VAL
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 212.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1702,9 +1743,11 @@ program: IF LPAREN VAL
 
 program: IF LPAREN IDENT VAL
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 213.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT ]
 ## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1721,7 +1764,7 @@ program: IF LPAREN IDENT VAL
 
 program: IF LPAREN IDENT RPAREN VAL
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 214.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1733,7 +1776,7 @@ program: IF LPAREN IDENT RPAREN VAL
 
 program: IF LPAREN IDENT RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 215.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1745,7 +1788,7 @@ program: IF LPAREN IDENT RPAREN LBRACE RBRACE VAL
 
 program: IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE VAL
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 216.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## else_ -> ELSE . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1758,7 +1801,7 @@ program: IF LPAREN IDENT RPAREN LBRACE RBRACE ELSE VAL
 
 program: IDENT VAL
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 221.
 ##
 ## expr -> IDENT . [ DOT ]
 ## fexpr -> IDENT . [ LPAREN ]
@@ -1773,7 +1816,7 @@ program: IDENT VAL
 
 program: FN VAL
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 222.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1794,7 +1837,7 @@ program: FN VAL
 
 program: FN LPAREN VAL
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 223.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
@@ -1809,7 +1852,7 @@ program: FN LPAREN VAL
 
 program: FN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 225.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -1822,7 +1865,7 @@ program: FN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 226.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -1834,14 +1877,14 @@ program: FN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 228.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -1854,7 +1897,7 @@ program: FN LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE RBRACE VAL
 
 program: FN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 230.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -1867,7 +1910,7 @@ program: FN LPAREN RPAREN VAL
 
 program: FN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 231.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -1879,14 +1922,14 @@ program: FN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN LPAREN RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 233.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -1899,7 +1942,7 @@ program: FN LPAREN RPAREN LBRACE RBRACE VAL
 
 program: FN IDENT VAL
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 234.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1916,7 +1959,7 @@ program: FN IDENT VAL
 
 program: FN IDENT LPAREN VAL
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 235.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1933,7 +1976,7 @@ program: FN IDENT LPAREN VAL
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 237.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1947,7 +1990,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 238.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -1960,7 +2003,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN VAL
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 240.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1972,7 +2015,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 241.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -1983,14 +2026,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 244.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2002,7 +2045,7 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN VAL
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 245.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2013,14 +2056,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 247.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2031,14 +2074,14 @@ program: FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 250.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2052,7 +2095,7 @@ program: FN IDENT LPAREN RPAREN VAL
 
 program: FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 251.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2065,7 +2108,7 @@ program: FN IDENT LPAREN RPAREN LPAREN VAL
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 253.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2077,7 +2120,7 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 254.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2088,14 +2131,14 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 257.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2107,7 +2150,7 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 258.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2118,14 +2161,14 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 260.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -2136,14 +2179,14 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM VAL
 ##
-## Ends in an error in state: 257.
+## Ends in an error in state: 262.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2166,7 +2209,7 @@ program: ENUM VAL
 
 program: ENUM LBRACE VAL
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 263.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2183,7 +2226,7 @@ program: ENUM LBRACE VAL
 
 program: ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 266.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2197,7 +2240,7 @@ program: ENUM LBRACE IDENT COMMA RBRACE VAL
 
 program: ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 269.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2211,7 +2254,7 @@ program: ENUM LBRACE RBRACE VAL
 
 program: ENUM IDENT VAL
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 270.
 ##
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2228,7 +2271,7 @@ program: ENUM IDENT VAL
 
 program: ENUM IDENT LPAREN VAL
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 271.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2243,7 +2286,7 @@ program: ENUM IDENT LPAREN VAL
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 273.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2256,7 +2299,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 274.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2269,7 +2312,7 @@ program: ENUM IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 
 program: ENUM IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 282.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2282,7 +2325,7 @@ program: ENUM IDENT LPAREN RPAREN VAL
 
 program: ENUM IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 283.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2295,7 +2338,7 @@ program: ENUM IDENT LPAREN RPAREN LBRACE VAL
 
 program: ENUM IDENT LBRACE VAL
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 290.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -2308,7 +2351,7 @@ program: ENUM IDENT LBRACE VAL
 
 program: IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 297.
 ##
 ## expr -> struct_constructor . [ DOT ]
 ## stmt_expr -> struct_constructor . [ SEMICOLON RBRACE EOF ]
@@ -2321,7 +2364,7 @@ program: IDENT LBRACE RBRACE VAL
 
 program: IDENT SEMICOLON VAL
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 301.
 ##
 ## block_stmt -> semicolon_stmt SEMICOLON . block_stmt [ RBRACE EOF ]
 ## block_stmt -> semicolon_stmt SEMICOLON . [ RBRACE EOF ]
@@ -2334,7 +2377,7 @@ program: IDENT SEMICOLON VAL
 
 program: LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 297.
+## Ends in an error in state: 302.
 ##
 ## block_stmt -> non_semicolon_stmt . block_stmt [ RBRACE EOF ]
 ## stmt -> non_semicolon_stmt . [ RBRACE EOF ]
@@ -2347,7 +2390,7 @@ program: LBRACE RBRACE VAL
 
 program: IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 307.
 ##
 ## expr -> function_call . [ DOT ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -2362,10 +2405,14 @@ program: IDENT LPAREN RPAREN VAL
 
 program: IDENT DOT VAL
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 309.
 ##
 ## expr -> expr DOT . IDENT [ DOT ]
+## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
+## expr -> expr DOT . IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
 ## stmt_expr -> expr DOT . IDENT [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> expr DOT . IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT
@@ -2375,10 +2422,14 @@ program: IDENT DOT VAL
 
 program: IDENT DOT IDENT VAL
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 310.
 ##
 ## expr -> expr DOT IDENT . [ DOT ]
+## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
+## expr -> expr DOT IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
 ## stmt_expr -> expr DOT IDENT . [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> expr DOT IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT IDENT
@@ -2386,9 +2437,50 @@ program: IDENT DOT IDENT VAL
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
+program: IDENT DOT IDENT LPAREN VAL
+##
+## Ends in an error in state: 311.
+##
+## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
+## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
+## stmt_expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT IDENT LPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: IDENT DOT IDENT LPAREN IDENT COMMA RPAREN VAL
+##
+## Ends in an error in state: 313.
+##
+## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ DOT ]
+## stmt_expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
+program: IDENT DOT IDENT LPAREN RPAREN VAL
+##
+## Ends in an error in state: 315.
+##
+## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ DOT ]
+## stmt_expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN
+##
+
+<YOUR SYNTAX ERROR MESSAGE HERE>
+
 program: LBRACE IDENT EOF
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 319.
 ##
 ## code_block -> LBRACE block_stmt . RBRACE [ VAL UNION TILDE STRUCT SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ELSE DOT COMMA ]
 ##
@@ -2399,17 +2491,17 @@ program: LBRACE IDENT EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 216, spurious reduction of production stmt_expr -> IDENT
-## In state 293, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 295, spurious reduction of production stmt -> semicolon_stmt
-## In state 294, spurious reduction of production block_stmt -> stmt
+## In state 221, spurious reduction of production stmt_expr -> IDENT
+## In state 298, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 300, spurious reduction of production stmt -> semicolon_stmt
+## In state 299, spurious reduction of production block_stmt -> stmt
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: RETURN FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 323.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
 ##
@@ -2421,9 +2513,11 @@ program: RETURN FN LPAREN RPAREN UNION
 
 program: ENUM LBRACE IDENT EQUALS IDENT VAL
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 325.
 ##
 ## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN DOT COMMA ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
 ## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . [ RBRACE FN ]
@@ -2443,7 +2537,7 @@ program: ENUM LBRACE IDENT EQUALS IDENT VAL
 
 program: ENUM LBRACE IDENT EQUALS IDENT COMMA VAL
 ##
-## Ends in an error in state: 316.
+## Ends in an error in state: 326.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -2457,7 +2551,7 @@ program: ENUM LBRACE IDENT EQUALS IDENT COMMA VAL
 
 program: ENUM LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 319.
+## Ends in an error in state: 329.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -2471,7 +2565,7 @@ program: ENUM LBRACE IDENT COMMA VAL
 
 program: LPAREN IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 338.
 ##
 ## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE FN EOF DOT COMMA ]
 ##
@@ -2483,7 +2577,7 @@ program: LPAREN IDENT LBRACE RBRACE VAL
 
 program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 340.
 ##
 ## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE FN EOF DOT COMMA ]
 ##
@@ -2494,7 +2588,7 @@ program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ## In state 89, spurious reduction of production function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 
@@ -2502,7 +2596,7 @@ program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
 
 program: FN LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 332.
+## Ends in an error in state: 342.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE ]
@@ -2515,7 +2609,7 @@ program: FN LPAREN RPAREN RARROW LPAREN IDENT LPAREN RPAREN VAL
 
 program: FN LPAREN RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 345.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE FN EOF DOT COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE FN EOF DOT COMMA ]
@@ -2529,7 +2623,7 @@ program: FN LPAREN RPAREN RARROW IDENT UNION
 
 program: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 348.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ##
@@ -2541,7 +2635,7 @@ program: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 
 program: LPAREN INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 351.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE ]
@@ -2554,7 +2648,7 @@ program: LPAREN INTERFACE LBRACE RBRACE VAL
 
 program: LPAREN INT VAL
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 353.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE ]
@@ -2567,7 +2661,7 @@ program: LPAREN INT VAL
 
 program: LPAREN IDENT VAL
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 355.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
 ## type_expr -> LPAREN IDENT . RPAREN [ LBRACE ]
@@ -2581,7 +2675,7 @@ program: LPAREN IDENT VAL
 
 program: LPAREN ENUM VAL
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 357.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -2596,7 +2690,7 @@ program: LPAREN ENUM VAL
 
 program: LPAREN ENUM LBRACE VAL
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 358.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -2611,7 +2705,7 @@ program: LPAREN ENUM LBRACE VAL
 
 program: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 361.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE ]
@@ -2624,7 +2718,7 @@ program: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
 
 program: LPAREN ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 365.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE ]
@@ -2637,7 +2731,7 @@ program: LPAREN ENUM LBRACE RBRACE VAL
 
 program: LPAREN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 367.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE ]
@@ -2651,9 +2745,11 @@ program: LPAREN IDENT LPAREN RPAREN VAL
 
 program: STRUCT LBRACE VAL IDENT COLON IDENT SEMICOLON
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 369.
 ##
 ## expr -> expr . DOT IDENT [ VAL RBRACE FN DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL RBRACE FN DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL RBRACE FN DOT ]
 ## list(struct_field) -> VAL IDENT COLON expr . list(struct_field) [ RBRACE FN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -2670,7 +2766,7 @@ program: STRUCT LBRACE VAL IDENT COLON IDENT SEMICOLON
 
 program: RETURN STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 373.
 ##
 ## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) RBRACE . [ VAL SEMICOLON RPAREN RBRACE FN EOF DOT COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2683,9 +2779,11 @@ program: RETURN STRUCT LBRACE RBRACE UNION
 
 program: FN LPAREN IDENT COLON IDENT VAL
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 374.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT COMMA ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
 ## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . [ RPAREN ]
@@ -2705,7 +2803,7 @@ program: FN LPAREN IDENT COLON IDENT VAL
 
 program: FN LPAREN IDENT COLON IDENT COMMA VAL
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 375.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -2719,7 +2817,7 @@ program: FN LPAREN IDENT COLON IDENT COMMA VAL
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 379.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -2733,7 +2831,7 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 380.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -2746,7 +2844,7 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN VAL
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 382.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -2758,7 +2856,7 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 383.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2769,14 +2867,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 386.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -2788,7 +2886,7 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPARE
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 387.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2799,14 +2897,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LPAREN RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 389.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2817,14 +2915,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 392.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -2838,7 +2936,7 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 393.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
@@ -2851,7 +2949,7 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN VAL
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 395.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -2863,7 +2961,7 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPARE
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 396.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2874,14 +2972,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON IDENT COMMA RPARE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 399.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE FN ]
 ##
@@ -2893,7 +2991,7 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 400.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2904,14 +3002,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 402.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE FN ]
 ##
@@ -2922,14 +3020,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 345, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>
 
 program: UNION LBRACE CASE STRUCT VAL
 ##
-## Ends in an error in state: 396.
+## Ends in an error in state: 406.
 ##
 ## union_member -> STRUCT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
 ##
@@ -2941,7 +3039,7 @@ program: UNION LBRACE CASE STRUCT VAL
 
 program: UNION LBRACE CASE STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 407.
 ##
 ## union_member -> STRUCT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
 ##
@@ -2953,7 +3051,7 @@ program: UNION LBRACE CASE STRUCT LBRACE UNION
 
 program: UNION LBRACE CASE INTERFACE VAL
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 411.
 ##
 ## union_member -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ RBRACE FN CASE ]
 ##
@@ -2965,7 +3063,7 @@ program: UNION LBRACE CASE INTERFACE VAL
 
 program: UNION LBRACE CASE INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 402.
+## Ends in an error in state: 412.
 ##
 ## union_member -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ RBRACE FN CASE ]
 ##
@@ -2977,7 +3075,7 @@ program: UNION LBRACE CASE INTERFACE LBRACE VAL
 
 program: UNION LBRACE CASE IDENT VAL
 ##
-## Ends in an error in state: 405.
+## Ends in an error in state: 415.
 ##
 ## union_member -> IDENT . [ RBRACE FN CASE ]
 ## union_member -> IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN CASE ]
@@ -2991,7 +3089,7 @@ program: UNION LBRACE CASE IDENT VAL
 
 program: UNION LBRACE CASE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 416.
 ##
 ## union_member -> IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN CASE ]
 ## union_member -> IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN CASE ]
@@ -3004,7 +3102,7 @@ program: UNION LBRACE CASE IDENT LPAREN VAL
 
 program: UNION LBRACE CASE ENUM VAL
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 421.
 ##
 ## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
 ## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
@@ -3017,7 +3115,7 @@ program: UNION LBRACE CASE ENUM VAL
 
 program: UNION LBRACE CASE ENUM LBRACE VAL
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 422.
 ##
 ## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
 ## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
@@ -3030,7 +3128,7 @@ program: UNION LBRACE CASE ENUM LBRACE VAL
 
 program: UNION LBRACE CASE ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 419.
+## Ends in an error in state: 429.
 ##
 ## list(preceded(CASE,located(union_member))) -> CASE union_member . list(preceded(CASE,located(union_member))) [ RBRACE FN ]
 ##
@@ -3042,7 +3140,7 @@ program: UNION LBRACE CASE ENUM LBRACE RBRACE VAL
 
 program: UNION LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 433.
 ##
 ## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -3056,7 +3154,7 @@ program: UNION LBRACE RBRACE VAL
 
 program: UNION IDENT VAL
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 434.
 ##
 ## non_semicolon_stmt -> UNION IDENT . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> UNION IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -3070,7 +3168,7 @@ program: UNION IDENT VAL
 
 program: UNION IDENT LPAREN VAL
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 435.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ## non_semicolon_stmt -> UNION IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
@@ -3083,7 +3181,7 @@ program: UNION IDENT LPAREN VAL
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 437.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -3095,7 +3193,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN VAL
 
 program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 428.
+## Ends in an error in state: 438.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -3107,7 +3205,7 @@ program: UNION IDENT LPAREN IDENT COLON IDENT COMMA RPAREN LBRACE VAL
 
 program: UNION IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 443.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -3119,7 +3217,7 @@ program: UNION IDENT LPAREN RPAREN VAL
 
 program: UNION IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 444.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -3131,7 +3229,7 @@ program: UNION IDENT LPAREN RPAREN LBRACE VAL
 
 program: UNION IDENT LBRACE VAL
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 448.
 ##
 ## non_semicolon_stmt -> UNION IDENT LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE STRUCT RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM ]
 ##
@@ -3143,7 +3241,7 @@ program: UNION IDENT LBRACE VAL
 
 program: IDENT RBRACE
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 454.
 ##
 ## program -> block_stmt . EOF [ # ]
 ##
@@ -3154,10 +3252,10 @@ program: IDENT RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 216, spurious reduction of production stmt_expr -> IDENT
-## In state 293, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 295, spurious reduction of production stmt -> semicolon_stmt
-## In state 294, spurious reduction of production block_stmt -> stmt
+## In state 221, spurious reduction of production stmt_expr -> IDENT
+## In state 298, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 300, spurious reduction of production stmt -> semicolon_stmt
+## In state 299, spurious reduction of production block_stmt -> stmt
 ##
 
 <YOUR SYNTAX ERROR MESSAGE HERE>

--- a/lib/stdlib.ml
+++ b/lib/stdlib.ml
@@ -1,0 +1,56 @@
+open Lang_types
+
+let int_type =
+  let struct_counter' = !struct_counter in
+  struct_counter := struct_counter' + 1 ;
+  (* int's newtype *)
+  let int_type_s =
+    { struct_fields = [("integer", {field_type = Value (Type IntegerType)})];
+      struct_methods = [];
+      struct_id = struct_counter' }
+  in
+  let rec constructor_impl bits p = function
+    | [Integer i] ->
+        let numbits = Zint.numbits i in
+        let i =
+          (* FIXME: or should we raise an error here? *)
+          if numbits > bits then
+            let extract =
+              if Zint.(lt i Zint.zero) then Zint.signed_extract
+              else Zint.extract
+            in
+            extract i 0 (numbits - bits)
+          else i
+        in
+        StructInstance (int_type_s, [("integer", Integer i)])
+    | _ ->
+        (* TODO: raise an error instead *)
+        constructor_impl bits p [Integer (Zint.of_int 0)]
+  in
+  let constructor bits =
+    Function
+      (BuiltinFn
+         { function_params = [("integer", Value (Type IntegerType))];
+           function_returns = Value (Struct int_type_s);
+           function_impl = constructor_impl bits } )
+  in
+  let function_impl _p = function
+    | [Integer bits] ->
+        constructor @@ Zint.to_int bits
+    | _ ->
+        (* TODO: raise an error instead *)
+        Void
+  in
+  Value
+    (Function
+       (BuiltinFn
+          { function_params = [("bits", Value (Type IntegerType))];
+            function_returns = Value (constructor 257);
+            function_impl } ) )
+
+let default_bindings =
+  [ ("Integer", Value (Type IntegerType));
+    ("Int", int_type);
+    ("Bool", Value (Builtin "Bool"));
+    ("Type", Value (Builtin "Type"));
+    ("Void", Value Void) ]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -1,0 +1,63 @@
+module Syntax = Tact.Syntax.Make (Tact.Located.Disabled)
+module Parser = Tact.Parser.Make (Syntax)
+module Lang = Tact.Lang.Make (Syntax)
+module Interpreter = Tact.Interpreter
+module Errors = Tact.Errors
+module Zint = Tact.Zint
+open Core
+
+type error = [Lang.error | Interpreter.error] [@@deriving sexp_of]
+
+let make_errors () = new Errors.errors
+
+let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
+
+let build_program ?(errors = make_errors ()) ?(bindings = Lang.default_bindings)
+    p =
+  let c = new Lang.constructor (bindings, errors) in
+  let p' = c#visit_program () p in
+  errors#to_result p'
+  |> Result.map_error ~f:(fun errors ->
+         List.map errors ~f:(fun (_, err, _) -> err) )
+
+let pp = Sexplib.Sexp.pp_hum Caml.Format.std_formatter
+
+exception Exn of error list
+
+let compile s =
+  parse_program s |> build_program
+  |> Result.map_error ~f:(fun err -> Exn err)
+  |> Result.ok_exn
+
+let test_equality () =
+  let source =
+    {|
+  let T = Int(257);
+  let T1 = Int(257);
+  let T2 = Int(256);
+  |}
+  in
+  Alcotest.(check bool)
+    "types with same bits are equal" true
+    (let scope = (compile source).bindings in
+     let t = List.Assoc.find scope ~equal:String.equal "T" |> Option.value_exn
+     and t1 =
+       List.Assoc.find scope ~equal:String.equal "T1" |> Option.value_exn
+     in
+     pp (Lang.sexp_of_expr t) ;
+     pp (Lang.sexp_of_expr t1) ;
+     Lang.equal_expr t t1 ) ;
+  Alcotest.(check bool)
+    "types with different bits are not equal" false
+    (let scope = (compile source).bindings in
+     let t = List.Assoc.find scope ~equal:String.equal "T" |> Option.value_exn
+     and t2 =
+       List.Assoc.find scope ~equal:String.equal "T2" |> Option.value_exn
+     in
+     pp (Lang.sexp_of_expr t) ;
+     pp (Lang.sexp_of_expr t2) ;
+     Lang.equal_expr t t2 )
+
+let () =
+  let open Alcotest in
+  run "Builtin" [("Int type", [test_case "equality" `Quick test_equality])]

--- a/test/dune
+++ b/test/dune
@@ -9,6 +9,6 @@
 (tests
  (preprocess
   (staged_pps ppx_matches))
- (names lang_types errors)
- (modules lang_types errors)
+ (names lang_types builtin errors)
+ (modules lang_types builtin errors)
  (libraries tact alcotest ppx_matches core))

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -39,29 +39,26 @@ let%expect_test "scope resolution" =
        ((Let
          ((T
            (Value
-            (Function
-             (BuiltinFn
-              ((function_params ((integer (Value (Type IntegerType)))))
-               (function_returns
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_methods ()) (struct_id <opaque>)))))
-               (function_impl <fun>))))))))))
+            (Struct
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_methods
+               ((new
+                 (BuiltinFn
+                  ((function_params ((integer (Value (Type IntegerType)))))
+                   (function_returns Hole) (function_impl <fun>))))))
+              (struct_id <opaque>)))))))))
       (bindings
        ((T
          (Value
-          (Function
-           (BuiltinFn
-            ((function_params ((integer (Value (Type IntegerType)))))
-             (function_returns
-              (Value
-               (Struct
-                ((struct_fields
-                  ((integer ((field_type (Value (Type IntegerType)))))))
-                 (struct_methods ()) (struct_id <opaque>)))))
-             (function_impl <fun>))))))
+          (Struct
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_methods
+             ((new
+               (BuiltinFn
+                ((function_params ((integer (Value (Type IntegerType)))))
+                 (function_returns Hole) (function_impl <fun>))))))
+            (struct_id <opaque>)))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -70,16 +67,15 @@ let%expect_test "scope resolution" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -101,56 +97,50 @@ let%expect_test "binding resolution" =
        ((Let
          ((T
            (Value
-            (Function
-             (BuiltinFn
-              ((function_params ((integer (Value (Type IntegerType)))))
-               (function_returns
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_methods ()) (struct_id <opaque>)))))
-               (function_impl <fun>))))))))
+            (Struct
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_methods
+               ((new
+                 (BuiltinFn
+                  ((function_params ((integer (Value (Type IntegerType)))))
+                   (function_returns Hole) (function_impl <fun>))))))
+              (struct_id <opaque>)))))))
         (Let
          ((T_
            (Value
-            (Function
-             (BuiltinFn
-              ((function_params ((integer (Value (Type IntegerType)))))
-               (function_returns
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_methods ()) (struct_id <opaque>)))))
-               (function_impl <fun>))))))))
+            (Struct
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_methods
+               ((new
+                 (BuiltinFn
+                  ((function_params ((integer (Value (Type IntegerType)))))
+                   (function_returns Hole) (function_impl <fun>))))))
+              (struct_id <opaque>)))))))
         (Let ((a (Value (Integer 1))))) (Let ((a_ (Value (Integer 1)))))))
       (bindings
        ((a_ (Value (Integer 1))) (a (Value (Integer 1)))
         (T_
          (Value
-          (Function
-           (BuiltinFn
-            ((function_params ((integer (Value (Type IntegerType)))))
-             (function_returns
-              (Value
-               (Struct
-                ((struct_fields
-                  ((integer ((field_type (Value (Type IntegerType)))))))
-                 (struct_methods ()) (struct_id <opaque>)))))
-             (function_impl <fun>))))))
+          (Struct
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_methods
+             ((new
+               (BuiltinFn
+                ((function_params ((integer (Value (Type IntegerType)))))
+                 (function_returns Hole) (function_impl <fun>))))))
+            (struct_id <opaque>)))))
         (T
          (Value
-          (Function
-           (BuiltinFn
-            ((function_params ((integer (Value (Type IntegerType)))))
-             (function_returns
-              (Value
-               (Struct
-                ((struct_fields
-                  ((integer ((field_type (Value (Type IntegerType)))))))
-                 (struct_methods ()) (struct_id <opaque>)))))
-             (function_impl <fun>))))))
+          (Struct
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_methods
+             ((new
+               (BuiltinFn
+                ((function_params ((integer (Value (Type IntegerType)))))
+                 (function_returns Hole) (function_impl <fun>))))))
+            (struct_id <opaque>)))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -159,16 +149,15 @@ let%expect_test "binding resolution" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -193,54 +182,48 @@ let%expect_test "scope resolution after let binding" =
        ((Let
          ((A
            (Value
-            (Function
-             (BuiltinFn
-              ((function_params ((integer (Value (Type IntegerType)))))
-               (function_returns
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_methods ()) (struct_id <opaque>)))))
-               (function_impl <fun>))))))))
+            (Struct
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_methods
+               ((new
+                 (BuiltinFn
+                  ((function_params ((integer (Value (Type IntegerType)))))
+                   (function_returns Hole) (function_impl <fun>))))))
+              (struct_id <opaque>)))))))
         (Let
          ((B
            (Value
-            (Function
-             (BuiltinFn
-              ((function_params ((integer (Value (Type IntegerType)))))
-               (function_returns
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_methods ()) (struct_id <opaque>)))))
-               (function_impl <fun>))))))))))
+            (Struct
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_methods
+               ((new
+                 (BuiltinFn
+                  ((function_params ((integer (Value (Type IntegerType)))))
+                   (function_returns Hole) (function_impl <fun>))))))
+              (struct_id <opaque>)))))))))
       (bindings
        ((B
          (Value
-          (Function
-           (BuiltinFn
-            ((function_params ((integer (Value (Type IntegerType)))))
-             (function_returns
-              (Value
-               (Struct
-                ((struct_fields
-                  ((integer ((field_type (Value (Type IntegerType)))))))
-                 (struct_methods ()) (struct_id <opaque>)))))
-             (function_impl <fun>))))))
+          (Struct
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_methods
+             ((new
+               (BuiltinFn
+                ((function_params ((integer (Value (Type IntegerType)))))
+                 (function_returns Hole) (function_impl <fun>))))))
+            (struct_id <opaque>)))))
         (A
          (Value
-          (Function
-           (BuiltinFn
-            ((function_params ((integer (Value (Type IntegerType)))))
-             (function_returns
-              (Value
-               (Struct
-                ((struct_fields
-                  ((integer ((field_type (Value (Type IntegerType)))))))
-                 (struct_methods ()) (struct_id <opaque>)))))
-             (function_impl <fun>))))))
+          (Struct
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_methods
+             ((new
+               (BuiltinFn
+                ((function_params ((integer (Value (Type IntegerType)))))
+                 (function_returns Hole) (function_impl <fun>))))))
+            (struct_id <opaque>)))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -249,16 +232,15 @@ let%expect_test "scope resolution after let binding" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -280,16 +262,16 @@ let%expect_test "basic struct definition" =
                ((t
                  ((field_type
                    (Value
-                    (Function
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))))
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods
+                       ((new
+                         (BuiltinFn
+                          ((function_params
+                            ((integer (Value (Type IntegerType)))))
+                           (function_returns Hole) (function_impl <fun>))))))
+                      (struct_id <opaque>)))))))))
               (struct_methods ()) (struct_id <opaque>)))))))))
       (bindings
        ((T
@@ -299,16 +281,15 @@ let%expect_test "basic struct definition" =
              ((t
                ((field_type
                  (Value
-                  (Function
-                   (BuiltinFn
-                    ((function_params ((integer (Value (Type IntegerType)))))
-                     (function_returns
-                      (Value
-                       (Struct
-                        ((struct_fields
-                          ((integer ((field_type (Value (Type IntegerType)))))))
-                         (struct_methods ()) (struct_id <opaque>)))))
-                     (function_impl <fun>))))))))))
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_methods
+                     ((new
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns Hole) (function_impl <fun>))))))
+                    (struct_id <opaque>)))))))))
             (struct_methods ()) (struct_id <opaque>)))))
         (Integer (Value (Type IntegerType)))
         (Int
@@ -318,16 +299,15 @@ let%expect_test "basic struct definition" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -371,16 +351,15 @@ let%expect_test "native function evaluation" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -407,44 +386,28 @@ let%expect_test "Tact function evaluation" =
               ((function_params
                 ((i
                   (Value
-                   (Function
-                    (BuiltinFn
-                     ((function_params ((integer (Value (Type IntegerType)))))
-                      (function_returns
-                       (Value
-                        (Struct
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_methods ()) (struct_id <opaque>)))))
-                      (function_impl <fun>))))))))
+                   (Struct
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_methods
+                      ((new
+                        (BuiltinFn
+                         ((function_params
+                           ((integer (Value (Type IntegerType)))))
+                          (function_returns Hole) (function_impl <fun>))))))
+                     (struct_id <opaque>)))))))
                (function_returns
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))
-               (function_impl
-                (((Break
-                   (Expr
-                    (Reference
-                     (i
-                      (FunctionType
-                       (BuiltinFn
-                        ((function_params ((integer (Value (Type IntegerType)))))
-                         (function_returns
-                          (Value
-                           (Struct
-                            ((struct_fields
-                              ((integer
-                                ((field_type (Value (Type IntegerType)))))))
-                             (struct_methods ()) (struct_id <opaque>)))))
-                         (function_impl <fun>))))))))))))))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))
+               (function_impl (((Break (Expr (Reference (i TypeType))))))))))))))
         (Let ((a (Value (Integer 1)))))))
       (bindings
        ((a (Value (Integer 1)))
@@ -455,43 +418,27 @@ let%expect_test "Tact function evaluation" =
             ((function_params
               ((i
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
-             (function_impl
-              (((Break
-                 (Expr
-                  (Reference
-                   (i
-                    (FunctionType
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))))))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
+             (function_impl (((Break (Expr (Reference (i TypeType))))))))))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -500,16 +447,15 @@ let%expect_test "Tact function evaluation" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -536,16 +482,16 @@ let%expect_test "struct definition" =
                  ((a
                    ((field_type
                      (Value
-                      (Function
-                       (BuiltinFn
-                        ((function_params ((integer (Value (Type IntegerType)))))
-                         (function_returns
-                          (Value
-                           (Struct
-                            ((struct_fields
-                              ((integer ((field_type (Value (Type IntegerType)))))))
-                             (struct_methods ()) (struct_id <opaque>)))))
-                         (function_impl <fun>))))))))
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods
+                         ((new
+                           (BuiltinFn
+                            ((function_params
+                              ((integer (Value (Type IntegerType)))))
+                             (function_returns Hole) (function_impl <fun>))))))
+                        (struct_id <opaque>)))))))
                   (b ((field_type (Value (Builtin Bool)))))))
                 (struct_methods ()) (struct_id <opaque>)))))))))
         (bindings
@@ -556,16 +502,15 @@ let%expect_test "struct definition" =
                ((a
                  ((field_type
                    (Value
-                    (Function
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods
+                       ((new
+                         (BuiltinFn
+                          ((function_params ((integer (Value (Type IntegerType)))))
+                           (function_returns Hole) (function_impl <fun>))))))
+                      (struct_id <opaque>)))))))
                 (b ((field_type (Value (Builtin Bool)))))))
               (struct_methods ()) (struct_id <opaque>)))))
           (Integer (Value (Type IntegerType)))
@@ -576,16 +521,15 @@ let%expect_test "struct definition" =
               ((function_params ((bits (Value (Type IntegerType)))))
                (function_returns
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))
                (function_impl <fun>))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
           (Void (Value Void)))))) |}]
@@ -609,16 +553,15 @@ let%expect_test "duplicate type field" =
           ((a
             ((field_type
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))))
            (a ((field_type (Value (Builtin Bool)))))))
          (struct_methods ()) (struct_id <opaque>)))))) |}]
 
@@ -656,16 +599,16 @@ let%expect_test "parametric struct instantiation" =
                ((a
                  ((field_type
                    (Value
-                    (Function
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))))
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods
+                       ((new
+                         (BuiltinFn
+                          ((function_params
+                            ((integer (Value (Type IntegerType)))))
+                           (function_returns Hole) (function_impl <fun>))))))
+                      (struct_id <opaque>)))))))))
               (struct_methods ()) (struct_id <opaque>)))))))))
       (bindings
        ((TA
@@ -675,16 +618,15 @@ let%expect_test "parametric struct instantiation" =
              ((a
                ((field_type
                  (Value
-                  (Function
-                   (BuiltinFn
-                    ((function_params ((integer (Value (Type IntegerType)))))
-                     (function_returns
-                      (Value
-                       (Struct
-                        ((struct_fields
-                          ((integer ((field_type (Value (Type IntegerType)))))))
-                         (struct_methods ()) (struct_id <opaque>)))))
-                     (function_impl <fun>))))))))))
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_methods
+                     ((new
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns Hole) (function_impl <fun>))))))
+                    (struct_id <opaque>)))))))))
             (struct_methods ()) (struct_id <opaque>)))))
         (T
          (Value
@@ -707,16 +649,15 @@ let%expect_test "parametric struct instantiation" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -755,16 +696,15 @@ let%expect_test "function without a return type" =
               ((function_params ((bits (Value (Type IntegerType)))))
                (function_returns
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))
                (function_impl <fun>))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
           (Void (Value Void)))))) |}]
@@ -792,49 +732,20 @@ let%expect_test "scoping that `let` introduces in code" =
               ((function_params
                 ((i
                   (Value
-                   (Function
-                    (BuiltinFn
-                     ((function_params ((integer (Value (Type IntegerType)))))
-                      (function_returns
-                       (Value
-                        (Struct
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_methods ()) (struct_id <opaque>)))))
-                      (function_impl <fun>))))))))
-               (function_returns Hole)
-               (function_impl
-                (((Let
-                   ((a
-                     (Reference
-                      (i
-                       (FunctionType
+                   (Struct
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_methods
+                      ((new
                         (BuiltinFn
                          ((function_params
                            ((integer (Value (Type IntegerType)))))
-                          (function_returns
-                           (Value
-                            (Struct
-                             ((struct_fields
-                               ((integer
-                                 ((field_type (Value (Type IntegerType)))))))
-                              (struct_methods ()) (struct_id <opaque>)))))
-                          (function_impl <fun>)))))))))
-                  (Break
-                   (Expr
-                    (Reference
-                     (a
-                      (FunctionType
-                       (BuiltinFn
-                        ((function_params ((integer (Value (Type IntegerType)))))
-                         (function_returns
-                          (Value
-                           (Struct
-                            ((struct_fields
-                              ((integer
-                                ((field_type (Value (Type IntegerType)))))))
-                             (struct_methods ()) (struct_id <opaque>)))))
-                         (function_impl <fun>))))))))))))))))))
+                          (function_returns Hole) (function_impl <fun>))))))
+                     (struct_id <opaque>)))))))
+               (function_returns Hole)
+               (function_impl
+                (((Let ((a (Reference (i TypeType)))))
+                  (Break (Expr (Reference (a TypeType))))))))))))))
         (Let ((b (Value (Integer 1)))))))
       (bindings
        ((b (Value (Integer 1)))
@@ -845,46 +756,19 @@ let%expect_test "scoping that `let` introduces in code" =
             ((function_params
               ((i
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))))
-             (function_returns Hole)
-             (function_impl
-              (((Let
-                 ((a
-                   (Reference
-                    (i
-                     (FunctionType
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
                       (BuiltinFn
                        ((function_params ((integer (Value (Type IntegerType)))))
-                        (function_returns
-                         (Value
-                          (Struct
-                           ((struct_fields
-                             ((integer ((field_type (Value (Type IntegerType)))))))
-                            (struct_methods ()) (struct_id <opaque>)))))
-                        (function_impl <fun>)))))))))
-                (Break
-                 (Expr
-                  (Reference
-                   (a
-                    (FunctionType
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))))))))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))))
+             (function_returns Hole)
+             (function_impl
+              (((Let ((a (Reference (i TypeType)))))
+                (Break (Expr (Reference (a TypeType))))))))))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -893,16 +777,15 @@ let%expect_test "scoping that `let` introduces in code" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void))))))
@@ -934,45 +817,30 @@ let%expect_test "reference in function bodies" =
               ((function_params
                 ((i
                   (Value
-                   (Function
-                    (BuiltinFn
-                     ((function_params ((integer (Value (Type IntegerType)))))
-                      (function_returns
-                       (Value
-                        (Struct
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_methods ()) (struct_id <opaque>)))))
-                      (function_impl <fun>))))))
+                   (Struct
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_methods
+                      ((new
+                        (BuiltinFn
+                         ((function_params
+                           ((integer (Value (Type IntegerType)))))
+                          (function_returns Hole) (function_impl <fun>))))))
+                     (struct_id <opaque>)))))
                  (i_
                   (Value
-                   (Function
-                    (BuiltinFn
-                     ((function_params ((integer (Value (Type IntegerType)))))
-                      (function_returns
-                       (Value
-                        (Struct
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_methods ()) (struct_id <opaque>)))))
-                      (function_impl <fun>))))))))
+                   (Struct
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_methods
+                      ((new
+                        (BuiltinFn
+                         ((function_params
+                           ((integer (Value (Type IntegerType)))))
+                          (function_returns Hole) (function_impl <fun>))))))
+                     (struct_id <opaque>)))))))
                (function_returns Hole)
-               (function_impl
-                (((Break
-                   (Expr
-                    (Reference
-                     (i
-                      (FunctionType
-                       (BuiltinFn
-                        ((function_params ((integer (Value (Type IntegerType)))))
-                         (function_returns
-                          (Value
-                           (Struct
-                            ((struct_fields
-                              ((integer
-                                ((field_type (Value (Type IntegerType)))))))
-                             (struct_methods ()) (struct_id <opaque>)))))
-                         (function_impl <fun>))))))))))))))))))
+               (function_impl (((Break (Expr (Reference (i TypeType))))))))))))))
         (Let
          ((f
            (Value
@@ -981,16 +849,16 @@ let%expect_test "reference in function bodies" =
               ((function_params
                 ((x
                   (Value
-                   (Function
-                    (BuiltinFn
-                     ((function_params ((integer (Value (Type IntegerType)))))
-                      (function_returns
-                       (Value
-                        (Struct
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_methods ()) (struct_id <opaque>)))))
-                      (function_impl <fun>))))))))
+                   (Struct
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_methods
+                      ((new
+                        (BuiltinFn
+                         ((function_params
+                           ((integer (Value (Type IntegerType)))))
+                          (function_returns Hole) (function_impl <fun>))))))
+                     (struct_id <opaque>)))))))
                (function_returns Hole)
                (function_impl
                 (((Let
@@ -1002,82 +870,36 @@ let%expect_test "reference in function bodies" =
                            ((function_params
                              ((i
                                (Value
-                                (Function
-                                 (BuiltinFn
-                                  ((function_params
-                                    ((integer (Value (Type IntegerType)))))
-                                   (function_returns
-                                    (Value
-                                     (Struct
-                                      ((struct_fields
-                                        ((integer
-                                          ((field_type
-                                            (Value (Type IntegerType)))))))
-                                       (struct_methods ()) (struct_id <opaque>)))))
-                                   (function_impl <fun>))))))
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods
+                                   ((new
+                                     (BuiltinFn
+                                      ((function_params
+                                        ((integer (Value (Type IntegerType)))))
+                                       (function_returns Hole)
+                                       (function_impl <fun>))))))
+                                  (struct_id <opaque>)))))
                               (i_
                                (Value
-                                (Function
-                                 (BuiltinFn
-                                  ((function_params
-                                    ((integer (Value (Type IntegerType)))))
-                                   (function_returns
-                                    (Value
-                                     (Struct
-                                      ((struct_fields
-                                        ((integer
-                                          ((field_type
-                                            (Value (Type IntegerType)))))))
-                                       (struct_methods ()) (struct_id <opaque>)))))
-                                   (function_impl <fun>))))))))
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods
+                                   ((new
+                                     (BuiltinFn
+                                      ((function_params
+                                        ((integer (Value (Type IntegerType)))))
+                                       (function_returns Hole)
+                                       (function_impl <fun>))))))
+                                  (struct_id <opaque>)))))))
                             (function_returns Hole)
                             (function_impl
-                             (((Break
-                                (Expr
-                                 (Reference
-                                  (i
-                                   (FunctionType
-                                    (BuiltinFn
-                                     ((function_params
-                                       ((integer (Value (Type IntegerType)))))
-                                      (function_returns
-                                       (Value
-                                        (Struct
-                                         ((struct_fields
-                                           ((integer
-                                             ((field_type
-                                               (Value (Type IntegerType)))))))
-                                          (struct_methods ())
-                                          (struct_id <opaque>)))))
-                                      (function_impl <fun>)))))))))))))))
-                        ((Reference
-                          (x
-                           (FunctionType
-                            (BuiltinFn
-                             ((function_params
-                               ((integer (Value (Type IntegerType)))))
-                              (function_returns
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods ()) (struct_id <opaque>)))))
-                              (function_impl <fun>))))))
-                         (Reference
-                          (x
-                           (FunctionType
-                            (BuiltinFn
-                             ((function_params
-                               ((integer (Value (Type IntegerType)))))
-                              (function_returns
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods ()) (struct_id <opaque>)))))
-                              (function_impl <fun>))))))))
+                             (((Break (Expr (Reference (i TypeType)))))))))))
+                        ((Reference (x TypeType)) (Reference (x TypeType))))
                        ())))))
                   (Let
                    ((b
@@ -1088,54 +910,35 @@ let%expect_test "reference in function bodies" =
                            ((function_params
                              ((i
                                (Value
-                                (Function
-                                 (BuiltinFn
-                                  ((function_params
-                                    ((integer (Value (Type IntegerType)))))
-                                   (function_returns
-                                    (Value
-                                     (Struct
-                                      ((struct_fields
-                                        ((integer
-                                          ((field_type
-                                            (Value (Type IntegerType)))))))
-                                       (struct_methods ()) (struct_id <opaque>)))))
-                                   (function_impl <fun>))))))
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods
+                                   ((new
+                                     (BuiltinFn
+                                      ((function_params
+                                        ((integer (Value (Type IntegerType)))))
+                                       (function_returns Hole)
+                                       (function_impl <fun>))))))
+                                  (struct_id <opaque>)))))
                               (i_
                                (Value
-                                (Function
-                                 (BuiltinFn
-                                  ((function_params
-                                    ((integer (Value (Type IntegerType)))))
-                                   (function_returns
-                                    (Value
-                                     (Struct
-                                      ((struct_fields
-                                        ((integer
-                                          ((field_type
-                                            (Value (Type IntegerType)))))))
-                                       (struct_methods ()) (struct_id <opaque>)))))
-                                   (function_impl <fun>))))))))
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods
+                                   ((new
+                                     (BuiltinFn
+                                      ((function_params
+                                        ((integer (Value (Type IntegerType)))))
+                                       (function_returns Hole)
+                                       (function_impl <fun>))))))
+                                  (struct_id <opaque>)))))))
                             (function_returns Hole)
                             (function_impl
-                             (((Break
-                                (Expr
-                                 (Reference
-                                  (i
-                                   (FunctionType
-                                    (BuiltinFn
-                                     ((function_params
-                                       ((integer (Value (Type IntegerType)))))
-                                      (function_returns
-                                       (Value
-                                        (Struct
-                                         ((struct_fields
-                                           ((integer
-                                             ((field_type
-                                               (Value (Type IntegerType)))))))
-                                          (struct_methods ())
-                                          (struct_id <opaque>)))))
-                                      (function_impl <fun>)))))))))))))))
+                             (((Break (Expr (Reference (i TypeType)))))))))))
                         ((Reference (a HoleType)) (Reference (a HoleType))))
                        ())))))))))))))))))
       (bindings
@@ -1146,16 +949,15 @@ let%expect_test "reference in function bodies" =
             ((function_params
               ((x
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))))
              (function_returns Hole)
              (function_impl
               (((Let
@@ -1167,79 +969,36 @@ let%expect_test "reference in function bodies" =
                          ((function_params
                            ((i
                              (Value
-                              (Function
-                               (BuiltinFn
-                                ((function_params
-                                  ((integer (Value (Type IntegerType)))))
-                                 (function_returns
-                                  (Value
-                                   (Struct
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_methods ()) (struct_id <opaque>)))))
-                                 (function_impl <fun>))))))
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods
+                                 ((new
+                                   (BuiltinFn
+                                    ((function_params
+                                      ((integer (Value (Type IntegerType)))))
+                                     (function_returns Hole)
+                                     (function_impl <fun>))))))
+                                (struct_id <opaque>)))))
                             (i_
                              (Value
-                              (Function
-                               (BuiltinFn
-                                ((function_params
-                                  ((integer (Value (Type IntegerType)))))
-                                 (function_returns
-                                  (Value
-                                   (Struct
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_methods ()) (struct_id <opaque>)))))
-                                 (function_impl <fun>))))))))
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods
+                                 ((new
+                                   (BuiltinFn
+                                    ((function_params
+                                      ((integer (Value (Type IntegerType)))))
+                                     (function_returns Hole)
+                                     (function_impl <fun>))))))
+                                (struct_id <opaque>)))))))
                           (function_returns Hole)
                           (function_impl
-                           (((Break
-                              (Expr
-                               (Reference
-                                (i
-                                 (FunctionType
-                                  (BuiltinFn
-                                   ((function_params
-                                     ((integer (Value (Type IntegerType)))))
-                                    (function_returns
-                                     (Value
-                                      (Struct
-                                       ((struct_fields
-                                         ((integer
-                                           ((field_type
-                                             (Value (Type IntegerType)))))))
-                                        (struct_methods ()) (struct_id <opaque>)))))
-                                    (function_impl <fun>)))))))))))))))
-                      ((Reference
-                        (x
-                         (FunctionType
-                          (BuiltinFn
-                           ((function_params
-                             ((integer (Value (Type IntegerType)))))
-                            (function_returns
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods ()) (struct_id <opaque>)))))
-                            (function_impl <fun>))))))
-                       (Reference
-                        (x
-                         (FunctionType
-                          (BuiltinFn
-                           ((function_params
-                             ((integer (Value (Type IntegerType)))))
-                            (function_returns
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods ()) (struct_id <opaque>)))))
-                            (function_impl <fun>))))))))
+                           (((Break (Expr (Reference (i TypeType)))))))))))
+                      ((Reference (x TypeType)) (Reference (x TypeType))))
                      ())))))
                 (Let
                  ((b
@@ -1250,51 +1009,35 @@ let%expect_test "reference in function bodies" =
                          ((function_params
                            ((i
                              (Value
-                              (Function
-                               (BuiltinFn
-                                ((function_params
-                                  ((integer (Value (Type IntegerType)))))
-                                 (function_returns
-                                  (Value
-                                   (Struct
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_methods ()) (struct_id <opaque>)))))
-                                 (function_impl <fun>))))))
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods
+                                 ((new
+                                   (BuiltinFn
+                                    ((function_params
+                                      ((integer (Value (Type IntegerType)))))
+                                     (function_returns Hole)
+                                     (function_impl <fun>))))))
+                                (struct_id <opaque>)))))
                             (i_
                              (Value
-                              (Function
-                               (BuiltinFn
-                                ((function_params
-                                  ((integer (Value (Type IntegerType)))))
-                                 (function_returns
-                                  (Value
-                                   (Struct
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_methods ()) (struct_id <opaque>)))))
-                                 (function_impl <fun>))))))))
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods
+                                 ((new
+                                   (BuiltinFn
+                                    ((function_params
+                                      ((integer (Value (Type IntegerType)))))
+                                     (function_returns Hole)
+                                     (function_impl <fun>))))))
+                                (struct_id <opaque>)))))))
                           (function_returns Hole)
                           (function_impl
-                           (((Break
-                              (Expr
-                               (Reference
-                                (i
-                                 (FunctionType
-                                  (BuiltinFn
-                                   ((function_params
-                                     ((integer (Value (Type IntegerType)))))
-                                    (function_returns
-                                     (Value
-                                      (Struct
-                                       ((struct_fields
-                                         ((integer
-                                           ((field_type
-                                             (Value (Type IntegerType)))))))
-                                        (struct_methods ()) (struct_id <opaque>)))))
-                                    (function_impl <fun>)))))))))))))))
+                           (((Break (Expr (Reference (i TypeType)))))))))))
                       ((Reference (a HoleType)) (Reference (a HoleType))))
                      ())))))))))))))
         (op
@@ -1304,44 +1047,28 @@ let%expect_test "reference in function bodies" =
             ((function_params
               ((i
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))
                (i_
                 (Value
-                 (Function
-                  (BuiltinFn
-                   ((function_params ((integer (Value (Type IntegerType)))))
-                    (function_returns
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_methods ()) (struct_id <opaque>)))))
-                    (function_impl <fun>))))))))
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods
+                    ((new
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns Hole) (function_impl <fun>))))))
+                   (struct_id <opaque>)))))))
              (function_returns Hole)
-             (function_impl
-              (((Break
-                 (Expr
-                  (Reference
-                   (i
-                    (FunctionType
-                     (BuiltinFn
-                      ((function_params ((integer (Value (Type IntegerType)))))
-                       (function_returns
-                        (Value
-                         (Struct
-                          ((struct_fields
-                            ((integer ((field_type (Value (Type IntegerType)))))))
-                           (struct_methods ()) (struct_id <opaque>)))))
-                       (function_impl <fun>))))))))))))))))
+             (function_impl (((Break (Expr (Reference (i TypeType))))))))))))
         (Integer (Value (Type IntegerType)))
         (Int
          (Value
@@ -1350,16 +1077,15 @@ let%expect_test "reference in function bodies" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -1404,16 +1130,15 @@ let%expect_test "resolving a reference from inside a function" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
@@ -1421,8 +1146,8 @@ let%expect_test "resolving a reference from inside a function" =
 let%expect_test "Int(bits) constructor" =
   let source =
     {|
-      let i = Int(257)(100);
-      let overflow = Int(8)(513);
+      let i = Int(257).new(100);
+      let overflow = Int(8).new(513);
     |}
   in
   pp source ;
@@ -1436,7 +1161,12 @@ let%expect_test "Int(bits) constructor" =
             (StructInstance
              (((struct_fields
                 ((integer ((field_type (Value (Type IntegerType)))))))
-               (struct_methods ()) (struct_id <opaque>))
+               (struct_methods
+                ((new
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns Hole) (function_impl <fun>))))))
+               (struct_id <opaque>))
               ((integer (Integer 100)))))))))
         (Let
          ((overflow
@@ -1444,7 +1174,12 @@ let%expect_test "Int(bits) constructor" =
             (StructInstance
              (((struct_fields
                 ((integer ((field_type (Value (Type IntegerType)))))))
-               (struct_methods ()) (struct_id <opaque>))
+               (struct_methods
+                ((new
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns Hole) (function_impl <fun>))))))
+               (struct_id <opaque>))
               ((integer (Integer 1)))))))))))
       (bindings
        ((overflow
@@ -1452,14 +1187,24 @@ let%expect_test "Int(bits) constructor" =
           (StructInstance
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
-             (struct_methods ()) (struct_id <opaque>))
+             (struct_methods
+              ((new
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns Hole) (function_impl <fun>))))))
+             (struct_id <opaque>))
             ((integer (Integer 1)))))))
         (i
          (Value
           (StructInstance
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
-             (struct_methods ()) (struct_id <opaque>))
+             (struct_methods
+              ((new
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns Hole) (function_impl <fun>))))))
+             (struct_id <opaque>))
             ((integer (Integer 100)))))))
         (Integer (Value (Type IntegerType)))
         (Int
@@ -1469,16 +1214,111 @@ let%expect_test "Int(bits) constructor" =
             ((function_params ((bits (Value (Type IntegerType)))))
              (function_returns
               (Value
-               (Function
-                (BuiltinFn
-                 ((function_params ((integer (Value (Type IntegerType)))))
-                  (function_returns
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_methods ()) (struct_id <opaque>)))))
-                  (function_impl <fun>))))))
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
+
+let%expect_test "method access" =
+  let source =
+    {|
+      struct Foo {
+        fn bar(self: Type, i: Integer) {
+           i
+        }
+      }
+      let foo = Foo {};
+      let res = foo.bar(1);
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((stmts
+       ((Let
+         ((Foo
+           (Value
+            (Struct
+             ((struct_fields ())
+              (struct_methods
+               ((bar
+                 (Fn
+                  ((function_params
+                    ((self (Value (Builtin Type)))
+                     (i (Value (Type IntegerType)))))
+                   (function_returns Hole)
+                   (function_impl (((Break (Expr (Reference (i IntegerType))))))))))))
+              (struct_id <opaque>)))))))
+        (Let
+         ((foo
+           (Value
+            (StructInstance
+             (((struct_fields ())
+               (struct_methods
+                ((bar
+                  (Fn
+                   ((function_params
+                     ((self (Value (Builtin Type)))
+                      (i (Value (Type IntegerType)))))
+                    (function_returns Hole)
+                    (function_impl
+                     (((Break (Expr (Reference (i IntegerType))))))))))))
+               (struct_id <opaque>))
+              ()))))))
+        (Let ((res (Value (Integer 1)))))))
+      (bindings
+       ((res (Value (Integer 1)))
+        (foo
+         (Value
+          (StructInstance
+           (((struct_fields ())
+             (struct_methods
+              ((bar
+                (Fn
+                 ((function_params
+                   ((self (Value (Builtin Type))) (i (Value (Type IntegerType)))))
+                  (function_returns Hole)
+                  (function_impl (((Break (Expr (Reference (i IntegerType))))))))))))
+             (struct_id <opaque>))
+            ()))))
+        (Foo
+         (Value
+          (Struct
+           ((struct_fields ())
+            (struct_methods
+             ((bar
+               (Fn
+                ((function_params
+                  ((self (Value (Builtin Type))) (i (Value (Type IntegerType)))))
+                 (function_returns Hole)
+                 (function_impl (((Break (Expr (Reference (i IntegerType))))))))))))
+            (struct_id <opaque>)))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods
+                  ((new
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns Hole) (function_impl <fun>))))))
+                 (struct_id <opaque>)))))
              (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -29,22 +29,65 @@ let pp ?(bindings = Lang.default_bindings) s =
 
 let%expect_test "scope resolution" =
   let source = {|
-    let T = Int257;
+    let T = Int(257);
   |} in
   pp source ;
   [%expect
     {|
     (Ok
-     ((stmts ((Let ((T (Value (Builtin Int257)))))))
+     ((stmts
+       ((Let
+         ((T
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((integer (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods ()) (struct_id <opaque>)))))
+               (function_impl <fun>))))))))))
       (bindings
-       ((T (Value (Builtin Int257))) (Int257 (Value (Builtin Int257)))
+       ((T
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((integer (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods ()) (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]
 
 let%expect_test "binding resolution" =
   let source =
     {|
-    let T = Int257;
+    let T = Int(257);
     let T_ = T;
     let a = 1;
     let a_ = a;
@@ -55,14 +98,80 @@ let%expect_test "binding resolution" =
     {|
     (Ok
      ((stmts
-       ((Let ((T (Value (Builtin Int257)))))
-        (Let ((T_ (Value (Builtin Int257))))) (Let ((a (Value (Integer 1)))))
-        (Let ((a_ (Value (Integer 1)))))))
+       ((Let
+         ((T
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((integer (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods ()) (struct_id <opaque>)))))
+               (function_impl <fun>))))))))
+        (Let
+         ((T_
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((integer (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods ()) (struct_id <opaque>)))))
+               (function_impl <fun>))))))))
+        (Let ((a (Value (Integer 1))))) (Let ((a_ (Value (Integer 1)))))))
       (bindings
        ((a_ (Value (Integer 1))) (a (Value (Integer 1)))
-        (T_ (Value (Builtin Int257))) (T (Value (Builtin Int257)))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+        (T_
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((integer (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods ()) (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (T
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((integer (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods ()) (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "failed scope resolution" =
   let source = {|
@@ -73,7 +182,7 @@ let%expect_test "failed scope resolution" =
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
-    let A = Int257;
+    let A = Int(257);
     let B = A;
   |} in
   pp source ;
@@ -81,16 +190,82 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((stmts
-       ((Let ((A (Value (Builtin Int257)))))
-        (Let ((B (Value (Builtin Int257)))))))
+       ((Let
+         ((A
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((integer (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods ()) (struct_id <opaque>)))))
+               (function_impl <fun>))))))))
+        (Let
+         ((B
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((integer (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_methods ()) (struct_id <opaque>)))))
+               (function_impl <fun>))))))))))
       (bindings
-       ((B (Value (Builtin Int257))) (A (Value (Builtin Int257)))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+       ((B
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((integer (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods ()) (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (A
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((integer (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Struct
+                ((struct_fields
+                  ((integer ((field_type (Value (Type IntegerType)))))))
+                 (struct_methods ()) (struct_id <opaque>)))))
+             (function_impl <fun>))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "basic struct definition" =
   let source = {|
-    struct T { val t: Int257 }
+    struct T { val t: Int(257) }
   |} in
   pp source ;
   [%expect
@@ -101,16 +276,61 @@ let%expect_test "basic struct definition" =
          ((T
            (Value
             (Struct
-             ((struct_fields ((t ((field_type (Value (Builtin Int257)))))))
+             ((struct_fields
+               ((t
+                 ((field_type
+                   (Value
+                    (Function
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))))
               (struct_methods ()) (struct_id <opaque>)))))))))
       (bindings
        ((T
          (Value
           (Struct
-           ((struct_fields ((t ((field_type (Value (Builtin Int257)))))))
+           ((struct_fields
+             ((t
+               ((field_type
+                 (Value
+                  (Function
+                   (BuiltinFn
+                    ((function_params ((integer (Value (Type IntegerType)))))
+                     (function_returns
+                      (Value
+                       (Struct
+                        ((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_methods ()) (struct_id <opaque>)))))
+                     (function_impl <fun>))))))))))
             (struct_methods ()) (struct_id <opaque>)))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "native function evaluation" =
   let source = {|
@@ -143,13 +363,32 @@ let%expect_test "native function evaluation" =
            (BuiltinFn
             ((function_params ((value (Value (Type IntegerType)))))
              (function_returns (Value (Type IntegerType))) (function_impl <fun>))))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "Tact function evaluation" =
   let source =
     {|
-    fn test(i: Int257) -> Int257 {
+    fn test(i: Int(257)) -> Int(257) {
       i
     }
     let a = test(test(1));
@@ -165,10 +404,47 @@ let%expect_test "Tact function evaluation" =
            (Value
             (Function
              (Fn
-              ((function_params ((i (Value (Builtin Int257)))))
-               (function_returns (Value (Builtin Int257)))
+              ((function_params
+                ((i
+                  (Value
+                   (Function
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns
+                       (Value
+                        (Struct
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_methods ()) (struct_id <opaque>)))))
+                      (function_impl <fun>))))))))
+               (function_returns
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))
                (function_impl
-                (((Break (Expr (Reference (i (BuiltinType Int257)))))))))))))))
+                (((Break
+                   (Expr
+                    (Reference
+                     (i
+                      (FunctionType
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns
+                          (Value
+                           (Struct
+                            ((struct_fields
+                              ((integer
+                                ((field_type (Value (Type IntegerType)))))))
+                             (struct_methods ()) (struct_id <opaque>)))))
+                         (function_impl <fun>))))))))))))))))))
         (Let ((a (Value (Integer 1)))))))
       (bindings
        ((a (Value (Integer 1)))
@@ -176,18 +452,73 @@ let%expect_test "Tact function evaluation" =
          (Value
           (Function
            (Fn
-            ((function_params ((i (Value (Builtin Int257)))))
-             (function_returns (Value (Builtin Int257)))
+            ((function_params
+              ((i
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
              (function_impl
-              (((Break (Expr (Reference (i (BuiltinType Int257)))))))))))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+              (((Break
+                 (Expr
+                  (Reference
+                   (i
+                    (FunctionType
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))))))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "struct definition" =
   let source =
     {|
   let MyType = struct {
-       val a: Int257
+       val a: Int(257)
        val b: Bool
   };
   |}
@@ -202,7 +533,19 @@ let%expect_test "struct definition" =
              (Value
               (Struct
                ((struct_fields
-                 ((a ((field_type (Value (Builtin Int257)))))
+                 ((a
+                   ((field_type
+                     (Value
+                      (Function
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns
+                          (Value
+                           (Struct
+                            ((struct_fields
+                              ((integer ((field_type (Value (Type IntegerType)))))))
+                             (struct_methods ()) (struct_id <opaque>)))))
+                         (function_impl <fun>))))))))
                   (b ((field_type (Value (Builtin Bool)))))))
                 (struct_methods ()) (struct_id <opaque>)))))))))
         (bindings
@@ -210,17 +553,48 @@ let%expect_test "struct definition" =
            (Value
             (Struct
              ((struct_fields
-               ((a ((field_type (Value (Builtin Int257)))))
+               ((a
+                 ((field_type
+                   (Value
+                    (Function
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))
                 (b ((field_type (Value (Builtin Bool)))))))
               (struct_methods ()) (struct_id <opaque>)))))
-          (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-          (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((bits (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))
+               (function_impl <fun>))))))
+          (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+          (Void (Value Void)))))) |}]
 
 let%expect_test "duplicate type field" =
   let source =
     {|
   let MyType = struct {
-      val a: Int257
+      val a: Int(257)
       val a: Bool
   };
   |}
@@ -232,7 +606,19 @@ let%expect_test "duplicate type field" =
      ((DuplicateField
        (a
         ((struct_fields
-          ((a ((field_type (Value (Builtin Int257)))))
+          ((a
+            ((field_type
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))))
            (a ((field_type (Value (Builtin Bool)))))))
          (struct_methods ()) (struct_id <opaque>)))))) |}]
 
@@ -240,7 +626,7 @@ let%expect_test "parametric struct instantiation" =
   let source =
     {|
       struct T(A: Type) { val a: A }
-      let TA = T(Int257);
+      let TA = T(Int(257));
    |}
   in
   pp source ;
@@ -266,13 +652,39 @@ let%expect_test "parametric struct instantiation" =
          ((TA
            (Value
             (Struct
-             ((struct_fields ((a ((field_type (Value (Builtin Int257)))))))
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (Value
+                    (Function
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))))
               (struct_methods ()) (struct_id <opaque>)))))))))
       (bindings
        ((TA
          (Value
           (Struct
-           ((struct_fields ((a ((field_type (Value (Builtin Int257)))))))
+           ((struct_fields
+             ((a
+               ((field_type
+                 (Value
+                  (Function
+                   (BuiltinFn
+                    ((function_params ((integer (Value (Type IntegerType)))))
+                     (function_returns
+                      (Value
+                       (Struct
+                        ((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_methods ()) (struct_id <opaque>)))))
+                     (function_impl <fun>))))))))))
             (struct_methods ()) (struct_id <opaque>)))))
         (T
          (Value
@@ -287,8 +699,27 @@ let%expect_test "parametric struct instantiation" =
                    ((struct_fields
                      ((a ((field_type (Reference (A (BuiltinType Type))))))))
                     (struct_methods ()) (struct_id <opaque>)))))))))))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "function without a return type" =
   let source = {|
@@ -316,13 +747,32 @@ let%expect_test "function without a return type" =
              (Fn
               ((function_params ()) (function_returns Hole)
                (function_impl (((Break (Expr (Value (Integer 1))))))))))))
-          (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-          (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             (BuiltinFn
+              ((function_params ((bits (Value (Type IntegerType)))))
+               (function_returns
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))
+               (function_impl <fun>))))))
+          (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+          (Void (Value Void)))))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
   let source =
     {|
-    fn f(i: Int257) {
+    fn f(i: Int(257)) {
       let a = i;
       a
     }
@@ -339,11 +789,52 @@ let%expect_test "scoping that `let` introduces in code" =
            (Value
             (Function
              (Fn
-              ((function_params ((i (Value (Builtin Int257)))))
+              ((function_params
+                ((i
+                  (Value
+                   (Function
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns
+                       (Value
+                        (Struct
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_methods ()) (struct_id <opaque>)))))
+                      (function_impl <fun>))))))))
                (function_returns Hole)
                (function_impl
-                (((Let ((a (Reference (i (BuiltinType Int257))))))
-                  (Break (Expr (Reference (a (BuiltinType Int257)))))))))))))))
+                (((Let
+                   ((a
+                     (Reference
+                      (i
+                       (FunctionType
+                        (BuiltinFn
+                         ((function_params
+                           ((integer (Value (Type IntegerType)))))
+                          (function_returns
+                           (Value
+                            (Struct
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_methods ()) (struct_id <opaque>)))))
+                          (function_impl <fun>)))))))))
+                  (Break
+                   (Expr
+                    (Reference
+                     (a
+                      (FunctionType
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns
+                          (Value
+                           (Struct
+                            ((struct_fields
+                              ((integer
+                                ((field_type (Value (Type IntegerType)))))))
+                             (struct_methods ()) (struct_id <opaque>)))))
+                         (function_impl <fun>))))))))))))))))))
         (Let ((b (Value (Integer 1)))))))
       (bindings
        ((b (Value (Integer 1)))
@@ -351,23 +842,80 @@ let%expect_test "scoping that `let` introduces in code" =
          (Value
           (Function
            (Fn
-            ((function_params ((i (Value (Builtin Int257)))))
+            ((function_params
+              ((i
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))))
              (function_returns Hole)
              (function_impl
-              (((Let ((a (Reference (i (BuiltinType Int257))))))
-                (Break (Expr (Reference (a (BuiltinType Int257)))))))))))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void))))))
+              (((Let
+                 ((a
+                   (Reference
+                    (i
+                     (FunctionType
+                      (BuiltinFn
+                       ((function_params ((integer (Value (Type IntegerType)))))
+                        (function_returns
+                         (Value
+                          (Struct
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_methods ()) (struct_id <opaque>)))))
+                        (function_impl <fun>)))))))))
+                (Break
+                 (Expr
+                  (Reference
+                   (a
+                    (FunctionType
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))))))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void))))))
      |}]
 
 let%expect_test "reference in function bodies" =
   let source =
     {|
-      fn op(i: Int257, i_: Int257) {
+      fn op(i: Int(257), i_: Int(257)) {
         i
       }
 
-      fn f(x: Int257) {
+      fn f(x: Int(257)) {
         let a = op(x, x);
         let b = op(a, a);
       }
@@ -384,16 +932,65 @@ let%expect_test "reference in function bodies" =
             (Function
              (Fn
               ((function_params
-                ((i (Value (Builtin Int257))) (i_ (Value (Builtin Int257)))))
+                ((i
+                  (Value
+                   (Function
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns
+                       (Value
+                        (Struct
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_methods ()) (struct_id <opaque>)))))
+                      (function_impl <fun>))))))
+                 (i_
+                  (Value
+                   (Function
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns
+                       (Value
+                        (Struct
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_methods ()) (struct_id <opaque>)))))
+                      (function_impl <fun>))))))))
                (function_returns Hole)
                (function_impl
-                (((Break (Expr (Reference (i (BuiltinType Int257)))))))))))))))
+                (((Break
+                   (Expr
+                    (Reference
+                     (i
+                      (FunctionType
+                       (BuiltinFn
+                        ((function_params ((integer (Value (Type IntegerType)))))
+                         (function_returns
+                          (Value
+                           (Struct
+                            ((struct_fields
+                              ((integer
+                                ((field_type (Value (Type IntegerType)))))))
+                             (struct_methods ()) (struct_id <opaque>)))))
+                         (function_impl <fun>))))))))))))))))))
         (Let
          ((f
            (Value
             (Function
              (Fn
-              ((function_params ((x (Value (Builtin Int257)))))
+              ((function_params
+                ((x
+                  (Value
+                   (Function
+                    (BuiltinFn
+                     ((function_params ((integer (Value (Type IntegerType)))))
+                      (function_returns
+                       (Value
+                        (Struct
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_methods ()) (struct_id <opaque>)))))
+                      (function_impl <fun>))))))))
                (function_returns Hole)
                (function_impl
                 (((Let
@@ -403,14 +1000,84 @@ let%expect_test "reference in function bodies" =
                          (Function
                           (Fn
                            ((function_params
-                             ((i (Value (Builtin Int257)))
-                              (i_ (Value (Builtin Int257)))))
+                             ((i
+                               (Value
+                                (Function
+                                 (BuiltinFn
+                                  ((function_params
+                                    ((integer (Value (Type IntegerType)))))
+                                   (function_returns
+                                    (Value
+                                     (Struct
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_methods ()) (struct_id <opaque>)))))
+                                   (function_impl <fun>))))))
+                              (i_
+                               (Value
+                                (Function
+                                 (BuiltinFn
+                                  ((function_params
+                                    ((integer (Value (Type IntegerType)))))
+                                   (function_returns
+                                    (Value
+                                     (Struct
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_methods ()) (struct_id <opaque>)))))
+                                   (function_impl <fun>))))))))
                             (function_returns Hole)
                             (function_impl
                              (((Break
-                                (Expr (Reference (i (BuiltinType Int257))))))))))))
-                        ((Reference (x (BuiltinType Int257)))
-                         (Reference (x (BuiltinType Int257)))))
+                                (Expr
+                                 (Reference
+                                  (i
+                                   (FunctionType
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns
+                                       (Value
+                                        (Struct
+                                         ((struct_fields
+                                           ((integer
+                                             ((field_type
+                                               (Value (Type IntegerType)))))))
+                                          (struct_methods ())
+                                          (struct_id <opaque>)))))
+                                      (function_impl <fun>)))))))))))))))
+                        ((Reference
+                          (x
+                           (FunctionType
+                            (BuiltinFn
+                             ((function_params
+                               ((integer (Value (Type IntegerType)))))
+                              (function_returns
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods ()) (struct_id <opaque>)))))
+                              (function_impl <fun>))))))
+                         (Reference
+                          (x
+                           (FunctionType
+                            (BuiltinFn
+                             ((function_params
+                               ((integer (Value (Type IntegerType)))))
+                              (function_returns
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_methods ()) (struct_id <opaque>)))))
+                              (function_impl <fun>))))))))
                        ())))))
                   (Let
                    ((b
@@ -419,12 +1086,56 @@ let%expect_test "reference in function bodies" =
                          (Function
                           (Fn
                            ((function_params
-                             ((i (Value (Builtin Int257)))
-                              (i_ (Value (Builtin Int257)))))
+                             ((i
+                               (Value
+                                (Function
+                                 (BuiltinFn
+                                  ((function_params
+                                    ((integer (Value (Type IntegerType)))))
+                                   (function_returns
+                                    (Value
+                                     (Struct
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_methods ()) (struct_id <opaque>)))))
+                                   (function_impl <fun>))))))
+                              (i_
+                               (Value
+                                (Function
+                                 (BuiltinFn
+                                  ((function_params
+                                    ((integer (Value (Type IntegerType)))))
+                                   (function_returns
+                                    (Value
+                                     (Struct
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_methods ()) (struct_id <opaque>)))))
+                                   (function_impl <fun>))))))))
                             (function_returns Hole)
                             (function_impl
                              (((Break
-                                (Expr (Reference (i (BuiltinType Int257))))))))))))
+                                (Expr
+                                 (Reference
+                                  (i
+                                   (FunctionType
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns
+                                       (Value
+                                        (Struct
+                                         ((struct_fields
+                                           ((integer
+                                             ((field_type
+                                               (Value (Type IntegerType)))))))
+                                          (struct_methods ())
+                                          (struct_id <opaque>)))))
+                                      (function_impl <fun>)))))))))))))))
                         ((Reference (a HoleType)) (Reference (a HoleType))))
                        ())))))))))))))))))
       (bindings
@@ -432,7 +1143,19 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            (Fn
-            ((function_params ((x (Value (Builtin Int257)))))
+            ((function_params
+              ((x
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))))
              (function_returns Hole)
              (function_impl
               (((Let
@@ -442,13 +1165,81 @@ let%expect_test "reference in function bodies" =
                        (Function
                         (Fn
                          ((function_params
-                           ((i (Value (Builtin Int257)))
-                            (i_ (Value (Builtin Int257)))))
+                           ((i
+                             (Value
+                              (Function
+                               (BuiltinFn
+                                ((function_params
+                                  ((integer (Value (Type IntegerType)))))
+                                 (function_returns
+                                  (Value
+                                   (Struct
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_methods ()) (struct_id <opaque>)))))
+                                 (function_impl <fun>))))))
+                            (i_
+                             (Value
+                              (Function
+                               (BuiltinFn
+                                ((function_params
+                                  ((integer (Value (Type IntegerType)))))
+                                 (function_returns
+                                  (Value
+                                   (Struct
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_methods ()) (struct_id <opaque>)))))
+                                 (function_impl <fun>))))))))
                           (function_returns Hole)
                           (function_impl
-                           (((Break (Expr (Reference (i (BuiltinType Int257))))))))))))
-                      ((Reference (x (BuiltinType Int257)))
-                       (Reference (x (BuiltinType Int257)))))
+                           (((Break
+                              (Expr
+                               (Reference
+                                (i
+                                 (FunctionType
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_methods ()) (struct_id <opaque>)))))
+                                    (function_impl <fun>)))))))))))))))
+                      ((Reference
+                        (x
+                         (FunctionType
+                          (BuiltinFn
+                           ((function_params
+                             ((integer (Value (Type IntegerType)))))
+                            (function_returns
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods ()) (struct_id <opaque>)))))
+                            (function_impl <fun>))))))
+                       (Reference
+                        (x
+                         (FunctionType
+                          (BuiltinFn
+                           ((function_params
+                             ((integer (Value (Type IntegerType)))))
+                            (function_returns
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_methods ()) (struct_id <opaque>)))))
+                            (function_impl <fun>))))))))
                      ())))))
                 (Let
                  ((b
@@ -457,11 +1248,53 @@ let%expect_test "reference in function bodies" =
                        (Function
                         (Fn
                          ((function_params
-                           ((i (Value (Builtin Int257)))
-                            (i_ (Value (Builtin Int257)))))
+                           ((i
+                             (Value
+                              (Function
+                               (BuiltinFn
+                                ((function_params
+                                  ((integer (Value (Type IntegerType)))))
+                                 (function_returns
+                                  (Value
+                                   (Struct
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_methods ()) (struct_id <opaque>)))))
+                                 (function_impl <fun>))))))
+                            (i_
+                             (Value
+                              (Function
+                               (BuiltinFn
+                                ((function_params
+                                  ((integer (Value (Type IntegerType)))))
+                                 (function_returns
+                                  (Value
+                                   (Struct
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_methods ()) (struct_id <opaque>)))))
+                                 (function_impl <fun>))))))))
                           (function_returns Hole)
                           (function_impl
-                           (((Break (Expr (Reference (i (BuiltinType Int257))))))))))))
+                           (((Break
+                              (Expr
+                               (Reference
+                                (i
+                                 (FunctionType
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_methods ()) (struct_id <opaque>)))))
+                                    (function_impl <fun>)))))))))))))))
                       ((Reference (a HoleType)) (Reference (a HoleType))))
                      ())))))))))))))
         (op
@@ -469,12 +1302,67 @@ let%expect_test "reference in function bodies" =
           (Function
            (Fn
             ((function_params
-              ((i (Value (Builtin Int257))) (i_ (Value (Builtin Int257)))))
+              ((i
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))
+               (i_
+                (Value
+                 (Function
+                  (BuiltinFn
+                   ((function_params ((integer (Value (Type IntegerType)))))
+                    (function_returns
+                     (Value
+                      (Struct
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_methods ()) (struct_id <opaque>)))))
+                    (function_impl <fun>))))))))
              (function_returns Hole)
              (function_impl
-              (((Break (Expr (Reference (i (BuiltinType Int257)))))))))))))
-        (Int257 (Value (Builtin Int257))) (Bool (Value (Builtin Bool)))
-        (Type (Value (Builtin Type))) (Void (Value Void)))))) |}]
+              (((Break
+                 (Expr
+                  (Reference
+                   (i
+                    (FunctionType
+                     (BuiltinFn
+                      ((function_params ((integer (Value (Type IntegerType)))))
+                       (function_returns
+                        (Value
+                         (Struct
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_methods ()) (struct_id <opaque>)))))
+                       (function_impl <fun>))))))))))))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
   let source =
@@ -508,6 +1396,89 @@ let%expect_test "resolving a reference from inside a function" =
            (Fn
             ((function_params ()) (function_returns Hole)
              (function_impl (((Break (Expr (Value (Integer 1))))))))))))
-        (i (Value (Integer 1))) (Int257 (Value (Builtin Int257)))
+        (i (Value (Integer 1))) (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
+        (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
+        (Void (Value Void)))))) |}]
+
+let%expect_test "Int(bits) constructor" =
+  let source =
+    {|
+      let i = Int(257)(100);
+      let overflow = Int(8)(513);
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((stmts
+       ((Let
+         ((i
+           (Value
+            (StructInstance
+             (((struct_fields
+                ((integer ((field_type (Value (Type IntegerType)))))))
+               (struct_methods ()) (struct_id <opaque>))
+              ((integer (Integer 100)))))))))
+        (Let
+         ((overflow
+           (Value
+            (StructInstance
+             (((struct_fields
+                ((integer ((field_type (Value (Type IntegerType)))))))
+               (struct_methods ()) (struct_id <opaque>))
+              ((integer (Integer 1)))))))))))
+      (bindings
+       ((overflow
+         (Value
+          (StructInstance
+           (((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_methods ()) (struct_id <opaque>))
+            ((integer (Integer 1)))))))
+        (i
+         (Value
+          (StructInstance
+           (((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_methods ()) (struct_id <opaque>))
+            ((integer (Integer 100)))))))
+        (Integer (Value (Type IntegerType)))
+        (Int
+         (Value
+          (Function
+           (BuiltinFn
+            ((function_params ((bits (Value (Type IntegerType)))))
+             (function_returns
+              (Value
+               (Function
+                (BuiltinFn
+                 ((function_params ((integer (Value (Type IntegerType)))))
+                  (function_returns
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_methods ()) (struct_id <opaque>)))))
+                  (function_impl <fun>))))))
+             (function_impl <fun>))))))
         (Bool (Value (Builtin Bool))) (Type (Value (Builtin Type)))
         (Void (Value Void)))))) |}]

--- a/test/lang_types.ml
+++ b/test/lang_types.ml
@@ -31,7 +31,7 @@ let compile s =
 
 let test_alias () =
   let source = {|
-  struct T { val a: Int257 }
+  struct T { val a: Int(257) }
   let T1 = T; 
   |} in
   Alcotest.(check bool)
@@ -48,8 +48,8 @@ let test_alias () =
 let test_carbon_copy () =
   let source =
     {|
-  struct T { val a: Int257 }
-  struct T1 { val a: Int257 }
+  struct T { val a: Int(257) }
+  struct T1 { val a: Int(257) }
   |}
   in
   Alcotest.(check bool)
@@ -67,9 +67,9 @@ let test_parameterized () =
   let source =
     {|
   struct T(X: Type) { val a: X }
-  let T1 = T(Int257);
+  let T1 = T(Int(257));
   let T2 = T(Bool);
-  let T3 = T(Int257);
+  let T3 = T(Int(257));
   |}
   in
   Alcotest.(check bool)

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -50,8 +50,8 @@ let%expect_test "struct construction" =
   let source =
     {|
     struct MyType { 
-     val a: Int257
-     val b: Int257
+     val a: Int(257)
+     val b: Int(257)
   }
   let my = MyType {
     a: 0,
@@ -68,8 +68,14 @@ let%expect_test "struct construction" =
            (binding_expr
             (Struct
              ((fields
-               (((field_name (Ident a)) (field_type (Reference (Ident Int257))))
-                ((field_name (Ident b)) (field_type (Reference (Ident Int257)))))))))))
+               (((field_name (Ident a))
+                 (field_type
+                  (FunctionCall
+                   ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))
+                ((field_name (Ident b))
+                 (field_type
+                  (FunctionCall
+                   ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))))))))
          (Let
           ((binding_name (Ident my))
            (binding_expr
@@ -97,7 +103,7 @@ let%expect_test "struct fields" =
   let source =
     {|
   struct MyType {
-    val a: Int257
+    val a: Int(257)
     val f: get_type()
   }
   |}
@@ -111,7 +117,10 @@ let%expect_test "struct fields" =
          (binding_expr
           (Struct
            ((fields
-             (((field_name (Ident a)) (field_type (Reference (Ident Int257))))
+             (((field_name (Ident a))
+               (field_type
+                (FunctionCall
+                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))
               ((field_name (Ident f))
                (field_type (FunctionCall ((fn (Reference (Ident get_type))))))))))))))))) |}]
 
@@ -120,7 +129,7 @@ let%expect_test "struct methods" =
     {|
     struct MyType {
       fn test() -> Bool {}
-      fn todo() -> Int257
+      fn todo() -> Int(257)
     }
   |}
   in
@@ -138,13 +147,17 @@ let%expect_test "struct methods" =
                 (Function
                  ((returns (Reference (Ident Bool))) (function_body ())))))
               ((binding_name (Ident todo))
-               (binding_expr (Function ((returns (Reference (Ident Int257))))))))))))))))) |}]
+               (binding_expr
+                (Function
+                 ((returns
+                   (FunctionCall
+                    ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))))))))))))) |}]
 
 let%expect_test "struct with fields and methods" =
   let source =
     {|
     struct MyType {
-      val a: Int257
+      val a: Int(257)
       fn test() -> Bool {}
     }
   |}
@@ -158,7 +171,10 @@ let%expect_test "struct with fields and methods" =
          (binding_expr
           (Struct
            ((fields
-             (((field_name (Ident a)) (field_type (Reference (Ident Int257))))))
+             (((field_name (Ident a))
+               (field_type
+                (FunctionCall
+                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))
             (struct_bindings
              (((binding_name (Ident test))
                (binding_expr
@@ -202,9 +218,9 @@ let%expect_test "function definition shorthand" =
 let%expect_test "function without a return type" =
   let source =
     {|
-    let f1 = fn(t: Int257);
-    let f2 = fn(t: Int257) {};
-    fn f4(t: Int257) {}
+    let f1 = fn(t: Int(257));
+    let f2 = fn(t: Int(257)) {};
+    fn f4(t: Int(257)) {}
     |}
   in
   pp source ;
@@ -214,17 +230,29 @@ let%expect_test "function without a return type" =
       ((Let
         ((binding_name (Ident f1))
          (binding_expr
-          (Function ((params (((Ident t) (Reference (Ident Int257))))))))))
+          (Function
+           ((params
+             (((Ident t)
+               (FunctionCall
+                ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))))))
        (Let
         ((binding_name (Ident f2))
          (binding_expr
           (Function
-           ((params (((Ident t) (Reference (Ident Int257))))) (function_body ()))))))
+           ((params
+             (((Ident t)
+               (FunctionCall
+                ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))
+            (function_body ()))))))
        (Let
         ((binding_name (Ident f4))
          (binding_expr
           (Function
-           ((params (((Ident t) (Reference (Ident Int257))))) (function_body ()))))))))) |}]
+           ((params
+             (((Ident t)
+               (FunctionCall
+                ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))
+            (function_body ()))))))))) |}]
 
 let%expect_test "parse parameterized return type as part of function \
                  signature, not a function call" =
@@ -313,7 +341,7 @@ let%expect_test "function call in a list of statements" =
 let%expect_test "let in function body" =
   let source =
     {|
-  let f = fn() -> Int257 { 
+  let f = fn() -> Int(257) { 
        let a = 1;
        return a;
   };
@@ -327,7 +355,9 @@ let%expect_test "let in function body" =
         ((binding_name (Ident f))
          (binding_expr
           (Function
-           ((returns (Reference (Ident Int257)))
+           ((returns
+             (FunctionCall
+              ((fn (Reference (Ident Int))) (arguments ((Int 257))))))
             (function_body
              ((function_stmts
                ((Let ((binding_name (Ident a)) (binding_expr (Int 1))))
@@ -336,7 +366,7 @@ let%expect_test "let in function body" =
 let%expect_test "code block without trailing semicolon" =
   let source =
     {|
-    let f = fn() -> Int257 { 
+    let f = fn() -> Int(257) { 
       let a = 1;
       a
     };
@@ -350,7 +380,9 @@ let%expect_test "code block without trailing semicolon" =
         ((binding_name (Ident f))
          (binding_expr
           (Function
-           ((returns (Reference (Ident Int257)))
+           ((returns
+             (FunctionCall
+              ((fn (Reference (Ident Int))) (arguments ((Int 257))))))
             (function_body
              ((function_stmts
                ((Let ((binding_name (Ident a)) (binding_expr (Int 1))))
@@ -446,7 +478,7 @@ let%expect_test "struct construction over a parameterized type" =
 let%expect_test "struct construction over an anonymous type" =
   let source =
     {|
-  let a = (struct { val field: Int257 }) { field: value };
+  let a = (struct { val field: Int(257) }) { field: value };
   |}
   in
   pp source ;
@@ -461,7 +493,9 @@ let%expect_test "struct construction over an anonymous type" =
              (Struct
               ((fields
                 (((field_name (Ident field))
-                  (field_type (Reference (Ident Int257)))))))))
+                  (field_type
+                   (FunctionCall
+                    ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))))))
             (fields_construction (((Ident field) (Reference (Ident value))))))))))))) |}]
 
 let%expect_test "struct construction over an anonymous type's function call" =
@@ -571,7 +605,7 @@ let%expect_test "union definition" =
   let source =
     {|
     union U {
-       case Int257
+       case Int(257)
        case Bool
     }  
     |}
@@ -584,13 +618,16 @@ let%expect_test "union definition" =
         ((binding_name (Ident U))
          (binding_expr
           (Union
-           ((union_members ((Reference (Ident Int257)) (Reference (Ident Bool)))))))))))) |}]
+           ((union_members
+             ((FunctionCall
+               ((fn (Reference (Ident Int))) (arguments ((Int 257)))))
+              (Reference (Ident Bool)))))))))))) |}]
 
 let%expect_test "union definition using let binding" =
   let source =
     {|
     let U = union {
-       case Int257
+       case Int(257)
        case Bool
     };
     |}
@@ -603,7 +640,10 @@ let%expect_test "union definition using let binding" =
         ((binding_name (Ident U))
          (binding_expr
           (Union
-           ((union_members ((Reference (Ident Int257)) (Reference (Ident Bool)))))))))))) |}]
+           ((union_members
+             ((FunctionCall
+               ((fn (Reference (Ident Int))) (arguments ((Int 257)))))
+              (Reference (Ident Bool)))))))))))) |}]
 
 let%expect_test "parameterized union definition" =
   let source =

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -601,6 +601,19 @@ let%expect_test "field access over other expressions" =
                       (to_field (Ident field)))))
                    (to_field (Ident other_field))))))))))))))))) |}]
 
+let%expect_test "method access" =
+  let source = {|
+      foo.bar(1);
+    |} in
+  pp source ;
+  [%expect
+    {|
+    ((stmts
+      ((Expr
+        (MethodCall
+         ((receiver (Reference (Ident foo))) (receiver_fn (Ident bar))
+          (receiver_arguments ((Int 1))))))))) |}]
+
 let%expect_test "union definition" =
   let source =
     {|


### PR DESCRIPTION
This allows us to express any size of integer and is internally represented by a newtype.

It can be used in such a way:

```
let i = Int(257).new(100);
```

This change has brought some much needed code to implement methods and method calling, though it is a bit crude and there are still tons of gaps. But it's a start.