### PR TITLE
Add codegen

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -32,7 +32,8 @@
   builtin
   interpreter
   lang
-  func)
+  func
+  func_codegen)
  (name tact))
 
 (ocamllex asm_lexer)

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -24,13 +24,13 @@ and expr =
 and ident = string
 
 and type_ =
-  | Int
-  | Cell
-  | Slice
-  | Builder
-  | Tuple of type_ list
-  | Tensor of type_ list
-  | Cont
+  | IntType
+  | CellType
+  | SliceType
+  | BuilderType
+  | TupleType of type_ list
+  | TensorType of type_ list
+  | ContType
 
 and top_level_expr = Function of function_ | Global of type_ * ident
 
@@ -118,23 +118,23 @@ and pp_expr f = function
       pp_print_string f ")"
 
 and pp_type f = function
-  | Int ->
+  | IntType ->
       pp_print_string f "int"
-  | Cell ->
+  | CellType ->
       pp_print_string f "cell"
-  | Slice ->
+  | SliceType ->
       pp_print_string f "slice"
-  | Builder ->
+  | BuilderType ->
       pp_print_string f "builder"
-  | Cont ->
+  | ContType ->
       pp_print_string f "cont"
-  | Tuple tuple ->
+  | TupleType tuple ->
       pp_print_string f "[" ;
       list_iter tuple
         ~f:(fun (t : type_) -> pp_type f t ; pp_print_string f ", ")
         ~flast:(pp_type f) ;
       pp_print_string f "]"
-  | Tensor tuple ->
+  | TensorType tuple ->
       pp_print_string f "(" ;
       list_iter tuple
         ~f:(fun t -> pp_type f t ; pp_print_string f ", ")

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -19,6 +19,7 @@ and stmt = Vars of (type_ * ident * expr) list | Return of expr
 and expr =
   | Integer of Zint.t
   | Reference of (ident * type_)
+  | Tuple of expr list
   | FunctionCall of (ident * expr list)
 
 and ident = string
@@ -35,6 +36,18 @@ and type_ =
 and top_level_expr = Function of function_ | Global of type_ * ident
 
 and program = top_level_expr list [@@deriving sexp_of]
+
+exception UnknownType
+
+let rec type_of = function
+  | Integer _ ->
+      IntType
+  | Reference (_, ty) ->
+      ty
+  | Tuple exprs ->
+      TupleType (List.map exprs ~f:type_of)
+  | FunctionCall _ ->
+      raise UnknownType
 
 open Caml.Format
 
@@ -116,6 +129,8 @@ and pp_expr f = function
         ~f:(fun t -> pp_expr f t ; pp_print_string f ", ")
         ~flast:(pp_expr f) ;
       pp_print_string f ")"
+  | Tuple _ ->
+      ()
 
 and pp_type f = function
   | IntType ->

--- a/lib/func_codegen.ml
+++ b/lib/func_codegen.ml
@@ -109,8 +109,6 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method private lang_expr_to_type : T.expr -> F.type_ =
       function
-      | Value (Struct s) ->
-          self#struct_to_ty s
       | Value (Type t) ->
           self#lang_type_to_type t
       | ResolvedReference (_ref, expr) ->
@@ -119,7 +117,13 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
           raise Invalid
 
     method private lang_type_to_type : T.type_ -> F.type_ =
-      function IntegerType -> F.Int | _ -> raise Invalid
+      function
+      | IntegerType ->
+          F.Int
+      | StructType s ->
+          self#struct_to_ty s
+      | _ ->
+          raise Invalid
 
     method private struct_to_ty : T.struct_ -> F.type_ =
       fun s ->

--- a/lib/func_codegen.ml
+++ b/lib/func_codegen.ml
@@ -39,7 +39,7 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_Integer : _ -> Zint.t -> F.expr = fun _env i -> F.Integer i
 
-    method build_IntegerType _env = F.Int
+    method build_IntegerType _env = F.IntType
 
     method build_Invalid _env = raise Invalid
 
@@ -121,7 +121,7 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
     method private lang_type_to_type : T.type_ -> F.type_ =
       function
       | IntegerType ->
-          F.Int
+          F.IntType
       | StructType s ->
           self#struct_to_ty s
       | _ ->
