### PR TITLE
Implement function calls and other exprs codegen into FunC

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -118,8 +118,9 @@ let serializer =
                      [ ( "builder",
                          FunctionCall
                            ( Value (Function method_),
-                             StructField (Reference ("self", HoleType), name)
-                             :: [builder] ) ) ] )
+                             StructField (Reference ("self", StructType s), name)
+                             :: [Reference ("builder", BuiltinType "Builder")]
+                           ) ) ] )
         | _ ->
             None )
     in
@@ -129,8 +130,8 @@ let serializer =
     Function
       { function_signature =
           { function_params =
-              [("self", Value (Type HoleType)); ("builder", builder)];
-            function_returns = Value (Type VoidType) };
+              [("self", Value (Type (StructType s))); ("builder", builder)];
+            function_returns = builder };
         function_impl = Fn (Some body) }
   in
   let function_impl p = function

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -86,7 +86,8 @@ class constructor =
 
     method cg_program : T.program -> F.program =
       fun program ->
-        List.filter_map program.bindings ~f:(fun (name, top_level_stmt) ->
+        List.filter_map (List.rev program.bindings)
+          ~f:(fun (name, top_level_stmt) ->
             self#cg_top_level_stmt name top_level_stmt )
 
     method cg_StructField (from_expr, field) =

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -97,9 +97,12 @@ class constructor =
 
     method cg_program : T.program -> F.program =
       fun program ->
-        List.filter_map (List.rev program.bindings)
-          ~f:(fun (name, top_level_stmt) ->
-            self#cg_top_level_stmt name top_level_stmt )
+        let _ =
+          List.filter_map (List.rev program.bindings)
+            ~f:(fun (name, top_level_stmt) ->
+              self#cg_top_level_stmt name top_level_stmt )
+        in
+        List.map (List.rev functions) ~f:(fun (_, f) -> F.Function f)
 
     method cg_StructField (from_expr, field) =
       let build_access struct_ty field =

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -20,7 +20,7 @@ and expr =
   | Integer of Zint.t
   | Reference of (ident * type_)
   | Tuple of expr list
-  | FunctionCall of (ident * expr list)
+  | FunctionCall of (ident * expr list * type_)
 
 and ident = string
 
@@ -48,8 +48,8 @@ let rec type_of = function
       ty
   | Tuple exprs ->
       TupleType (List.map exprs ~f:type_of)
-  | FunctionCall _ ->
-      raise UnknownType
+  | FunctionCall (_, _, ty) ->
+      ty
 
 open Caml.Format
 
@@ -131,7 +131,7 @@ and pp_expr f = function
       pp_print_string f (Zint.to_string i)
   | Reference (ref, _) ->
       pp_print_string f ref
-  | FunctionCall (name, args) ->
+  | FunctionCall (name, args, _) ->
       pp_print_string f name ;
       pp_print_string f "(" ;
       list_iter args

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -92,16 +92,17 @@ and pp_function f fn =
   pp_print_space f () ;
   pp_print_string f "{" ;
   pp_print_newline f () ;
-  pp_print_string f indentation ;
-  pp_open_box f 4 ;
-  pp_function_body f fn.function_body ;
-  pp_close_box f () ;
+  pp_function_body f indentation fn.function_body ;
   pp_print_string f "}" ;
   pp_close_box f ()
 
-and pp_function_body f = function
+and pp_function_body f indentation = function
   | Fn stmts ->
-      List.iter stmts ~f:(pp_stmt f)
+      List.iter stmts ~f:(fun stmt ->
+          pp_print_string f indentation ;
+          pp_open_hovbox f 2 ;
+          pp_stmt f stmt ;
+          pp_close_box f () )
   | _ ->
       raise Unsupported
 

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -31,6 +31,7 @@ and type_ =
   | BuilderType
   | TupleType of type_ list
   | TensorType of type_ list
+  | FunctionType of function_
   | ContType
 
 and top_level_expr = Function of function_ | Global of type_ * ident
@@ -160,5 +161,7 @@ and pp_type f = function
         ~f:(fun t -> pp_type f t ; pp_print_string f ", ")
         ~flast:(pp_type f) ;
       pp_print_string f ")"
+  | FunctionType _ ->
+      raise UnknownType
 
 and pp_ident f i = pp_print_string f i

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -14,7 +14,7 @@ and function_body =
   | AsmFn of Asm.instr list [@sexp.list]
   | Fn of stmt list [@sexp.list]
 
-and stmt = Vars of (type_ * ident * expr) list | Return of expr
+and stmt = Vars of (type_ * ident * expr) list | Return of expr | Expr of expr
 
 and expr =
   | Integer of Zint.t
@@ -33,6 +33,7 @@ and type_ =
   | TensorType of type_ list
   | FunctionType of function_
   | ContType
+  | InferType
 
 and top_level_expr = Function of function_ | Global of type_ * ident
 
@@ -122,6 +123,8 @@ and pp_stmt f = function
       pp_expr f expr ;
       pp_print_string f ";" ;
       pp_print_newline f ()
+  | Expr expr ->
+      pp_expr f expr ; pp_print_string f ";" ; pp_print_newline f ()
 
 and pp_expr f = function
   | Integer i ->
@@ -135,8 +138,12 @@ and pp_expr f = function
         ~f:(fun t -> pp_expr f t ; pp_print_string f ", ")
         ~flast:(pp_expr f) ;
       pp_print_string f ")"
-  | Tuple _ ->
-      ()
+  | Tuple tuple ->
+      pp_print_string f "[" ;
+      list_iter tuple
+        ~f:(fun t -> pp_expr f t ; pp_print_string f ", ")
+        ~flast:(pp_expr f) ;
+      pp_print_string f "]"
 
 and pp_type f = function
   | IntType ->
@@ -161,6 +168,8 @@ and pp_type f = function
         ~f:(fun t -> pp_type f t ; pp_print_string f ", ")
         ~flast:(pp_type f) ;
       pp_print_string f ")"
+  | InferType ->
+      pp_print_string f "_"
   | FunctionType _ ->
       raise UnknownType
 

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -150,12 +150,10 @@ functor
           in
           (* TODO: check method signatures *)
           match receiver with
-          | ResolvedReference (_, Value (Type (StructType struct')))
-          | Value (Type (StructType struct')) -> (
-              let receiver' = Value (Type (StructType struct')) in
+          | ResolvedReference (_, Value (Type ty)) | Value (Type ty) -> (
+              let receiver' = Value (Type ty) in
               let methods =
-                List.Assoc.find program.methods ~equal:equal_value
-                  (Type (StructType struct'))
+                List.Assoc.find program.methods ~equal:equal_value (Type ty)
               in
               match
                 Option.bind methods ~f:(fun methods ->

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -222,10 +222,7 @@ let%expect_test "demo struct serializer" =
             (function_impl
              (Fn
               (((Let
-                 ((b
-                   (FunctionCall
-                    ((ResolvedReference (new <opaque>))
-                     ((ResolvedReference (Builder <opaque>))))))))
+                 ((b (FunctionCall ((ResolvedReference (new <opaque>)) ())))))
                 (Expr
                  (FunctionCall
                   ((ResolvedReference (T_serializer <opaque>))
@@ -258,9 +255,32 @@ let%expect_test "demo struct serializer" =
           (Function
            ((function_signature
              ((function_params
-               ((self (Value (Type HoleType)))
+               ((self
+                 (Value
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((a
+                        ((field_type
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>))))))))
+                       (b
+                        ((field_type
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>))))))))))
+                     (struct_id <opaque>))))))
                 (builder (Value (Type (BuiltinType Builder))))))
-              (function_returns (Value (Type VoidType)))))
+              (function_returns (Value (Type (BuiltinType Builder))))))
             (function_impl
              (Fn
               (((Let
@@ -299,8 +319,32 @@ let%expect_test "demo struct serializer" =
                                       (struct_id <opaque>)))))
                                   integer)))
                                (signed true)))))))))))
