### PR TITLE
Evaluate and collapse function calls in compile-time

### DIFF
--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -55,14 +55,8 @@ class interpreter ((bindings, errors) : expr named_map list * _ errors) =
     method interpret_expr : expr -> value =
       fun expr ->
         match expr with
-        | FunctionCall (fc, result) -> (
-          match !result with
-          | Some t ->
-              t
-          | _ ->
-              let value = self#interpret_fc fc in
-              result := Some value ;
-              value )
+        | FunctionCall fc ->
+            self#interpret_fc fc
         | Reference (name, _) -> (
           match self#find_ref name with
           | Some expr' ->
@@ -92,7 +86,7 @@ class interpreter ((bindings, errors) : expr named_map list * _ errors) =
 
     method interpret_fc : function_call -> value =
       fun (func, args) ->
-        let mk_err = Expr (FunctionCall ((func, args), ref None)) in
+        let mk_err = Expr (FunctionCall (func, args)) in
         let args' = List.map args ~f:(fun arg -> self#interpret_expr arg) in
         let args_to_list params values =
           match

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -14,8 +14,7 @@ and binding = string * expr
 and program = {stmts : stmt list; [@sexp.list] bindings : expr named_map}
 
 and expr =
-  | FunctionCall of (function_call * (value option[@sexp.option]) ref)
-    (* expr option is cached result *)
+  | FunctionCall of function_call
   | Reference of (string * type_)
   | Value of value
   | Hole
@@ -94,8 +93,8 @@ let rec expr_to_type = function
       type_
   | Hole ->
       HoleType
-  | FunctionCall ((Value (Function (Fn {function_returns; _})), _), _)
-  | FunctionCall ((Value (Function (BuiltinFn {function_returns; _})), _), _) ->
+  | FunctionCall (Value (Function (Fn {function_returns; _})), _)
+  | FunctionCall (Value (Function (BuiltinFn {function_returns; _})), _) ->
       expr_to_type function_returns
   | Reference (_, t) ->
       t
@@ -105,7 +104,7 @@ let rec expr_to_type = function
 let rec is_immediate_expr = function
   | Value _ ->
       true
-  | FunctionCall ((_, args), _) ->
+  | FunctionCall (_, args) ->
       are_immediate_arguments args
   | Hole ->
       false

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -310,6 +310,53 @@ let%expect_test "Tact function evaluation" =
                  (struct_id <opaque>)))))
              (function_impl (((Break (Expr (Reference (i TypeType)))))))))))))))) |}]
 