@@ -146,5 +146,5 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
           List.map struct_fields ~f:(fun (_, {field_type}) ->
               self#lang_expr_to_type field_type )
         in
-        Tuple types
+        TupleType types
   end

--- a/lib/func_codegen.ml
+++ b/lib/func_codegen.ml
@@ -13,6 +13,8 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     val mutable struct_representations : (T.struct_ * F.type_) list = []
 
+    val mutable functions : (string * F.function_) list = []
+
     method build_Asm _env _asm = raise Unsupported
 
     method build_Break _env _e = raise Unsupported
@@ -51,7 +53,7 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_Let _env _bindings = raise Invalid
 
-    method build_Reference _env (_name, _t) = raise Invalid
+    method build_Reference _env (name, ty) = F.Reference (name, ty)
 
     method build_Return _env expr = F.Return expr
 
@@ -118,7 +120,14 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
       | _ ->
           raise Invalid
 
-    method build_ResolvedReference _env _sf = raise Invalid
+    method build_ResolvedReference _env (name, _) =
+      match
+        List.find functions ~f:(fun (fname, _) -> equal_string name fname)
+      with
+      | Some (_, fn) ->
+          F.Reference (name, fn.function_returns)
+      | None ->
+          raise Invalid
 
     method build_StoreInt _env builder length int_ is_signed =
       let name =

--- a/lib/func_codegen.ml
+++ b/lib/func_codegen.ml
@@ -39,7 +39,7 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_Integer : _ -> Zint.t -> F.expr = fun _env i -> F.Integer i
 
-    method build_IntegerType _env = raise Invalid
+    method build_IntegerType _env = F.Int
 
     method build_Invalid _env = raise Invalid
 
@@ -59,11 +59,9 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_StringType _env = raise Invalid
 
-    method build_Struct _env _s = raise Invalid
-
     method build_StructInstance _env _si = raise Unsupported
 
-    method build_StructType _env _t = raise Invalid
+    method build_StructType _env ty = ty
 
     method build_Type _env _t = raise Invalid (* typeof_type t *)
 
@@ -86,7 +84,7 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_struct_ _env _field _id = raise Invalid
 
-    method! visit_struct_ _env _s = ()
+    method! visit_struct_ _env s = self#struct_to_ty s
 
     method build_struct_field _env _sf = raise Invalid
 
@@ -94,15 +92,19 @@ class ['s] constructor ((_program, _errors) : T.program * _ errors) =
 
     method build_StructField _env _sf = raise Invalid
 
-    method build_StoreInt _env _sf = raise Invalid
+    method build_StoreInt _env builder length int_ is_signed =
+      let name =
+        match is_signed with true -> "store_int" | false -> "store_uint"
+      in
+      (name, [builder; int_; length])
 
     method build_ResolvedReference _env _sf = raise Invalid
 
-    method build_Primitive _env _sf = raise Invalid
+    method build_Primitive _env p = FunctionCall p
 
-    method build_EmptyBuilder _env _sf = raise Invalid
+    method build_EmptyBuilder _env = ("new_builder", [])
 
-    method build_BuildCell _env _sf = raise Invalid
+    method build_BuildCell _env builder_arg = ("build", [builder_arg])
 
     method! visit_program env p =
       self#visit_list self#visit_binding env p.bindings

--- a/lib/func_codegen.ml
+++ b/lib/func_codegen.ml
@@ -1,0 +1,144 @@
+open Base
+module T = Lang_types
+module F = Func
+include Errors
+
+exception Invalid
+
+exception Unsupported
+
+class ['s] constructor ((_program, _errors) : T.program * _ errors) =
+  object (self : 's)
+    inherit ['s] Lang_types.visitor as _super
+
+    val mutable struct_representations : (T.struct_ * F.type_) list = []
+
+    method build_Asm _env _asm = raise Unsupported
+
+    method build_Break _env _e = raise Unsupported
+
+    method build_Builtin _env _b = raise Invalid
+
+    method build_BuiltinFn _env _b = raise Invalid
+
+    method build_BuiltinType _env = raise Invalid
+
+    method build_Expr _env _expr = raise Invalid
+
+    method build_Fn _env _ = raise Invalid
+
+    method build_Function _env _f = raise Unsupported
+
+    method build_FunctionCall _env _fc = raise Invalid
+
+    method build_FunctionType _env _ft = raise Invalid
+
+    method build_Hole _env = raise Invalid
+
+    method build_HoleType _env = raise Invalid
+
+    method build_Integer : _ -> Zint.t -> F.expr = fun _env i -> F.Integer i
+
+    method build_IntegerType _env = raise Invalid
+
+    method build_Invalid _env = raise Invalid
+
+    method build_InvalidExpr _env = raise Invalid
+
+    method build_InvalidFn _env = raise Invalid
+
+    method build_InvalidType _env = raise Invalid
+
+    method build_Let _env _bindings = raise Invalid
+
+    method build_Reference _env (_name, _t) = raise Invalid
+
+    method build_Return _env expr = F.Return expr
+
+    method build_String : 's -> string -> F.expr = fun _env -> raise Invalid
+
+    method build_StringType _env = raise Invalid
+
+    method build_Struct _env _s = raise Invalid
+
+    method build_StructInstance _env _si = raise Unsupported
+
+    method build_StructType _env _t = raise Invalid
+
+    method build_Type _env _t = raise Invalid (* typeof_type t *)
+
+    method build_TypeType _env = raise Invalid
+
+    method build_Value _env _v = raise Invalid
+
+    method build_Void _env = raise Invalid
+
+    method build_VoidType _env = raise Invalid
+
+    method build_function_ _env _params returns impl =
+      F.Function
+        { function_name = "dummy";
+          function_args = [];
+          function_returns = returns;
+          function_body = impl }
+
+    method build_program _env _p = raise Invalid
+
+    method build_struct_ _env _field _id = raise Invalid
+
+    method! visit_struct_ _env _s = ()
+
+    method build_struct_field _env _sf = raise Invalid
+
+    method build_function_signature _env _sf = raise Invalid
+
+    method build_StructField _env _sf = raise Invalid
+
+    method build_StoreInt _env _sf = raise Invalid
+
+    method build_ResolvedReference _env _sf = raise Invalid
+
+    method build_Primitive _env _sf = raise Invalid
+
+    method build_EmptyBuilder _env _sf = raise Invalid
+
+    method build_BuildCell _env _sf = raise Invalid
+
+    method! visit_program env p =
+      self#visit_list self#visit_binding env p.bindings
+
+    method private lang_expr_to_type : T.expr -> F.type_ =
+      function
+      | Value (Struct s) ->
+          self#struct_to_ty s
+      | Value (Type t) ->
+          self#lang_type_to_type t
+      | ResolvedReference (_ref, expr) ->
+          self#lang_expr_to_type expr
+      | _ ->
+          raise Invalid
+
+    method private lang_type_to_type : T.type_ -> F.type_ =
+      function IntegerType -> F.Int | _ -> raise Invalid
+
+    method private struct_to_ty : T.struct_ -> F.type_ =
+      fun s ->
+        match
+          List.find struct_representations ~f:(fun (s', _) ->
+              Lang_types.equal_struct_ s s' )
+        with
+        | Some (_, ty) ->
+            ty
+        | None ->
+            let ty = self#create_ty_from_struct s in
+            struct_representations <- (s, ty) :: struct_representations ;
+            ty
+
+    method private create_ty_from_struct : T.struct_ -> F.type_ =
+      fun {struct_fields; _} ->
+        let types =
+          List.map struct_fields ~f:(fun (_, {field_type}) ->
+              self#lang_expr_to_type field_type )
+        in
+        Tuple types
+  end

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -91,12 +91,12 @@ class interpreter
     method interpret_value : value -> value =
       fun value ->
         match value with
-        | Struct {struct_fields; struct_id} ->
+        | Type (StructType {struct_fields; struct_id}) ->
             let struct_fields =
               List.map struct_fields ~f:(fun (name, {field_type}) ->
                   (name, {field_type = Value (self#interpret_expr field_type)}) )
             in
-            Struct {struct_fields; struct_id}
+            Type (StructType {struct_fields; struct_id})
         | value ->
             value
 

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -77,7 +77,7 @@ functor
               current_bindings <- amend_bindings (name, expr) current_bindings ;
               Let [(name, expr)]
           | false ->
-              let ty = expr_to_type expr in
+              let ty = type_of expr in
               runtime_bindings <- amend_bindings (name, ty) runtime_bindings ;
               Let [(name, expr)]
 
@@ -250,7 +250,7 @@ functor
           and function_returns =
             returns
             |> Option.map ~f:(fun x -> Syntax.value x)
-            |> Option.value ~default:Hole
+            |> Option.value ~default:(Value (Type HoleType))
           and function_impl = body in
           { function_signature = {function_params; function_returns};
             function_impl = Fn function_impl }

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -103,7 +103,7 @@ functor
 
         method build_Break _env stmt = Break stmt
 
-        method build_Struct _env s = Value (Struct s)
+        method build_Struct _env s = Value (Type (StructType s))
 
         method build_StructConstructor _env sc = Value (StructInstance sc)
 
@@ -150,12 +150,12 @@ functor
           in
           (* TODO: check method signatures *)
           match receiver with
-          | ResolvedReference (_, Value (Struct struct'))
-          | Value (Struct struct') -> (
-              let receiver' = Value (Struct struct') in
+          | ResolvedReference (_, Value (Type (StructType struct')))
+          | Value (Type (StructType struct')) -> (
+              let receiver' = Value (Type (StructType struct')) in
               let methods =
                 List.Assoc.find program.methods ~equal:equal_value
-                  (Struct struct')
+                  (Type (StructType struct'))
               in
               match
                 Option.bind methods ~f:(fun methods ->
@@ -169,10 +169,10 @@ functor
                   dummy )
           | ResolvedReference (_, Value (StructInstance (struct', _)))
           | Value (StructInstance (struct', _)) -> (
-              let receiver' = Value (Struct struct') in
+              let receiver' = Value (Type (StructType struct')) in
               let methods =
                 List.Assoc.find program.methods ~equal:equal_value
-                  (Struct struct')
+                  (Type (StructType struct'))
               in
               match
                 Option.bind methods ~f:(fun methods ->
@@ -266,8 +266,8 @@ functor
 
         method build_struct_constructor _env id _fields =
           match Syntax.value id with
-          | ResolvedReference (_, Value (Struct struct'))
-          | Value (Struct struct') ->
+          | ResolvedReference (_, Value (Type (StructType struct')))
+          | Value (Type (StructType struct')) ->
               (struct', []) (* TODO: handle fields *)
           | e ->
               errors#report `Error (`UnexpectedType e) () ;
@@ -299,7 +299,7 @@ functor
           let struct_ = s#build_struct_definition env _visitors_r0 []
           and current_bindings' = current_bindings in
           current_bindings <-
-            [("Self", Value (Struct struct_))] :: current_bindings' ;
+            [("Self", Value (Type (StructType struct_)))] :: current_bindings' ;
           let bindings =
             s#visit_list
               (s#visit_located s#visit_binding)
@@ -315,7 +315,8 @@ functor
                 | _ ->
                     None )
           in
-          program.methods <- (Struct struct_, struct_methods) :: program.methods ;
+          program.methods <-
+            (Type (StructType struct_), struct_methods) :: program.methods ;
           struct_
 
         method build_struct_field _env field_name field_type =

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -109,6 +109,23 @@ and primitive =
     visitors {variety = "fold"; name = "visitor"; ancestors = ["base_visitor"]}]
 
 let rec expr_to_type = function
+  | Value (Type type_) ->
+      type_
+  | FunctionCall
+      ( ResolvedReference
+          (_, Value (Function {function_signature = {function_returns; _}; _})),
+        _ )
+  | FunctionCall
+      (Value (Function {function_signature = {function_returns; _}; _}), _) ->
+      expr_to_type function_returns
+  | Reference (_, t) ->
+      t
+  | ResolvedReference (_, e) ->
+      expr_to_type e
+  | _other ->
+      InvalidType
+
+let rec type_of = function
   | Value (StructInstance (struct_, _)) ->
       StructType struct_
   | Value (Function {function_signature; _}) ->
@@ -119,8 +136,8 @@ let rec expr_to_type = function
       IntegerType
   | Value Void ->
       VoidType
-  | Value (Type type_) ->
-      type_
+  | Value (Type _) ->
+      TypeType
   | Hole ->
       HoleType
   | FunctionCall
@@ -133,7 +150,7 @@ let rec expr_to_type = function
   | Reference (_, t) ->
       t
   | ResolvedReference (_, e) ->
-      expr_to_type e
+      type_of e
   | _other ->
       InvalidType
 

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -46,7 +46,6 @@ and expr =
 
 and value =
   | Void
-  | Struct of struct_
   (* Instance of a Struct *)
   | StructInstance of (struct_ * (string * value) list)
   | Function of function_
@@ -110,8 +109,6 @@ and primitive =
     visitors {variety = "fold"; name = "visitor"; ancestors = ["base_visitor"]}]
 
 let rec expr_to_type = function
-  | Value (Struct _) ->
-      TypeType
   | Value (StructInstance (struct_, _)) ->
       StructType struct_
   | Value (Function {function_signature; _}) ->

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -133,7 +133,7 @@ let%expect_test "Int(bits) serializer" =
             (Function
              ((function_signature
                ((function_params ((b (Value (Type (BuiltinType Builder))))))
-                (function_returns Hole)))
+                (function_returns (Value (Type HoleType)))))
               (function_impl
                (Fn
                 (((Let
@@ -217,7 +217,8 @@ let%expect_test "demo struct serializer" =
        ((test
          (Value
           (Function
-           ((function_signature ((function_params ()) (function_returns Hole)))
+           ((function_signature
+             ((function_params ()) (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn
               (((Let

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -27,18 +27,20 @@ let%expect_test "Int(bits) constructor" =
              (struct_id <opaque>))
             ((integer (Integer 100)))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -68,18 +70,20 @@ let%expect_test "Int(bits) constructor" =
                           (struct_id <opaque>)))))
                       integer)))
                    (signed true))))))))))))
-        ((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+        ((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -146,18 +150,20 @@ let%expect_test "Int(bits) serializer" =
                      ((ResolvedReference (i <opaque>))
                       (Reference (b (BuiltinType Builder)))))))))))))))))
         (methods
-         (((Struct
-            ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-             (struct_id <opaque>)))
+         (((Type
+            (StructType
+             ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_id <opaque>))))
            ((new
              ((function_signature
                ((function_params ((integer (Value (Type IntegerType)))))
                 (function_returns
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
@@ -228,19 +234,21 @@ let%expect_test "demo struct serializer" =
                          ((a
                            ((field_type
                              (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))))
+                              (Type
+                               (StructType
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_id <opaque>))))))))
                           (b
                            ((field_type
                              (Value
-                              (Struct
-                               ((struct_fields
-                                 ((integer
-                                   ((field_type (Value (Type IntegerType)))))))
-                                (struct_id <opaque>)))))))))
+                              (Type
+                               (StructType
+                                ((struct_fields
+                                  ((integer
+                                    ((field_type (Value (Type IntegerType)))))))
+                                 (struct_id <opaque>))))))))))
                         (struct_id <opaque>))
                        ())))
                     (Reference (b (BuiltinType Builder)))))))))))))))
@@ -333,54 +341,62 @@ let%expect_test "demo struct serializer" =
                 (Return (Reference (builder (BuiltinType Builder))))))))))))
         (T
          (Value
-          (Struct
+          (Type
+           (StructType
+            ((struct_fields
+              ((a
+                ((field_type
+                  (Value
+                   (Type
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>))))))))
+               (b
+                ((field_type
+                  (Value
+                   (Type
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>))))))))))
+             (struct_id <opaque>))))))))
+      (methods
+       (((Type
+          (StructType
            ((struct_fields
              ((a
                ((field_type
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (b
                ((field_type
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))))
-            (struct_id <opaque>)))))))
-      (methods
-       (((Struct
-          ((struct_fields
-            ((a
-              ((field_type
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_id <opaque>)))))))
-             (b
-              ((field_type
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_id <opaque>)))))))))
-           (struct_id <opaque>)))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))))
+            (struct_id <opaque>))))
          ())
