### PR TITLE
Implement a rough demonstration of the serialization approach

### DIFF
--- a/lib/asm.ml
+++ b/lib/asm.ml
@@ -1,6 +1,14 @@
 open Base
 
-type instr = ADD | NOP | SWAP | XCHG0 of int
+type instr =
+  | ADD
+  | NOP
+  | SWAP
+  | XCHG0 of int
+  | PUSHINT of int
+  | NEWC
+  | STIX
+  | ENDC
 [@@deriving equal, sexp_of, yojson_of]
 
 class ['s] map =

--- a/lib/asm_lexer.mll
+++ b/lib/asm_lexer.mll
@@ -18,7 +18,12 @@ rule token = parse
  | "NOP" { NOP }
  | "SWAP" { SWAP }
  | "XCHG0" { XCHG0 }
+ | "PUSHINT" { PUSHINT }
+ | "INT" { PUSHINT }
  | "ADD" { ADD }
+ | "NEWC" { NEWC }
+ | "STIX" { STIX }
+ | "ENDC" { ENDC }
  | integer as i { INT (int_of_string i) }
  | eof { EOF }
  | _

--- a/lib/asm_parser.mly
+++ b/lib/asm_parser.mly
@@ -1,7 +1,9 @@
 (* Stack manipulation *)
-%token NOP SWAP XCHG0
+%token NOP SWAP XCHG0 PUSHINT
 (* Arithmetics *)
 %token ADD
+(* Cell *)
+%token NEWC STIX ENDC
 
 %token <int> INT
 %token EOF
@@ -20,4 +22,8 @@ let instr :=
     | NOP; { NOP }
     | SWAP; { SWAP }
     | ~= INT; XCHG0; <XCHG0> 
+    | ~= INT; PUSHINT; <PUSHINT> 
     | ADD; { ADD }
+    | NEWC; { NEWC }
+    | STIX; { STIX }
+    | ENDC; { ENDC }

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -1,11 +1,15 @@
 open Base
 open Lang_types
 
+let builder = Value (Type (BuiltinType "Builder"))
+
 let int_type =
   (* memoize struct ids for equality *)
   let struct_ids = Hashtbl.create (module Int)
   (* memoize constructor funs for equality *)
-  and int_constructor_funs = Hashtbl.create (module Int) in
+  and int_constructor_funs = Hashtbl.create (module Int)
+  (* memoize serializator funs for equality *)
+  and int_serializator_funs = Hashtbl.create (module Int) in
   (* int's newtype *)
   let rec int_type_s p bits =
     let struct_id =
@@ -18,7 +22,10 @@ let int_type =
       { struct_fields = [("integer", {field_type = Value (Type IntegerType)})];
         struct_id }
     in
-    let methods = [("new", int_type_s_new s bits)] in
+    let methods =
+      [ ("new", int_type_s_new s bits);
+        ("serialize", int_type_s_serialize s bits) ]
+    in
     if Option.is_none @@ List.Assoc.find p.methods ~equal:equal_value (Struct s)
     then p.methods <- (Struct s, methods) :: p.methods
     else () ;
@@ -31,8 +38,16 @@ let int_type =
     { function_params = [("integer", Value (Type IntegerType))];
       function_returns = Value (Struct self);
       function_impl = BuiltinFn function_impl }
+  and int_type_s_serialize self bits =
+    let function_impl =
+      Hashtbl.find_or_add int_serializator_funs bits ~default:(fun () ->
+          builtin_fun @@ serialize_impl bits )
+    in
+    { function_params = [("self", Value (Struct self)); ("builder", builder)];
+      function_returns = Value (Type VoidType);
+      function_impl = BuiltinFn function_impl }
   and constructor_impl bits p = function
-    | [Integer i] ->
+    | [Value (Integer i)] ->
         let numbits = Zint.numbits i in
         let i =
           (* FIXME: or should we raise an error here? *)
@@ -47,9 +62,18 @@ let int_type =
         Value (StructInstance (int_type_s p bits, [("integer", Integer i)]))
     | _ ->
         (* TODO: raise an error instead *)
-        constructor_impl bits p [Integer (Zint.of_int 0)]
+        constructor_impl bits p [Value (Integer (Zint.of_int 0))]
+  and serialize_impl bits _p = function
+    | [self; b] ->
+        (* TODO: we should extract this to a method in `Builder` but for demonstration's
+         * sake we're keeping it here for now
+         *)
+        Asm ([StructField (self, "integer"); b], [PUSHINT bits; STIX])
+    | _ ->
+        (* TODO: raise an error instead *)
+        Value Void
   and function_impl p = function
-    | [Integer bits] ->
+    | [Value (Integer bits)] ->
         Value (Struct (int_type_s p @@ Z.to_int bits))
     | _ ->
         (* TODO: raise an error instead *)
@@ -63,10 +87,10 @@ let int_type =
 
 let asm =
   let function_impl _p = function
-    | [String code] ->
+    | [Value (String code)] ->
         let lexbuf = Lexing.from_string code in
         let code = Asm_parser.code Asm_lexer.token lexbuf in
-        Asm code
+        Asm ([], code)
     | _ ->
         Value Void
   in
@@ -78,6 +102,7 @@ let asm =
 
 let default_bindings =
   [ ("asm", asm);
+    ("Builder", builder);
     ("Integer", Value (Type IntegerType));
     ("Int", int_type);
     ("Bool", Value (Builtin "Bool"));

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -141,8 +141,9 @@ functor
           and dummy : expr * expr list =
             ( Value
                 (Function
-                   { function_params = [];
-                     function_returns = Value (Type VoidType);
+                   { function_signature =
+                       { function_params = [];
+                         function_returns = Value (Type VoidType) };
                      function_impl =
                        BuiltinFn (builtin_fun (fun _ _ -> Value Void)) } ),
               [] )
@@ -230,7 +231,8 @@ functor
             |> Option.map ~f:(fun x -> Syntax.value x)
             |> Option.value ~default:Hole
           and function_impl = body in
-          {function_params; function_returns; function_impl = Fn function_impl}
+          { function_signature = {function_params; function_returns};
+            function_impl = Fn function_impl }
 
         method build_if_ _env _condition _then _else = ()
 

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -45,7 +45,7 @@ functor
 
         method build_FunctionCall _env (f, args) =
           let fc = (f, args) in
-          if are_immediate_arguments args then
+          if is_immediate_expr (FunctionCall (f, args)) then
             let inter =
               new interpreter (program, current_bindings, errors, functions)
             in

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -48,50 +48,54 @@ let%expect_test "Int(bits) constructor" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))
         ((Struct
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
-let%expect_test "Int(bits) serializator" =
+let%expect_test "Int(bits) serializer" =
   let source =
     {|
       fn test(b: Builder) {
@@ -109,8 +113,9 @@ let%expect_test "Int(bits) serializator" =
            ((test
              (Value
               (Function
-               ((function_params ((b (Value (Type (BuiltinType Builder))))))
-                (function_returns Hole)
+               ((function_signature
+                 ((function_params ((b (Value (Type (BuiltinType Builder))))))
+                  (function_returns Hole)))
                 (function_impl
                  (Fn
                   (((Let
@@ -137,8 +142,9 @@ let%expect_test "Int(bits) serializator" =
          ((test
            (Value
             (Function
-             ((function_params ((b (Value (Type (BuiltinType Builder))))))
-              (function_returns Hole)
+             ((function_signature
+               ((function_params ((b (Value (Type (BuiltinType Builder))))))
+                (function_returns Hole)))
               (function_impl
                (Fn
                 (((Let
@@ -166,15 +172,291 @@ let%expect_test "Int(bits) serializator" =
             ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>)))
            ((new
+             ((function_signature
+               ((function_params ((integer (Value (Type IntegerType)))))
+                (function_returns
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))
+                  (builder (Value (Type (BuiltinType Builder))))))
+                (function_returns (Value (Type VoidType)))))
+              (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
+
+let%expect_test "demo struct serializer" =
+  let source =
+    {|
+      struct T {
+        val a: Int(32)
+        val b: Int(16)
+      }
+      let T_serializer = serializer(T);
+
+      fn test(b: Builder) {
+        T_serializer(T{}, b);
+      }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((stmts
+       ((Let
+         ((T
+           (Value
+            (Struct
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))
+                (b
+                 ((field_type
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))))
+              (struct_id <opaque>)))))))
+        (Let
+         ((T_serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (Let
+         ((test
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((b (Value (Type (BuiltinType Builder))))))
+                (function_returns Hole)))
+              (function_impl
+               (Fn
+                (((Expr
+                   (Block
+                    (Expr
+                     (Asm
+                      (((StructField
+                         ((StructField
+                           ((Value
+                             (StructInstance
+                              (((struct_fields
+                                 ((a
+                                   ((field_type
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))
+                                  (b
+                                   ((field_type
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))))
+                                (struct_id <opaque>))
+                               ())))
+                            a))
+                          integer))
+                        (Reference (b (BuiltinType Builder))))
+                       ((PUSHINT 32) STIX))))
+                    (Expr
+                     (Asm
+                      (((StructField
+                         ((StructField
+                           ((Value
+                             (StructInstance
+                              (((struct_fields
+                                 ((a
+                                   ((field_type
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))
+                                  (b
+                                   ((field_type
+                                     (Value
+                                      (Struct
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))))
+                                (struct_id <opaque>))
+                               ())))
+                            b))
+                          integer))
+                        (Reference (b (BuiltinType Builder))))
+                       ((PUSHINT 16) STIX))))))))))))))))))
+      (bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((b (Value (Type (BuiltinType Builder))))))
+              (function_returns Hole)))
+            (function_impl
+             (Fn
+              (((Expr
+                 (Block
+                  (Expr
+                   (Asm
+                    (((StructField
+                       ((StructField
+                         ((Value
+                           (StructInstance
+                            (((struct_fields
+                               ((a
+                                 ((field_type
+                                   (Value
+                                    (Struct
+                                     ((struct_fields
+                                       ((integer
+                                         ((field_type (Value (Type IntegerType)))))))
+                                      (struct_id <opaque>)))))))
+                                (b
+                                 ((field_type
+                                   (Value
+                                    (Struct
+                                     ((struct_fields
+                                       ((integer
+                                         ((field_type (Value (Type IntegerType)))))))
+                                      (struct_id <opaque>)))))))))
+                              (struct_id <opaque>))
+                             ())))
+                          a))
+                        integer))
+                      (Reference (b (BuiltinType Builder))))
+                     ((PUSHINT 32) STIX))))
+                  (Expr
+                   (Asm
+                    (((StructField
+                       ((StructField
+                         ((Value
+                           (StructInstance
+                            (((struct_fields
+                               ((a
+                                 ((field_type
+                                   (Value
+                                    (Struct
+                                     ((struct_fields
+                                       ((integer
+                                         ((field_type (Value (Type IntegerType)))))))
+                                      (struct_id <opaque>)))))))
+                                (b
+                                 ((field_type
+                                   (Value
+                                    (Struct
+                                     ((struct_fields
+                                       ((integer
+                                         ((field_type (Value (Type IntegerType)))))))
+                                      (struct_id <opaque>)))))))))
+                              (struct_id <opaque>))
+                             ())))
+                          b))
+                        integer))
+                      (Reference (b (BuiltinType Builder))))
+                     ((PUSHINT 16) STIX))))))))))))))
+        (T_serializer
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((t (Value (Type TypeType)))))
+              (function_returns
+               (Value
+                (Type
+                 (FunctionType
+                  ((function_params
+                    ((t (Value (Type HoleType)))
+                     (builder (Value (Type (BuiltinType Builder))))))
+                   (function_returns (Value (Type VoidType))))))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))))
+        (T
+         (Value
+          (Struct
+           ((struct_fields
+             ((a
+               ((field_type
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))
+              (b
+               ((field_type
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))))
+            (struct_id <opaque>)))))))
+      (methods
+       (((Struct
+          ((struct_fields
+            ((a
+              ((field_type
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>)))))))
+             (b
+              ((field_type
+                (Value
+                 (Struct
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>)))))))))
+           (struct_id <opaque>)))
+         ())
+        ((Struct
+          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+           (struct_id <opaque>)))
+         ((new
+           ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
              ((function_params
                ((self
                  (Value
@@ -183,5 +465,30 @@ let%expect_test "Int(bits) serializator" =
                      ((integer ((field_type (Value (Type IntegerType)))))))
                     (struct_id <opaque>)))))
                 (builder (Value (Type (BuiltinType Builder))))))
-              (function_returns (Value (Type VoidType)))
-              (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
+              (function_returns (Value (Type VoidType)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))))
+        ((Struct
+          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+           (struct_id <opaque>)))
+         ((new
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
+            (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -55,6 +55,17 @@ let%expect_test "Int(bits) constructor" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))
         ((Struct
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
@@ -67,4 +78,110 @@ let%expect_test "Int(bits) constructor" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
+
+let%expect_test "Int(bits) serializator" =
+  let source =
+    {|
+      fn test(b: Builder) {
+        let i = Int(32).new(100);
+        i.serialize(b);
+      }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+      (Ok
+       ((stmts
+         ((Let
+           ((test
+             (Value
+              (Function
+               ((function_params ((b (Value (Type (BuiltinType Builder))))))
+                (function_returns Hole)
+                (function_impl
+                 (Fn
+                  (((Let
+                     ((i
+                       (Value
+                        (StructInstance
+                         (((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_id <opaque>))
+                          ((integer (Integer 100)))))))))
+                    (Expr
+                     (Asm
+                      (((StructField
+                         ((Value
+                           (StructInstance
+                            (((struct_fields
+                               ((integer ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>))
+                             ((integer (Integer 100))))))
+                          integer))
+                        (Reference (b (BuiltinType Builder))))
+                       ((PUSHINT 32) STIX))))))))))))))))
+        (bindings
+         ((test
+           (Value
+            (Function
+             ((function_params ((b (Value (Type (BuiltinType Builder))))))
+              (function_returns Hole)
+              (function_impl
+               (Fn
+                (((Let
+                   ((i
+                     (Value
+                      (StructInstance
+                       (((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_id <opaque>))
+                        ((integer (Integer 100)))))))))
+                  (Expr
+                   (Asm
+                    (((StructField
+                       ((Value
+                         (StructInstance
+                          (((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>))
+                           ((integer (Integer 100))))))
+                        integer))
+                      (Reference (b (BuiltinType Builder))))
+                     ((PUSHINT 32) STIX))))))))))))))
+        (methods
+         (((Struct
+            ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>)))
+           ((new
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))
+              (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -8,7 +8,7 @@ let incr_f =
       function_impl =
         BuiltinFn
           (builtin_fun (fun _p -> function
-             | Integer arg :: _ ->
+             | Value (Integer arg) :: _ ->
                  Value (Integer (Zint.succ arg))
              | _ ->
                  Value (Integer Zint.zero) ) ) }
@@ -47,6 +47,17 @@ let%expect_test "scope resolution" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "binding resolution" =
@@ -102,6 +113,17 @@ let%expect_test "binding resolution" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -121,6 +143,7 @@ let%expect_test "failed scope resolution" =
              ((function_params ((instructions (Value (Type StringType)))))
               (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -178,6 +201,17 @@ let%expect_test "scope resolution after let binding" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "basic struct definition" =
@@ -238,6 +272,17 @@ let%expect_test "basic struct definition" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "native function evaluation" =
@@ -315,6 +360,17 @@ let%expect_test "Tact function evaluation" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -416,6 +472,17 @@ let%expect_test "struct definition" =
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
                   (struct_id <opaque>)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "duplicate type field" =
@@ -478,6 +545,7 @@ let%expect_test "duplicate type field" =
              ((function_params ((instructions (Value (Type StringType)))))
               (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -512,6 +580,17 @@ let%expect_test "duplicate type field" =
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
                   (struct_id <opaque>)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>))))))))))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -590,6 +669,17 @@ let%expect_test "parametric struct instantiation" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))
         ((Struct
           ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
@@ -682,6 +772,17 @@ let%expect_test "scoping that `let` introduces in code" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))))))
      |}]
 
@@ -876,6 +977,17 @@ let%expect_test "reference in function bodies" =
                ((struct_fields
                  ((integer ((field_type (Value (Type IntegerType)))))))
                 (struct_id <opaque>)))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_params
+             ((self
+               (Value
+                (Struct
+                 ((struct_fields
+                   ((integer ((field_type (Value (Type IntegerType)))))))
+                  (struct_id <opaque>)))))
+              (builder (Value (Type (BuiltinType Builder))))))
+            (function_returns (Value (Type VoidType)))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -982,7 +1094,7 @@ let%expect_test "can't use asm in compile-time" =
   [%expect
     {|
     (Error
-     (((UninterpretableStatement (Expr (Asm (SWAP (XCHG0 2)))))
+     (((UninterpretableStatement (Expr (Asm (() (SWAP (XCHG0 2))))))
        ((stmts ((Expr (Value Void)) (Expr (Value Void))))
         (bindings
          ((asm
@@ -991,6 +1103,7 @@ let%expect_test "can't use asm in compile-time" =
              ((function_params ((instructions (Value (Type StringType)))))
               (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -1000,7 +1113,7 @@ let%expect_test "can't use asm in compile-time" =
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
           (Void (Value Void))))))
-      ((UninterpretableStatement (Expr (Asm (ADD))))
+      ((UninterpretableStatement (Expr (Asm (() (ADD)))))
        ((stmts ((Expr (Value Void)) (Expr (Value Void))))
         (bindings
          ((asm
@@ -1009,6 +1122,7 @@ let%expect_test "can't use asm in compile-time" =
              ((function_params ((instructions (Value (Type StringType)))))
               (function_returns (Value (Type VoidType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -1039,11 +1153,12 @@ let%expect_test "use of asm in a function" =
             (Function
              ((function_params ()) (function_returns Hole)
               (function_impl
-               (Fn (((Expr (Asm (SWAP (XCHG0 2)))) (Expr (Asm (ADD)))))))))))))))
+               (Fn
+                (((Expr (Asm (() (SWAP (XCHG0 2))))) (Expr (Asm (() (ADD))))))))))))))))
       (bindings
        ((f
          (Value
           (Function
            ((function_params ()) (function_returns Hole)
             (function_impl
-             (Fn (((Expr (Asm (SWAP (XCHG0 2)))) (Expr (Asm (ADD))))))))))))))) |}]
+             (Fn (((Expr (Asm (() (SWAP (XCHG0 2))))) (Expr (Asm (() (ADD)))))))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -3,8 +3,9 @@ open Tact.Lang_types
 
 let incr_f =
   Function
-    { function_params = [("value", Value (Type IntegerType))];
-      function_returns = Value (Type IntegerType);
+    { function_signature =
+        { function_params = [("value", Value (Type IntegerType))];
+          function_returns = Value (Type IntegerType) };
       function_impl =
         BuiltinFn
           (builtin_fun (fun _p -> function
@@ -40,24 +41,26 @@ let%expect_test "scope resolution" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "binding resolution" =
@@ -106,24 +109,26 @@ let%expect_test "binding resolution" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -140,19 +145,35 @@ let%expect_test "failed scope resolution" =
          ((asm
            (Value
             (Function
-             ((function_params ((instructions (Value (Type StringType)))))
-              (function_returns (Value (Type VoidType)))
+             ((function_signature
+               ((function_params ((instructions (Value (Type StringType)))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
             (Function
-             ((function_params ((bits (Value (Type IntegerType)))))
-              (function_returns (Value (Type TypeType)))
+             ((function_signature
+               ((function_params ((bits (Value (Type IntegerType)))))
+                (function_returns (Value (Type TypeType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
-          (Void (Value Void)))))))) |}]
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>))))))))))))) |}]
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
@@ -194,24 +215,26 @@ let%expect_test "scope resolution after let binding" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "basic struct definition" =
@@ -265,24 +288,26 @@ let%expect_test "basic struct definition" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "native function evaluation" =
@@ -314,6 +339,28 @@ let%expect_test "Tact function evaluation" =
          ((test
            (Value
             (Function
+             ((function_signature
+               ((function_params
+                 ((i
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))
+                (function_returns
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))
+              (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
+        (Let ((a (Value (Integer 1)))))))
+      (bindings
+       ((a (Value (Integer 1)))
+        (test
+         (Value
+          (Function
+           ((function_signature
              ((function_params
                ((i
                  (Value
@@ -326,51 +373,33 @@ let%expect_test "Tact function evaluation" =
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
-        (Let ((a (Value (Integer 1)))))))
-      (bindings
-       ((a (Value (Integer 1)))
-        (test
-         (Value
-          (Function
-           ((function_params
-             ((i
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
                   (struct_id <opaque>)))))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
             (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
       (methods
        (((Struct
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -391,7 +420,7 @@ let%expect_test "compile-time function evaluation within a function" =
          ((test
            (Value
             (Function
-             ((function_params ()) (function_returns Hole)
+             ((function_signature ((function_params ()) (function_returns Hole)))
               (function_impl
                (Fn
                 (((Let ((v (Value (Integer 4)))))
@@ -400,7 +429,7 @@ let%expect_test "compile-time function evaluation within a function" =
        ((test
          (Value
           (Function
-           ((function_params ()) (function_returns Hole)
+           ((function_signature ((function_params ()) (function_returns Hole)))
             (function_impl
              (Fn
               (((Let ((v (Value (Integer 4)))))
@@ -465,24 +494,26 @@ let%expect_test "struct definition" =
             ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>)))
            ((new
-             ((function_params ((integer (Value (Type IntegerType)))))
-              (function_returns
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_params
-               ((self
+             ((function_signature
+               ((function_params ((integer (Value (Type IntegerType)))))
+                (function_returns
                  (Value
                   (Struct
                    ((struct_fields
                      ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))
-                (builder (Value (Type (BuiltinType Builder))))))
-              (function_returns (Value (Type VoidType)))
+                    (struct_id <opaque>)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))
+                  (builder (Value (Type (BuiltinType Builder))))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "duplicate type field" =
@@ -542,19 +573,35 @@ let%expect_test "duplicate type field" =
           (asm
            (Value
             (Function
-             ((function_params ((instructions (Value (Type StringType)))))
-              (function_returns (Value (Type VoidType)))
+             ((function_signature
+               ((function_params ((instructions (Value (Type StringType)))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
             (Function
-             ((function_params ((bits (Value (Type IntegerType)))))
-              (function_returns (Value (Type TypeType)))
+             ((function_signature
+               ((function_params ((bits (Value (Type IntegerType)))))
+                (function_returns (Value (Type TypeType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
-          (Void (Value Void))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
          (((Struct
             ((struct_fields
@@ -573,24 +620,26 @@ let%expect_test "duplicate type field" =
               ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>)))
            ((new
-             ((function_params ((integer (Value (Type IntegerType)))))
-              (function_returns
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_params
-               ((self
+             ((function_signature
+               ((function_params ((integer (Value (Type IntegerType)))))
+                (function_returns
                  (Value
                   (Struct
                    ((struct_fields
                      ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))
-                (builder (Value (Type (BuiltinType Builder))))))
-              (function_returns (Value (Type VoidType)))
+                    (struct_id <opaque>)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))
+                  (builder (Value (Type (BuiltinType Builder))))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>))))))))))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -609,8 +658,9 @@ let%expect_test "parametric struct instantiation" =
          ((T
            (Value
             (Function
-             ((function_params ((A (Value (Type TypeType)))))
-              (function_returns (Value (Type TypeType)))
+             ((function_signature
+               ((function_params ((A (Value (Type TypeType)))))
+                (function_returns (Value (Type TypeType)))))
               (function_impl
                (Fn
                 (((Expr
@@ -648,8 +698,9 @@ let%expect_test "parametric struct instantiation" =
         (T
          (Value
           (Function
-           ((function_params ((A (Value (Type TypeType)))))
-            (function_returns (Value (Type TypeType)))
+           ((function_signature
+             ((function_params ((A (Value (Type TypeType)))))
+              (function_returns (Value (Type TypeType)))))
             (function_impl
              (Fn
               (((Expr
@@ -662,24 +713,26 @@ let%expect_test "parametric struct instantiation" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))
         ((Struct
           ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
@@ -700,7 +753,7 @@ let%expect_test "function without a return type" =
            ((f
              (Value
               (Function
-               ((function_params ()) (function_returns Hole)
+               ((function_signature ((function_params ()) (function_returns Hole)))
                 (function_impl (Fn (((Break (Expr (Value (Integer 1))))))))))))))
           (Let ((a (Value (Integer 1)))))))
         (bindings
@@ -708,7 +761,7 @@ let%expect_test "function without a return type" =
           (f
            (Value
             (Function
-             ((function_params ()) (function_returns Hole)
+             ((function_signature ((function_params ()) (function_returns Hole)))
               (function_impl (Fn (((Break (Expr (Value (Integer 1)))))))))))))))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
@@ -730,14 +783,15 @@ let%expect_test "scoping that `let` introduces in code" =
          ((f
            (Value
             (Function
-             ((function_params
-               ((i
-                 (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
-              (function_returns Hole)
+             ((function_signature
+               ((function_params
+                 ((i
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))
+                (function_returns Hole)))
               (function_impl
                (Fn
                 (((Let ((a (Reference (i TypeType)))))
@@ -748,14 +802,15 @@ let%expect_test "scoping that `let` introduces in code" =
         (f
          (Value
           (Function
-           ((function_params
-             ((i
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
-            (function_returns Hole)
+           ((function_signature
+             ((function_params
+               ((i
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))
+              (function_returns Hole)))
             (function_impl
              (Fn
               (((Let ((a (Reference (i TypeType)))))
@@ -765,24 +820,26 @@ let%expect_test "scoping that `let` introduces in code" =
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))))))))
      |}]
 
@@ -808,6 +865,156 @@ let%expect_test "reference in function bodies" =
          ((op
            (Value
             (Function
+             ((function_signature
+               ((function_params
+                 ((i
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))
+                  (i_
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))
+                (function_returns Hole)))
+              (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
+        (Let
+         ((f
+           (Value
+            (Function
+             ((function_signature
+               ((function_params
+                 ((x
+                   (Value
+                    (Struct
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))
+                (function_returns Hole)))
+              (function_impl
+               (Fn
+                (((Let
+                   ((a
+                     (FunctionCall
+                      ((Value
+                        (Function
+                         ((function_signature
+                           ((function_params
+                             ((i
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_id <opaque>)))))
+                              (i_
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_id <opaque>)))))))
+                            (function_returns Hole)))
+                          (function_impl
+                           (Fn (((Break (Expr (Reference (i TypeType)))))))))))
+                       ((Reference (x TypeType)) (Reference (x TypeType))))))))
+                  (Let
+                   ((b
+                     (FunctionCall
+                      ((Value
+                        (Function
+                         ((function_signature
+                           ((function_params
+                             ((i
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_id <opaque>)))))
+                              (i_
+                               (Value
+                                (Struct
+                                 ((struct_fields
+                                   ((integer
+                                     ((field_type (Value (Type IntegerType)))))))
+                                  (struct_id <opaque>)))))))
+                            (function_returns Hole)))
+                          (function_impl
+                           (Fn (((Break (Expr (Reference (i TypeType)))))))))))
+                       ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))))))
+      (bindings
+       ((f
+         (Value
+          (Function
+           ((function_signature
+             ((function_params
+               ((x
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))))
+              (function_returns Hole)))
+            (function_impl
+             (Fn
+              (((Let
+                 ((a
+                   (FunctionCall
+                    ((Value
+                      (Function
+                       ((function_signature
+                         ((function_params
+                           ((i
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_id <opaque>)))))
+                            (i_
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_id <opaque>)))))))
+                          (function_returns Hole)))
+                        (function_impl
+                         (Fn (((Break (Expr (Reference (i TypeType)))))))))))
+                     ((Reference (x TypeType)) (Reference (x TypeType))))))))
+                (Let
+                 ((b
+                   (FunctionCall
+                    ((Value
+                      (Function
+                       ((function_signature
+                         ((function_params
+                           ((i
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_id <opaque>)))))
+                            (i_
+                             (Value
+                              (Struct
+                               ((struct_fields
+                                 ((integer
+                                   ((field_type (Value (Type IntegerType)))))))
+                                (struct_id <opaque>)))))))
+                          (function_returns Hole)))
+                        (function_impl
+                         (Fn (((Break (Expr (Reference (i TypeType)))))))))))
+                     ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))
+        (op
+         (Value
+          (Function
+           ((function_signature
              ((function_params
                ((i
                  (Value
@@ -821,173 +1028,33 @@ let%expect_test "reference in function bodies" =
                    ((struct_fields
                      ((integer ((field_type (Value (Type IntegerType)))))))
                     (struct_id <opaque>)))))))
-              (function_returns Hole)
-              (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
-        (Let
-         ((f
-           (Value
-            (Function
-             ((function_params
-               ((x
-                 (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
-              (function_returns Hole)
-              (function_impl
-               (Fn
-                (((Let
-                   ((a
-                     (FunctionCall
-                      ((Value
-                        (Function
-                         ((function_params
-                           ((i
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))
-                            (i_
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))))
-                          (function_returns Hole)
-                          (function_impl
-                           (Fn (((Break (Expr (Reference (i TypeType)))))))))))
-                       ((Reference (x TypeType)) (Reference (x TypeType))))))))
-                  (Let
-                   ((b
-                     (FunctionCall
-                      ((Value
-                        (Function
-                         ((function_params
-                           ((i
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))
-                            (i_
-                             (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))))
-                          (function_returns Hole)
-                          (function_impl
-                           (Fn (((Break (Expr (Reference (i TypeType)))))))))))
-                       ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))))))
-      (bindings
-       ((f
-         (Value
-          (Function
-           ((function_params
-             ((x
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
-            (function_returns Hole)
-            (function_impl
-             (Fn
-              (((Let
-                 ((a
-                   (FunctionCall
-                    ((Value
-                      (Function
-                       ((function_params
-                         ((i
-                           (Value
-                            (Struct
-                             ((struct_fields
-                               ((integer
-                                 ((field_type (Value (Type IntegerType)))))))
-                              (struct_id <opaque>)))))
-                          (i_
-                           (Value
-                            (Struct
-                             ((struct_fields
-                               ((integer
-                                 ((field_type (Value (Type IntegerType)))))))
-                              (struct_id <opaque>)))))))
-                        (function_returns Hole)
-                        (function_impl
-                         (Fn (((Break (Expr (Reference (i TypeType)))))))))))
-                     ((Reference (x TypeType)) (Reference (x TypeType))))))))
-                (Let
-                 ((b
-                   (FunctionCall
-                    ((Value
-                      (Function
-                       ((function_params
-                         ((i
-                           (Value
-                            (Struct
-                             ((struct_fields
-                               ((integer
-                                 ((field_type (Value (Type IntegerType)))))))
-                              (struct_id <opaque>)))))
-                          (i_
-                           (Value
-                            (Struct
-                             ((struct_fields
-                               ((integer
-                                 ((field_type (Value (Type IntegerType)))))))
-                              (struct_id <opaque>)))))))
-                        (function_returns Hole)
-                        (function_impl
-                         (Fn (((Break (Expr (Reference (i TypeType)))))))))))
-                     ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))
-        (op
-         (Value
-          (Function
-           ((function_params
-             ((i
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (i_
-               (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
-            (function_returns Hole)
+              (function_returns Hole)))
             (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
       (methods
        (((Struct
           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
            (struct_id <opaque>)))
          ((new
-           ((function_params ((integer (Value (Type IntegerType)))))
-            (function_returns
-             (Value
-              (Struct
-               ((struct_fields
-                 ((integer ((field_type (Value (Type IntegerType)))))))
-                (struct_id <opaque>)))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_params
-             ((self
+           ((function_signature
+             ((function_params ((integer (Value (Type IntegerType)))))
+              (function_returns
                (Value
                 (Struct
                  ((struct_fields
                    ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))
-              (builder (Value (Type (BuiltinType Builder))))))
-            (function_returns (Value (Type VoidType)))
+                  (struct_id <opaque>)))))))
+            (function_impl (BuiltinFn (<fun> <opaque>)))))
+          (serialize
+           ((function_signature
+             ((function_params
+               ((self
+                 (Value
+                  (Struct
+                   ((struct_fields
+                     ((integer ((field_type (Value (Type IntegerType)))))))
+                    (struct_id <opaque>)))))
+                (builder (Value (Type (BuiltinType Builder))))))
+              (function_returns (Value (Type VoidType)))))
             (function_impl (BuiltinFn (<fun> <opaque>))))))))))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -1010,7 +1077,7 @@ let%expect_test "resolving a reference from inside a function" =
          ((f
            (Value
             (Function
-             ((function_params ()) (function_returns Hole)
+             ((function_signature ((function_params ()) (function_returns Hole)))
               (function_impl (Fn (((Break (Expr (Value (Integer 1))))))))))))))
         (Let ((x (Value (Integer 1)))))))
       (bindings
@@ -1018,7 +1085,7 @@ let%expect_test "resolving a reference from inside a function" =
         (f
          (Value
           (Function
-           ((function_params ()) (function_returns Hole)
+           ((function_signature ((function_params ()) (function_returns Hole)))
             (function_impl (Fn (((Break (Expr (Value (Integer 1))))))))))))
         (i (Value (Integer 1))))))) |}]
 
@@ -1053,9 +1120,10 @@ let%expect_test "method access" =
       (methods
        (((Struct ((struct_fields ()) (struct_id <opaque>)))
          ((bar
-           ((function_params
-             ((self (Value (Type TypeType))) (i (Value (Type IntegerType)))))
-            (function_returns Hole)
+           ((function_signature
+             ((function_params
+               ((self (Value (Type TypeType))) (i (Value (Type IntegerType)))))
+              (function_returns Hole)))
             (function_impl (Fn (((Break (Expr (Reference (i IntegerType)))))))))))))))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -1079,10 +1147,11 @@ let%expect_test "Self type resolution in methods" =
       (methods
        (((Struct ((struct_fields ()) (struct_id <opaque>)))
          ((bar
-           ((function_params
-             ((self (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
-            (function_returns
-             (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))
+           ((function_signature
+             ((function_params
+               ((self (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
+              (function_returns
+               (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
             (function_impl (Fn (((Break (Expr (Reference (self TypeType)))))))))))))))) |}]
 
 let%expect_test "can't use asm in compile-time" =
@@ -1100,38 +1169,70 @@ let%expect_test "can't use asm in compile-time" =
          ((asm
            (Value
             (Function
-             ((function_params ((instructions (Value (Type StringType)))))
-              (function_returns (Value (Type VoidType)))
+             ((function_signature
+               ((function_params ((instructions (Value (Type StringType)))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
             (Function
-             ((function_params ((bits (Value (Type IntegerType)))))
-              (function_returns (Value (Type TypeType)))
+             ((function_signature
+               ((function_params ((bits (Value (Type IntegerType)))))
+                (function_returns (Value (Type TypeType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
-          (Void (Value Void))))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))))
       ((UninterpretableStatement (Expr (Asm (() (ADD)))))
        ((stmts ((Expr (Value Void)) (Expr (Value Void))))
         (bindings
          ((asm
            (Value
             (Function
-             ((function_params ((instructions (Value (Type StringType)))))
-              (function_returns (Value (Type VoidType)))
+             ((function_signature
+               ((function_params ((instructions (Value (Type StringType)))))
+                (function_returns (Value (Type VoidType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
             (Function
-             ((function_params ((bits (Value (Type IntegerType)))))
-              (function_returns (Value (Type TypeType)))
+             ((function_signature
+               ((function_params ((bits (Value (Type IntegerType)))))
+                (function_returns (Value (Type TypeType)))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
-          (Void (Value Void)))))))) |}]
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>))))))))))))) |}]
 
 let%expect_test "use of asm in a function" =
   let source =
@@ -1151,7 +1252,7 @@ let%expect_test "use of asm in a function" =
          ((f
            (Value
             (Function
-             ((function_params ()) (function_returns Hole)
+             ((function_signature ((function_params ()) (function_returns Hole)))
               (function_impl
                (Fn
                 (((Expr (Asm (() (SWAP (XCHG0 2))))) (Expr (Asm (() (ADD))))))))))))))))
@@ -1159,6 +1260,6 @@ let%expect_test "use of asm in a function" =
        ((f
          (Value
           (Function
-           ((function_params ()) (function_returns Hole)
+           ((function_signature ((function_params ()) (function_returns Hole)))
             (function_impl
              (Fn (((Expr (Asm (() (SWAP (XCHG0 2))))) (Expr (Asm (() (ADD)))))))))))))))) |}]

--- a/test/lang_types.ml
+++ b/test/lang_types.ml
@@ -67,12 +67,12 @@ let%test "parameterized structure equality" =
 
 let%test "builtin function equality" =
   let f1 =
-    { function_params = [];
-      function_returns = Value (Type VoidType);
+    { function_signature =
+        {function_params = []; function_returns = Value (Type VoidType)};
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Value Void)) }
   and f2 =
-    { function_params = [];
-      function_returns = Value (Type VoidType);
+    { function_signature =
+        {function_params = []; function_returns = Value (Type VoidType)};
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Value Void)) }
   in
   Alcotest.(check bool)


### PR DESCRIPTION
Important additions:

* Built-in functions now take `expr` (in addition to returning `expr`)
  to be able to do processing of the runtime expressions
* Built-in function calls are always considered immediate as they can't
  be executed in runtime
* `StructField` expr to denote access to a struct field
* `Asm` expr gets a list of expressions, values of which should be
  pushed onto the stack


I've also developed a function called `serializer(T)` that takes a struct and returns a function that serializes the struct, as a proof of concept.