+let%expect_test "compile-time function evaluation within a function" =
+  let source =
+    {|
+    fn test() {
+      let v = incr(incr(incr(1)));
+      v
+    }
+  |}
+  in
+  pp source
+    ~bindings:
+      ( ( "incr",
+          Value
+            (Function
+               (BuiltinFn
+                  { function_params = [("value", Value (Type IntegerType))];
+                    function_returns = Value (Type IntegerType);
+                    function_impl =
+                      builtin_fun (fun _p -> function
+                        | Integer arg :: _ ->
+                            Integer (Zint.succ arg)
+                        | _ ->
+                            Integer Zint.zero ) } ) ) )
+      :: Lang.default_bindings ) ;
+  [%expect
+    {|
+    (Ok
+     ((stmts
+       ((Let
+         ((test
+           (Value
+            (Function
+             (Fn
+              ((function_params ()) (function_returns Hole)
+               (function_impl
+                (((Let ((v (Value (Integer 4)))))
+                  (Break (Expr (Value (Integer 4))))))))))))))))
+      (bindings
+       ((test
+         (Value
+          (Function
+           (Fn
+            ((function_params ()) (function_returns Hole)
+             (function_impl
+              (((Let ((v (Value (Integer 4)))))
+                (Break (Expr (Value (Integer 4)))))))))))))))) |}]
+
 let%expect_test "struct definition" =
   let source =
     {|
@@ -642,83 +689,81 @@ let%expect_test "reference in function bodies" =
                 (((Let
                    ((a
                      (FunctionCall
-                      (((Value
-                         (Function
-                          (Fn
-                           ((function_params
-                             ((i
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods
-                                   ((new
-                                     (BuiltinFn
-                                      ((function_params
-                                        ((integer (Value (Type IntegerType)))))
-                                       (function_returns Hole)
-                                       (function_impl (<fun> <opaque>)))))))
-                                  (struct_id <opaque>)))))
-                              (i_
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods
-                                   ((new
-                                     (BuiltinFn
-                                      ((function_params
-                                        ((integer (Value (Type IntegerType)))))
-                                       (function_returns Hole)
-                                       (function_impl (<fun> <opaque>)))))))
-                                  (struct_id <opaque>)))))))
-                            (function_returns Hole)
-                            (function_impl
-                             (((Break (Expr (Reference (i TypeType)))))))))))
-                        ((Reference (x TypeType)) (Reference (x TypeType))))
-                       ())))))
+                      ((Value
+                        (Function
+                         (Fn
+                          ((function_params
+                            ((i
+                              (Value
+                               (Struct
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_methods
+                                  ((new
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns Hole)
+                                      (function_impl (<fun> <opaque>)))))))
+                                 (struct_id <opaque>)))))
+                             (i_
+                              (Value
+                               (Struct
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_methods
+                                  ((new
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns Hole)
+                                      (function_impl (<fun> <opaque>)))))))
+                                 (struct_id <opaque>)))))))
+                           (function_returns Hole)
+                           (function_impl
+                            (((Break (Expr (Reference (i TypeType)))))))))))
+                       ((Reference (x TypeType)) (Reference (x TypeType))))))))
                   (Let
                    ((b
                      (FunctionCall
-                      (((Value
-                         (Function
-                          (Fn
-                           ((function_params
-                             ((i
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods
-                                   ((new
-                                     (BuiltinFn
-                                      ((function_params
-                                        ((integer (Value (Type IntegerType)))))
-                                       (function_returns Hole)
-                                       (function_impl (<fun> <opaque>)))))))
-                                  (struct_id <opaque>)))))
-                              (i_
-                               (Value
-                                (Struct
-                                 ((struct_fields
-                                   ((integer
-                                     ((field_type (Value (Type IntegerType)))))))
-                                  (struct_methods
-                                   ((new
-                                     (BuiltinFn
-                                      ((function_params
-                                        ((integer (Value (Type IntegerType)))))
-                                       (function_returns Hole)
-                                       (function_impl (<fun> <opaque>)))))))
-                                  (struct_id <opaque>)))))))
-                            (function_returns Hole)
-                            (function_impl
-                             (((Break (Expr (Reference (i TypeType)))))))))))
-                        ((Reference (a HoleType)) (Reference (a HoleType))))
-                       ())))))))))))))))))
+                      ((Value
+                        (Function
+                         (Fn
+                          ((function_params
+                            ((i
+                              (Value
+                               (Struct
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_methods
+                                  ((new
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns Hole)
+                                      (function_impl (<fun> <opaque>)))))))
+                                 (struct_id <opaque>)))))
+                             (i_
+                              (Value
+                               (Struct
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_methods
+                                  ((new
+                                    (BuiltinFn
+                                     ((function_params
+                                       ((integer (Value (Type IntegerType)))))
+                                      (function_returns Hole)
+                                      (function_impl (<fun> <opaque>)))))))
+                                 (struct_id <opaque>)))))))
+                           (function_returns Hole)
+                           (function_impl
+                            (((Break (Expr (Reference (i TypeType)))))))))))
+                       ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))))))
       (bindings
        ((f
          (Value
@@ -741,83 +786,81 @@ let%expect_test "reference in function bodies" =
               (((Let
                  ((a
                    (FunctionCall
-                    (((Value
-                       (Function
-                        (Fn
-                         ((function_params
-                           ((i
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods
-                                 ((new
-                                   (BuiltinFn
-                                    ((function_params
-                                      ((integer (Value (Type IntegerType)))))
-                                     (function_returns Hole)
-                                     (function_impl (<fun> <opaque>)))))))
-                                (struct_id <opaque>)))))
-                            (i_
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods
-                                 ((new
-                                   (BuiltinFn
-                                    ((function_params
-                                      ((integer (Value (Type IntegerType)))))
-                                     (function_returns Hole)
-                                     (function_impl (<fun> <opaque>)))))))
-                                (struct_id <opaque>)))))))
-                          (function_returns Hole)
-                          (function_impl
-                           (((Break (Expr (Reference (i TypeType)))))))))))
-                      ((Reference (x TypeType)) (Reference (x TypeType))))
-                     ())))))
+                    ((Value
+                      (Function
+                       (Fn
+                        ((function_params
+                          ((i
+                            (Value
+                             (Struct
+                              ((struct_fields
+                                ((integer
+                                  ((field_type (Value (Type IntegerType)))))))
+                               (struct_methods
+                                ((new
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns Hole)
+                                    (function_impl (<fun> <opaque>)))))))
+                               (struct_id <opaque>)))))
+                           (i_
+                            (Value
+                             (Struct
+                              ((struct_fields
+                                ((integer
+                                  ((field_type (Value (Type IntegerType)))))))
+                               (struct_methods
+                                ((new
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns Hole)
+                                    (function_impl (<fun> <opaque>)))))))
+                               (struct_id <opaque>)))))))
+                         (function_returns Hole)
+                         (function_impl
+                          (((Break (Expr (Reference (i TypeType)))))))))))
+                     ((Reference (x TypeType)) (Reference (x TypeType))))))))
                 (Let
                  ((b
                    (FunctionCall
-                    (((Value
-                       (Function
-                        (Fn
-                         ((function_params
-                           ((i
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods
-                                 ((new
-                                   (BuiltinFn
-                                    ((function_params
-                                      ((integer (Value (Type IntegerType)))))
-                                     (function_returns Hole)
-                                     (function_impl (<fun> <opaque>)))))))
-                                (struct_id <opaque>)))))
-                            (i_
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_methods
-                                 ((new
-                                   (BuiltinFn
-                                    ((function_params
-                                      ((integer (Value (Type IntegerType)))))
-                                     (function_returns Hole)
-                                     (function_impl (<fun> <opaque>)))))))
-                                (struct_id <opaque>)))))))
-                          (function_returns Hole)
-                          (function_impl
-                           (((Break (Expr (Reference (i TypeType)))))))))))
-                      ((Reference (a HoleType)) (Reference (a HoleType))))
-                     ())))))))))))))
+                    ((Value
+                      (Function
+                       (Fn
+                        ((function_params
+                          ((i
+                            (Value
+                             (Struct
+                              ((struct_fields
+                                ((integer
+                                  ((field_type (Value (Type IntegerType)))))))
+                               (struct_methods
+                                ((new
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns Hole)
+                                    (function_impl (<fun> <opaque>)))))))
+                               (struct_id <opaque>)))))
+                           (i_
+                            (Value
+                             (Struct
+                              ((struct_fields
+                                ((integer
+                                  ((field_type (Value (Type IntegerType)))))))
+                               (struct_methods
+                                ((new
+                                  (BuiltinFn
+                                   ((function_params
+                                     ((integer (Value (Type IntegerType)))))
+                                    (function_returns Hole)
+                                    (function_impl (<fun> <opaque>)))))))
+                               (struct_id <opaque>)))))))
+                         (function_returns Hole)
+                         (function_impl
+                          (((Break (Expr (Reference (i TypeType)))))))))))
+                     ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))
         (op
          (Value
           (Function


### PR DESCRIPTION
If it is safe to evaluate a function call in compile-time (it has immediate
arguments and is not otherwise marked for runtime execution), why keep
it around? Optimize it away.