-        ((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+        ((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -410,18 +426,20 @@ let%expect_test "demo struct serializer" =
                           (struct_id <opaque>)))))
                       integer)))
                    (signed true))))))))))))
-        ((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+        ((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature

--- a/test/dune
+++ b/test/dune
@@ -11,7 +11,7 @@
   (staged_pps ppx_matches ppx_expect ppx_sexp_conv))
  (name tact_tests)
  (inline_tests)
- (modules syntax lang builtin)
+ (modules syntax func_codegen lang builtin)
  (libraries tact core sexplib shared))
 
 (library

--- a/test/func_codegen.ml
+++ b/test/func_codegen.ml
@@ -1,0 +1,60 @@
+module Syntax = Tact.Syntax.Make (Tact.Located.Disabled)
+module Parser = Tact.Parser.Make (Syntax)
+module Lang = Tact.Lang.Make (Syntax)
+module Interpreter = Tact.Interpreter
+module Errors = Tact.Errors
+module Zint = Tact.Zint
+module Codegen = Tact.Func_codegen
+module Func = Tact.Func
+include Core
+
+type error = [Lang.error | Interpreter.error] * Lang.program
+[@@deriving sexp_of]
+
+let make_errors () = new Errors.errors
+
+let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
+
+let build_program ?(errors = make_errors ()) ?(bindings = Lang.default_bindings)
+    ?(methods = Lang.default_methods) ?(strip_defaults = true) p =
+  let c = new Lang.constructor bindings methods errors in
+  let p' = c#visit_program () p in
+  errors#to_result {p' with stmts = []}
+  (* remove default bindings and methods *)
+  |> Result.map ~f:(fun (program : Lang.program) ->
+         if strip_defaults then
+           { program with
+             bindings =
+               List.filter program.bindings ~f:(fun binding ->
+                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
+             methods =
+               List.filter program.methods ~f:(fun (rcvr, rmethods) ->
+                   not
+                   @@ List.exists methods ~f:(fun (rcvr', rmethods') ->
+                          Lang.equal_value rcvr' rcvr
+                          && List.equal
+                               (fun (name, value) (name', value') ->
+                                 String.equal name' name
+                                 && Lang.equal_function_ value' value )
+                               rmethods' rmethods ) ) }
+         else program )
+  |> Result.map_error ~f:(fun errors ->
+         List.map errors ~f:(fun (_, err, _) -> (err, p')) )
+
+exception Exn of error list
+
+let pp ?(bindings = Lang.default_bindings) s =
+  parse_program s |> build_program ~bindings
+  |> Result.map_error ~f:(fun err -> Exn err)
+  |> Result.ok_exn |> Codegen.codegen
+  |> Func.pp_program Caml.Format.std_formatter
+
+let%expect_test "simple function generation" =
+  let source = {|
+      fn test() -> Integer { return 0; }
+    |} in
+  pp source ; [%expect {|
+    int test() {
+    return
+    0;
+    } |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -25,22 +25,26 @@ let%expect_test "scope resolution" =
      ((bindings
        ((T
          (Value
-          (Struct
-           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-            (struct_id <opaque>)))))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -88,27 +92,33 @@ let%expect_test "binding resolution" =
        ((a_ (Value (Integer 1))) (a (Value (Integer 1)))
         (T_
          (Value
-          (Struct
-           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-            (struct_id <opaque>)))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>))))))
         (T
          (Value
-          (Struct
-           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-            (struct_id <opaque>)))))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -195,27 +205,33 @@ let%expect_test "scope resolution after let binding" =
      ((bindings
        ((B
          (Value
-          (Struct
-           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-            (struct_id <opaque>)))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>))))))
         (A
          (Value
-          (Struct
-           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-            (struct_id <opaque>)))))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -257,40 +273,46 @@ let%expect_test "basic struct definition" =
      ((bindings
        ((T
          (Value
-          (Struct
+          (Type
+           (StructType
+            ((struct_fields
+              ((t
+                ((field_type
+                  (Value
+                   (Type
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>))))))))))
+             (struct_id <opaque>))))))))
+      (methods
+       (((Type
+          (StructType
            ((struct_fields
              ((t
                ((field_type
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))))
-            (struct_id <opaque>)))))))
-      (methods
-       (((Struct
-          ((struct_fields
-            ((t
-              ((field_type
-                (Value
-                 (Struct
-                  ((struct_fields
-                    ((integer ((field_type (Value (Type IntegerType)))))))
-                   (struct_id <opaque>)))))))))
-           (struct_id <opaque>)))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))))
+            (struct_id <opaque>))))
          ())
-        ((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+        ((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -351,30 +373,43 @@ let%expect_test "Tact function evaluation" =
              ((function_params
                ((i
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
-            (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
+            (function_impl
+             (Fn
+              (((Break
+                 (Expr
+                  (Reference
+                   (i
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))))))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -444,42 +479,48 @@ let%expect_test "struct definition" =
        ((bindings
          ((MyType
            (Value
-            (Struct
+            (Type
+             (StructType
+              ((struct_fields
+                ((a
+                  ((field_type
+                    (Value
+                     (Type
+                      (StructType
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_id <opaque>))))))))
+                 (b ((field_type (Value (Builtin Bool)))))))
+               (struct_id <opaque>))))))))
+        (methods
+         (((Type
+            (StructType
              ((struct_fields
                ((a
                  ((field_type
                    (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_id <opaque>)))))))
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))))
                 (b ((field_type (Value (Builtin Bool)))))))
-              (struct_id <opaque>)))))))
-        (methods
-         (((Struct
-            ((struct_fields
-              ((a
-                ((field_type
-                  (Value
-                   (Struct
-                    ((struct_fields
-                      ((integer ((field_type (Value (Type IntegerType)))))))
-                     (struct_id <opaque>)))))))
-               (b ((field_type (Value (Builtin Bool)))))))
-             (struct_id <opaque>)))
+              (struct_id <opaque>))))
            ())
-          ((Struct
-            ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-             (struct_id <opaque>)))
+          ((Type
+            (StructType
+             ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_id <opaque>))))
            ((new
              ((function_signature
                ((function_params ((integer (Value (Type IntegerType)))))
                 (function_returns
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
@@ -529,41 +570,46 @@ let%expect_test "duplicate type field" =
            ((a
              ((field_type
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (a ((field_type (Value (Builtin Bool)))))))
           (struct_id <opaque>))))
        ((stmts
          ((Let
            ((MyType
              (Value
-              (Struct
-               ((struct_fields
-                 ((a
-                   ((field_type
-                     (Value
-                      (Struct
-                       ((struct_fields
-                         ((integer ((field_type (Value (Type IntegerType)))))))
-                        (struct_id <opaque>)))))))
-                  (a ((field_type (Value (Builtin Bool)))))))
-                (struct_id <opaque>)))))))))
+              (Type
+               (StructType
+                ((struct_fields
+                  ((a
+                    ((field_type
+                      (Value
+                       (Type
+                        (StructType
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_id <opaque>))))))))
+                   (a ((field_type (Value (Builtin Bool)))))))
+                 (struct_id <opaque>))))))))))
         (bindings
          ((MyType
            (Value
-            (Struct
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (Value
-                    (Struct
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_id <opaque>)))))))
-                (a ((field_type (Value (Builtin Bool)))))))
-              (struct_id <opaque>)))))
+            (Type
+             (StructType
+              ((struct_fields
+                ((a
+                  ((field_type
+                    (Value
+                     (Type
+                      (StructType
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_id <opaque>))))))))
+                 (a ((field_type (Value (Builtin Bool)))))))
+               (struct_id <opaque>))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
@@ -590,31 +636,35 @@ let%expect_test "duplicate type field" =
                      (function_returns (Value (Type VoidType))))))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