-                     ((StructField ((Reference (self HoleType)) a))
-                      (Value (Type (BuiltinType Builder)))))))))
+                     ((StructField
+                       ((Reference
+                         (self
+                          (StructType
+                           ((struct_fields
+                             ((a
+                               ((field_type
+                                 (Value
+                                  (Type
+                                   (StructType
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_id <opaque>))))))))
+                              (b
+                               ((field_type
+                                 (Value
+                                  (Type
+                                   (StructType
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_id <opaque>))))))))))
+                            (struct_id <opaque>)))))
+                        a))
+                      (Reference (builder (BuiltinType Builder)))))))))
                 (Let
                  ((builder
                    (FunctionCall
@@ -337,8 +381,32 @@ let%expect_test "demo struct serializer" =
                                       (struct_id <opaque>)))))
                                   integer)))
                                (signed true)))))))))))
-                     ((StructField ((Reference (self HoleType)) b))
-                      (Value (Type (BuiltinType Builder)))))))))
+                     ((StructField
+                       ((Reference
+                         (self
+                          (StructType
+                           ((struct_fields
+                             ((a
+                               ((field_type
+                                 (Value
+                                  (Type
+                                   (StructType
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_id <opaque>))))))))
+                              (b
+                               ((field_type
+                                 (Value
+                                  (Type
+                                   (StructType
+                                    ((struct_fields
+                                      ((integer
+                                        ((field_type (Value (Type IntegerType)))))))
+                                     (struct_id <opaque>))))))))))
+                            (struct_id <opaque>)))))
+                        b))
+                      (Reference (builder (BuiltinType Builder)))))))))
                 (Return (Reference (builder (BuiltinType Builder))))))))))))
         (T
          (Value

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -109,7 +109,7 @@ let%expect_test "Int(bits) serializer codegen" =
     }
     _ test(builder b) {
       [int] i = [100];
-    function_0([100], b);
+      function_0([100], b);
     } |}]
 
 let%expect_test "demo struct serializer" =
