### PR TITLE
Showcase generating crc32 compile-time

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -26,6 +26,7 @@
    (menhirSdk (= 20220210))
    (zarith (>= 1.12))
    (base (>= 0.15.0))
+   (checkseum (>= 0.3.3))
    (ppx_jane (>= 0.15.0))
    (visitors (= 20210608))
    (core (and :with-test (>= 0.15.0)))

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -144,6 +144,26 @@ let serializer =
        { function_signature;
          function_impl = BuiltinFn (builtin_fun function_impl) } )
 
+let crc32 =
+  let function_signature =
+    { function_params = [("string", Value (Type StringType))];
+      function_returns = Value (Type IntegerType) }
+  and function_impl _p = function
+    | [String s] ->
+        Integer
+          Checkseum.Crc32.(
+            digest_string s 0 (String.length s) default
+            |> Optint.to_int |> Zint.of_int)
+    | other :: _ ->
+        other
+    | [] ->
+        Void
+  in
+  Value
+    (Function
+       { function_signature;
+         function_impl = BuiltinFn (builtin_fun function_impl) } )
+
 let default_bindings =
   [ ("Builder", builder);
     ("Integer", Value (Type IntegerType));
@@ -151,6 +171,7 @@ let default_bindings =
     ("Bool", Value (Builtin "Bool"));
     ("Type", Value (Type TypeType));
     ("Void", Value Void);
+    ("crc32", crc32);
     (* TODO: re-design the serialization API surface; this is more for demonstration
      * purposes
      *)

--- a/lib/dune
+++ b/lib/dune
@@ -6,7 +6,8 @@
   zarith
   visitors.runtime
   ppx_sexp_conv
-  sexplib)
+  sexplib
+  checkseum)
  (preprocess
   (pps
    ppx_show

--- a/tact.opam
+++ b/tact.opam
@@ -21,6 +21,7 @@ depends: [
   "menhirSdk" {= "20220210"}
   "zarith" {>= "1.12"}
   "base" {>= "0.15.0"}
+  "checkseum" {>= "0.3.3"}
   "ppx_jane" {>= "0.15.0"}
   "visitors" {= "20210608"}
   "core" {with-test & >= "0.15.0"}

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -470,3 +470,10 @@ let%expect_test "demo struct serializer" =
                           (struct_id <opaque>)))))
                       integer)))
                    (signed true)))))))))))))))) |}]
+
+let%expect_test "compile-time crc32" =
+  let source = {|
+      let i = crc32("transfer(slice, int)"); 
+    |} in
+  pp source ;
+  [%expect {| (Ok ((bindings ((i (Value (Integer 2235694568))))))) |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -59,15 +59,18 @@ let%expect_test "simple function generation" =
     } |}]
 
 let%expect_test "passing struct to function" =
-  let source = {|
+  let source =
+    {|
       struct T { 
        val a: Int(32)
        val b: Integer
        val c: struct { val d : Integer }
       }
       fn test(t: T) -> Integer { return 1; }
-    |} in
-  pp source ; [%expect {|
+    |}
+  in
+  pp source ;
+  [%expect {|
     int test([[int], int, [int]] t) {
       return 1;
     } |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -171,6 +171,13 @@ let%expect_test "failed scope resolution" =
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
           (Void (Value Void))
+          (crc32
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((string (Value (Type StringType)))))
+                (function_returns (Value (Type IntegerType)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (serializer
            (Value
             (Function
@@ -622,6 +629,13 @@ let%expect_test "duplicate type field" =
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
           (Void (Value Void))
+          (crc32
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((string (Value (Type StringType)))))
+                (function_returns (Value (Type IntegerType)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (serializer
            (Value
             (Function


### PR DESCRIPTION
This is instead of postfix-denoted literals in FunC.