-         (((Struct
-            ((struct_fields
-              ((a
-                ((field_type
-                  (Value
-                   (Struct
-                    ((struct_fields
-                      ((integer ((field_type (Value (Type IntegerType)))))))
-                     (struct_id <opaque>)))))))
-               (a ((field_type (Value (Builtin Bool)))))))
-             (struct_id <opaque>)))
+         (((Type
+            (StructType
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (Value
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))))
+                (a ((field_type (Value (Builtin Bool)))))))
+              (struct_id <opaque>))))
            ())
-          ((Struct
-            ((struct_fields
-              ((integer ((field_type (Value (Type IntegerType)))))))
-             (struct_id <opaque>)))
+          ((Type
+            (StructType
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_id <opaque>))))
            ((new
              ((function_signature
                ((function_params ((integer (Value (Type IntegerType)))))
                 (function_returns
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
@@ -666,16 +716,18 @@ let%expect_test "parametric struct instantiation" =
      ((bindings
        ((TA
          (Value
-          (Struct
-           ((struct_fields
-             ((a
-               ((field_type
-                 (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))))
-            (struct_id <opaque>)))))
+          (Type
+           (StructType
+            ((struct_fields
+              ((a
+                ((field_type
+                  (Value
+                   (Type
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>))))))))))
+             (struct_id <opaque>))))))
         (T
          (Value
           (Function
@@ -686,22 +738,26 @@ let%expect_test "parametric struct instantiation" =
              (Fn
               (((Expr
                  (Value
-                  (Struct
-                   ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
-                    (struct_id <opaque>)))))))))))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((a ((field_type (Reference (A TypeType)))))))
+                     (struct_id <opaque>))))))))))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -731,9 +787,10 @@ let%expect_test "parametric struct instantiation" =
                           (struct_id <opaque>)))))
                       integer)))
                    (signed true))))))))))))