@@ -136,15 +136,13 @@ let%expect_test "demo struct serializer" =
     }
     builder T_serializer([[int], [int]] self, builder builder) {
       builder builder = function_0(first(self), builder);
-    builder builder =
-    function_1(second(self), builder);
-    return
-    builder;
+      builder builder = function_1(second(self), builder);
+      return builder;
     }
     builder function_2() {
       return new_builder();
     }
     _ test() {
       builder b = function_2();
-    T_serializer([], b);
+      T_serializer([], b);
     } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -74,3 +74,20 @@ let%expect_test "passing struct to function" =
     int test([[int], int, [int]] t) {
       return 1;
     } |}]
+
+let%expect_test "function calls" =
+  let source =
+    {|
+      fn test(value: Integer) -> Integer { return value; }
+      fn test2(value: Integer) -> Integer { return test(value); }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    int test2(int value) {
+      return function_0(value);
+    }
+    int function_0(int value) {
+      return value;
+    } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -101,11 +101,50 @@ let%expect_test "Int(bits) serializer codegen" =
         }
       |}
   in
-  pp source ; [%expect {|
+  pp source ;
+  [%expect
+    {|
     builder function_0([int] self, builder builder) {
       return store_int(builder, first(self), 32);
     }
     _ test(builder b) {
       [int] i = [100];
     function_0([100], b);
+    } |}]
+
+let%expect_test "demo struct serializer" =
+  let source =
+    {|
+        struct T {
+          val a: Int(32)
+          val b: Int(16)
+        }
+        let T_serializer = serializer(T);
+  
+        fn test() {
+          let b = Builder.new();
+          T_serializer(T{}, b);
+        }
+      |}
+  in
+  pp source ; [%expect {|
+    builder function_0([int] self, builder builder) {
+      return store_int(builder, first(self), 32);
+    }
+    builder function_1([int] self, builder builder) {
+      return store_int(builder, first(self), 16);
+    }
+    builder T_serializer([[int], [int]] self, builder builder) {
+      builder builder = function_0(first(self), builder);
+    builder builder =
+    function_1(second(self), builder);
+    return
+    builder;
+    }
+    builder function_2() {
+      return new_builder();
+    }
+    _ test() {
+      builder b = function_2();
+    T_serializer([], b);
     } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -127,7 +127,9 @@ let%expect_test "demo struct serializer" =
         }
       |}
   in
-  pp source ; [%expect {|
+  pp source ;
+  [%expect
+    {|
     builder function_0([int] self, builder builder) {
       return store_int(builder, first(self), 32);
     }

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -75,7 +75,7 @@ let%expect_test "passing struct to function" =
       return 1;
     } |}]
 
-let%expect_test "function calls" =
+let%expect_test "function calls " =
   let source =
     {|
       fn test(value: Integer) -> Integer { return value; }
@@ -85,9 +85,9 @@ let%expect_test "function calls" =
   pp source ;
   [%expect
     {|
-    int test2(int value) {
-      return function_0(value);
-    }
-    int function_0(int value) {
+    int test(int value) {
       return value;
+    }
+    int test2(int value) {
+      return test(value);
     } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -102,6 +102,9 @@ let%expect_test "Int(bits) serializer codegen" =
       |}
   in
   pp source ; [%expect {|
+    builder function_0([int] self, builder builder) {
+      return store_int(builder, first(self), 32);
+    }
     _ test(builder b) {
       [int] i = [100];
     function_0([100], b);

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -91,3 +91,18 @@ let%expect_test "function calls " =
     int test2(int value) {
       return test(value);
     } |}]
+
+let%expect_test "Int(bits) serializer codegen" =
+  let source =
+    {|
+        fn test(b: Builder) {
+          let i = Int(32).new(100);
+          i.serialize(b);
+        }
+      |}
+  in
+  pp source ; [%expect {|
+    _ test(builder b) {
+      [int] i = [100];
+    function_0([100], b);
+    } |}]


### PR DESCRIPTION
This PR implements codegen of function calls, references, etc. It fixes additionally some bugs with `serializer` built-in function and pretty-printing problems.