-        ((Struct
-          ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
-           (struct_id <opaque>)))
+        ((Type
+          (StructType
+           ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
+            (struct_id <opaque>))))
          ()))))) |}]
 
 let%expect_test "function without a return type" =
@@ -776,28 +833,45 @@ let%expect_test "scoping that `let` introduces in code" =
              ((function_params
                ((i
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_returns Hole)))
             (function_impl
              (Fn
-              (((Let ((a (Reference (i TypeType)))))
-                (Break (Expr (Reference (a TypeType))))))))))))))
+              (((Let
+                 ((a
+                   (Reference
+                    (i
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))))
+                (Break
+                 (Expr
+                  (Reference
+                   (a
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))))))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -854,10 +928,11 @@ let%expect_test "reference in function bodies" =
              ((function_params
                ((x
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_returns Hole)))
             (function_impl
              (Fn
@@ -865,7 +940,18 @@ let%expect_test "reference in function bodies" =
                  ((a
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
-                     ((Reference (x TypeType)) (Reference (x TypeType))))))))
+                     ((Reference
+                       (x
+                        (StructType
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_id <opaque>)))))
+                      (Reference
+                       (x
+                        (StructType
+                         ((struct_fields
+                           ((integer ((field_type (Value (Type IntegerType)))))))
+                          (struct_id <opaque>)))))))))))
                 (Let
                  ((b
                    (FunctionCall
@@ -878,31 +964,44 @@ let%expect_test "reference in function bodies" =
              ((function_params
                ((i
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))
                 (i_
                  (Value
-                  (Struct
-                   ((struct_fields
-                     ((integer ((field_type (Value (Type IntegerType)))))))
-                    (struct_id <opaque>)))))))
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
               (function_returns Hole)))
-            (function_impl (Fn (((Break (Expr (Reference (i TypeType))))))))))))))
+            (function_impl
+             (Fn
+              (((Break
+                 (Expr
+                  (Reference
+                   (i
+                    (StructType
+                     ((struct_fields
+                       ((integer ((field_type (Value (Type IntegerType)))))))
+                      (struct_id <opaque>)))))))))))))))))
       (methods
-       (((Struct
-          ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
-           (struct_id <opaque>)))
+       (((Type
+          (StructType
+           ((struct_fields ((integer ((field_type (Value (Type IntegerType)))))))
+            (struct_id <opaque>))))
          ((new
            ((function_signature
              ((function_params ((integer (Value (Type IntegerType)))))
               (function_returns
                (Value
-                (Struct
-                 ((struct_fields
-                   ((integer ((field_type (Value (Type IntegerType)))))))
-                  (struct_id <opaque>)))))))
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl (BuiltinFn (<fun> <opaque>)))))
           (serialize
            ((function_signature
@@ -977,9 +1076,10 @@ let%expect_test "method access" =
        ((res (Value (Integer 1)))
         (foo
          (Value (StructInstance (((struct_fields ()) (struct_id <opaque>)) ()))))
-        (Foo (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
+        (Foo
+         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
       (methods
-       (((Struct ((struct_fields ()) (struct_id <opaque>)))
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
          ((bar
            ((function_signature
              ((function_params
@@ -1002,13 +1102,22 @@ let%expect_test "Self type resolution in methods" =
     {|
     (Ok
      ((bindings
-       ((Foo (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
+       ((Foo
+         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
       (methods
-       (((Struct ((struct_fields ()) (struct_id <opaque>)))
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
          ((bar
            ((function_signature
              ((function_params
-               ((self (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
+               ((self
+                 (Value
+                  (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
               (function_returns
-               (Value (Struct ((struct_fields ()) (struct_id <opaque>)))))))
-            (function_impl (Fn (((Break (Expr (Reference (self TypeType)))))))))))))))) |}]
+               (Value
+                (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
+            (function_impl
+             (Fn
+              (((Break
+                 (Expr
+                  (Reference
+                   (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -457,7 +457,8 @@ let%expect_test "compile-time function evaluation within a function" =
        ((test
          (Value
           (Function
-           ((function_signature ((function_params ()) (function_returns Hole)))
+           ((function_signature
+             ((function_params ()) (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn
               (((Let ((v (Value (Integer 4)))))
@@ -807,7 +808,8 @@ let%expect_test "function without a return type" =
           (f
            (Value
             (Function
-             ((function_signature ((function_params ()) (function_returns Hole)))
+             ((function_signature
+               ((function_params ()) (function_returns (Value (Type HoleType)))))
               (function_impl (Fn (((Break (Expr (Value (Integer 1)))))))))))))))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
@@ -838,7 +840,7 @@ let%expect_test "scoping that `let` introduces in code" =
                     ((struct_fields
                       ((integer ((field_type (Value (Type IntegerType)))))))
                      (struct_id <opaque>))))))))
-              (function_returns Hole)))
+              (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn
               (((Let
@@ -933,7 +935,7 @@ let%expect_test "reference in function bodies" =
                     ((struct_fields
                       ((integer ((field_type (Value (Type IntegerType)))))))
                      (struct_id <opaque>))))))))
-              (function_returns Hole)))
+              (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn
               (((Let
@@ -976,7 +978,7 @@ let%expect_test "reference in function bodies" =
                     ((struct_fields
                       ((integer ((field_type (Value (Type IntegerType)))))))
                      (struct_id <opaque>))))))))
-              (function_returns Hole)))
+              (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn
               (((Break
@@ -1051,7 +1053,8 @@ let%expect_test "resolving a reference from inside a function" =
         (f
          (Value
           (Function
-           ((function_signature ((function_params ()) (function_returns Hole)))
+           ((function_signature
+             ((function_params ()) (function_returns (Value (Type HoleType)))))
             (function_impl
              (Fn (((Break (Expr (ResolvedReference (i <opaque>))))))))))))
         (i (Value (Integer 1))))))) |}]
@@ -1084,7 +1087,7 @@ let%expect_test "method access" =
            ((function_signature
              ((function_params
                ((self (Value (Type TypeType))) (i (Value (Type IntegerType)))))
-              (function_returns Hole)))
+              (function_returns (Value (Type HoleType)))))
             (function_impl (Fn (((Break (Expr (Reference (i IntegerType)))))))))))))))) |}]
 
 let%expect_test "Self type resolution in methods" =


### PR DESCRIPTION
Add codegen that simply converts `Lang_types.program` -> `Func.program` without hardcoding implementation details into codegenerator.