### PR TITLE
Add type infer and type check for return/break stmts

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -76,11 +76,12 @@ let int_type =
              [ Return
                  (Primitive
                     (StoreInt
-                       { builder = Reference ("builder", BuiltinType "Builder");
+                       { builder = Reference ("builder", builder);
                          length = Value (Integer (Z.of_int bits));
                          integer =
                            StructField
-                             (Reference ("self", StructType s), "integer");
+                             ( Reference ("self", Value (Type (StructType s))),
+                               "integer" );
                          signed = true } ) ) ] ) }
   and function_impl p = function
     | [Integer bits] ->
@@ -118,15 +119,14 @@ let serializer =
                      [ ( "builder",
                          FunctionCall
                            ( Value (Function method_),
-                             StructField (Reference ("self", StructType s), name)
-                             :: [Reference ("builder", BuiltinType "Builder")]
-                           ) ) ] )
+                             StructField
+                               ( Reference ("self", Value (Type (StructType s))),
+                                 name )
+                             :: [Reference ("builder", builder)] ) ) ] )
         | _ ->
             None )
     in
-    let body =
-      calls @ [Return (Reference ("builder", BuiltinType "Builder"))]
-    in
+    let body = calls @ [Return (Reference ("builder", builder))] in
     Function
       { function_signature =
           { function_params =

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -44,7 +44,7 @@ class constructor =
       | ResolvedReference s ->
           self#cg_ResolvedReference s
       | Reference (name, ty) ->
-          F.Reference (name, self#lang_type_to_type ty)
+          F.Reference (name, self#lang_expr_to_type ty)
       | Primitive p ->
           self#cg_Primitive p
       | Value (Function f) ->
@@ -121,9 +121,9 @@ class constructor =
         F.FunctionCall (name, [struct_ty], field_ty)
       in
       match T.type_of from_expr with
-      | StructType {struct_fields = [_]; _} ->
+      | Value (Type (StructType {struct_fields = [_]; _})) ->
           self#cg_expr from_expr
-      | StructType s ->
+      | Value (Type (StructType s)) ->
           let field_id, (_, field) =
             Option.value_exn
               (List.findi s.struct_fields ~f:(fun _ (name, _) ->

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -13,10 +13,14 @@ functor
       [ `DuplicateField of string * struct_
       | `UnresolvedIdentifier of string
       | `MethodNotFound of expr * string
-      | `UnexpectedType of expr ]
+      | `UnexpectedType of expr
+      | `TypeError of expr * expr
+      | `UnallowedStmt of stmt ]
     [@@deriving equal, sexp_of]
 
     include Builtin
+
+    type infer_ctx = {mutable fn_returns : expr option}
 
     class ['s] constructor (bindings : (string * expr) list)
       (methods : (value * (string * function_) list) list) (errors : _ errors) =
@@ -28,6 +32,8 @@ functor
 
         (* Bindings that will available only in runtime *)
         val mutable runtime_bindings = []
+
+        val infer_ctx = {fn_returns = None}
 
         (* Are we inside of a function body? How deep? *)
         val mutable functions = 0
@@ -89,17 +95,31 @@ functor
               s#build_Reference env ref'
           | Some (Value value) ->
               ResolvedReference (ref, Value value)
-          | Some _ ->
-              (* TODO: type_of *) Reference (ref, HoleType)
+          | Some ex ->
+              Reference (ref, type_of ex)
           | None -> (
             match find_in_scope ref runtime_bindings with
             | Some ty ->
                 Reference (ref, ty)
             | None ->
                 errors#report `Error (`UnresolvedIdentifier ref) () ;
-                Reference (ref, HoleType) )
+                Reference (ref, Value (Type HoleType)) )
 
-        method build_Return _env return = Return return
+        method build_Return _env return =
+          match infer_ctx.fn_returns with
+          | Some fn_returns -> (
+            match s#check_type (type_of return) ~expected:fn_returns with
+            | Ok ty ->
+                infer_ctx.fn_returns <- Some ty ;
+                Return return
+            | Error _ ->
+                errors#report `Error
+                  (`TypeError (fn_returns, type_of return))
+                  () ;
+                Return return )
+          | None ->
+              errors#report `Error (`UnallowedStmt (Return return)) () ;
+              Return return
 
         method build_Break _env stmt = Break stmt
 
@@ -208,13 +228,21 @@ functor
             |> List.map ~f:(fun (ident, expr) ->
                    ( s#visit_ident env @@ Syntax.value ident,
                      s#visit_expr env @@ Syntax.value expr ) )
-            |> List.map ~f:(fun (id, expr) -> (id, expr_to_type expr))
+            |> List.map ~f:(fun (id, expr) -> (id, expr))
+          in
+          let function_returns =
+            f.returns
+            |> Option.map ~f:(fun x -> s#visit_expr env (Syntax.value x))
+            |> Option.value ~default:(Value (Type HoleType))
           in
           let bindings' = runtime_bindings in
           (* inject them into current bindings *)
           runtime_bindings <- param_bindings :: runtime_bindings ;
           (* process the function definition *)
-          let result = super#visit_function_definition env f in
+          let result =
+            s#with_fn_returns env function_returns (fun env' ->
+                super#visit_function_definition env' f )
+          in
           (* restore bindings as before entering the function *)
           runtime_bindings <- bindings' ;
           result
@@ -240,15 +268,13 @@ functor
 
         method build_function_body _env stmts = s#of_located_list stmts
 
-        method build_function_definition _env _name params returns body =
+        method build_function_definition _env _name params _ body =
           let function_params =
             s#of_located_list params
             |> List.map ~f:(fun (name, type_) ->
                    (Syntax.value name, Syntax.value type_) )
           and function_returns =
-            returns
-            |> Option.map ~f:(fun x -> Syntax.value x)
-            |> Option.value ~default:(Value (Type HoleType))
+            Option.value infer_ctx.fn_returns ~default:(Value (Type HoleType))
           and function_impl = body in
           { function_signature = {function_params; function_returns};
             function_impl = Fn function_impl }
@@ -326,5 +352,23 @@ functor
 
         method private of_located_list : 'a. 'a Syntax.located list -> 'a list =
           List.map ~f:Syntax.value
+
+        method private with_fn_returns
+            : 'env 'a. 'env -> expr -> ('env -> 'a) -> 'a =
+          fun env ty f ->
+            let prev = infer_ctx.fn_returns in
+            infer_ctx.fn_returns <- Some ty ;
+            let result = f env in
+            infer_ctx.fn_returns <- prev ;
+            result
+
+        method private check_type ~expected actual =
+          match expected with
+          | Value (Type HoleType) ->
+              Ok actual
+          | _ when equal_expr expected actual ->
+              Ok actual
+          | _ ->
+              Error ()
       end
   end

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -58,16 +58,20 @@ let%expect_test "Int(bits) constructor" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 8)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true))))))))))))
         ((Type
@@ -101,16 +105,20 @@ let%expect_test "Int(bits) constructor" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -148,7 +156,7 @@ let%expect_test "Int(bits) serializer" =
                    (FunctionCall
                     ((ResolvedReference (serialize <opaque>))
                      ((ResolvedReference (i <opaque>))
-                      (Reference (b (BuiltinType Builder)))))))))))))))))
+                      (Reference (b (Value (Type (BuiltinType Builder)))))))))))))))))))
         (methods
          (((Type
             (StructType
@@ -181,16 +189,20 @@ let%expect_test "Int(bits) serializer" =
                (Fn
                 (((Return
                    (Primitive
-                    (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                    (StoreInt
+                     (builder
+                      (Reference (builder (Value (Type (BuiltinType Builder))))))
                      (length (Value (Integer 32)))
                      (integer
                       (StructField
                        ((Reference
                          (self
-                          (StructType
-                           ((struct_fields
-                             ((integer ((field_type (Value (Type IntegerType)))))))
-                            (struct_id <opaque>)))))
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>)))))))
                         integer)))
                      (signed true)))))))))))))))) |}]
 
@@ -264,7 +276,7 @@ let%expect_test "demo struct serializer" =
                                 ((field_type (Value (Type IntegerType)))))))
                              (struct_id <opaque>))
                             ((integer (Value (Integer 1))))))))))))
-                    (Reference (b (BuiltinType Builder)))))))))))))))
+                    (Reference (b (Value (Type (BuiltinType Builder)))))))))))))))))
         (T_serializer
          (Value
           (Function
@@ -321,45 +333,53 @@ let%expect_test "demo struct serializer" =
                              (Primitive
                               (StoreInt
                                (builder
-                                (Reference (builder (BuiltinType Builder))))
+                                (Reference
+                                 (builder (Value (Type (BuiltinType Builder))))))
                                (length (Value (Integer 32)))
                                (integer
                                 (StructField
                                  ((Reference
                                    (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer
-                                         ((field_type (Value (Type IntegerType)))))))
-                                      (struct_id <opaque>)))))
+                                    (Value
+                                     (Type
+                                      (StructType
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))
                                   integer)))
                                (signed true)))))))))))
                      ((StructField
                        ((Reference
                          (self
-                          (StructType
-                           ((struct_fields
-                             ((a
-                               ((field_type
-                                 (Value
-                                  (Type
-                                   (StructType
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_id <opaque>))))))))
-                              (b
-                               ((field_type
-                                 (Value
-                                  (Type
-                                   (StructType
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_id <opaque>))))))))))
-                            (struct_id <opaque>)))))
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((a
+                                 ((field_type
+                                   (Value
+                                    (Type
+                                     (StructType
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_id <opaque>))))))))
+                                (b
+                                 ((field_type
+                                   (Value
+                                    (Type
+                                     (StructType
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_id <opaque>))))))))))
+                              (struct_id <opaque>)))))))
                         a))
-                      (Reference (builder (BuiltinType Builder)))))))))
+                      (Reference (builder (Value (Type (BuiltinType Builder)))))))))))
                 (Let
                  ((builder
                    (FunctionCall
@@ -383,46 +403,55 @@ let%expect_test "demo struct serializer" =
                              (Primitive
                               (StoreInt
                                (builder
-                                (Reference (builder (BuiltinType Builder))))
+                                (Reference
+                                 (builder (Value (Type (BuiltinType Builder))))))
                                (length (Value (Integer 16)))
                                (integer
                                 (StructField
                                  ((Reference
                                    (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer
-                                         ((field_type (Value (Type IntegerType)))))))
-                                      (struct_id <opaque>)))))
+                                    (Value
+                                     (Type
+                                      (StructType
+                                       ((struct_fields
+                                         ((integer
+                                           ((field_type
+                                             (Value (Type IntegerType)))))))
+                                        (struct_id <opaque>)))))))
                                   integer)))
                                (signed true)))))))))))
                      ((StructField
                        ((Reference
                          (self
-                          (StructType
-                           ((struct_fields
-                             ((a
-                               ((field_type
-                                 (Value
-                                  (Type
-                                   (StructType
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_id <opaque>))))))))
-                              (b
-                               ((field_type
-                                 (Value
-                                  (Type
-                                   (StructType
-                                    ((struct_fields
-                                      ((integer
-                                        ((field_type (Value (Type IntegerType)))))))
-                                     (struct_id <opaque>))))))))))
-                            (struct_id <opaque>)))))
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((a
+                                 ((field_type
+                                   (Value
+                                    (Type
+                                     (StructType
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_id <opaque>))))))))
+                                (b
+                                 ((field_type
+                                   (Value
+                                    (Type
+                                     (StructType
+                                      ((struct_fields
+                                        ((integer
+                                          ((field_type
+                                            (Value (Type IntegerType)))))))
+                                       (struct_id <opaque>))))))))))
+                              (struct_id <opaque>)))))))
                         b))
-                      (Reference (builder (BuiltinType Builder)))))))))
-                (Return (Reference (builder (BuiltinType Builder))))))))))))
+                      (Reference (builder (Value (Type (BuiltinType Builder)))))))))))
+                (Return
+                 (Reference (builder (Value (Type (BuiltinType Builder))))))))))))))
         (T
          (Value
           (Type
@@ -498,16 +527,20 @@ let%expect_test "demo struct serializer" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 16)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true))))))))))))
         ((Type
@@ -541,15 +574,19 @@ let%expect_test "demo struct serializer" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 32)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -1469,7 +1469,9 @@ let%expect_test "type inference" =
   let source = {|
       fn foo(i: Integer) { return i; }
     |} in
-  pp source ; [%expect {|
+  pp source ;
+  [%expect
+    {|
     (Ok
      ((bindings
        ((foo

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -480,7 +480,7 @@ let%expect_test "compile-time function evaluation within a function" =
          (Value
           (Function
            ((function_signature
-             ((function_params ()) (function_returns (Value (Type HoleType)))))
+             ((function_params ()) (function_returns (Value (Type IntegerType)))))
             (function_impl
              (Fn
               (((Let ((v (Value (Integer 4)))))
@@ -844,7 +844,7 @@ let%expect_test "function without a return type" =
            (Value
             (Function
              ((function_signature
-               ((function_params ()) (function_returns (Value (Type HoleType)))))
+               ((function_params ()) (function_returns (Value (Type IntegerType)))))
               (function_impl (Fn (((Break (Expr (Value (Integer 1)))))))))))))))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
@@ -875,7 +875,13 @@ let%expect_test "scoping that `let` introduces in code" =
                     ((struct_fields
                       ((integer ((field_type (Value (Type IntegerType)))))))
                      (struct_id <opaque>))))))))
-              (function_returns (Value (Type HoleType)))))
+              (function_returns
+               (Value
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl
              (Fn
               (((Let
@@ -1005,8 +1011,22 @@ let%expect_test "reference in function bodies" =
                  ((b
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
-                     ((Reference (a (Value (Type HoleType))))
-                      (Reference (a (Value (Type HoleType))))))))))))))))))
+                     ((Reference
+                       (a
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
+                      (Reference
+                       (a
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))))))))))))))))
         (op
          (Value
           (Function
@@ -1026,7 +1046,13 @@ let%expect_test "reference in function bodies" =
                     ((struct_fields
                       ((integer ((field_type (Value (Type IntegerType)))))))
                      (struct_id <opaque>))))))))
-              (function_returns (Value (Type HoleType)))))
+              (function_returns
+               (Value
+                (Type
+                 (StructType
+                  ((struct_fields
+                    ((integer ((field_type (Value (Type IntegerType)))))))
+                   (struct_id <opaque>))))))))
             (function_impl
              (Fn
               (((Break
@@ -1108,7 +1134,7 @@ let%expect_test "resolving a reference from inside a function" =
          (Value
           (Function
            ((function_signature
-             ((function_params ()) (function_returns (Value (Type HoleType)))))
+             ((function_params ()) (function_returns (Value (Type IntegerType)))))
             (function_impl
              (Fn (((Break (Expr (ResolvedReference (i <opaque>))))))))))))
         (i (Value (Integer 1))))))) |}]
@@ -1141,7 +1167,7 @@ let%expect_test "method access" =
            ((function_signature
              ((function_params
                ((self (Value (Type TypeType))) (i (Value (Type IntegerType)))))
-              (function_returns (Value (Type HoleType)))))
+              (function_returns (Value (Type IntegerType)))))
             (function_impl
              (Fn (((Break (Expr (Reference (i (Value (Type IntegerType)))))))))))))))))) |}]
 

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -62,16 +62,20 @@ let%expect_test "scope resolution" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -136,16 +140,20 @@ let%expect_test "binding resolution" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -158,7 +166,7 @@ let%expect_test "failed scope resolution" =
     {|
     (Error
      (((UnresolvedIdentifier Int256)
-       ((stmts ((Let ((T (Reference (Int256 HoleType)))))))
+       ((stmts ((Let ((T (Reference (Int256 (Value (Type HoleType)))))))))
         (bindings
          ((Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
@@ -249,16 +257,20 @@ let%expect_test "scope resolution after let binding" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -330,16 +342,20 @@ let%expect_test "basic struct definition" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -391,10 +407,12 @@ let%expect_test "Tact function evaluation" =
                  (Expr
                   (Reference
                    (i
-                    (StructType
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_id <opaque>)))))))))))))))))
+                    (Value
+                     (Type
+                      (StructType
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_id <opaque>)))))))))))))))))))
       (methods
        (((Type
           (StructType
@@ -427,16 +445,20 @@ let%expect_test "Tact function evaluation" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -539,16 +561,20 @@ let%expect_test "struct definition" =
                (Fn
                 (((Return
                    (Primitive
-                    (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                    (StoreInt
+                     (builder
+                      (Reference (builder (Value (Type (BuiltinType Builder))))))
                      (length (Value (Integer 257)))
                      (integer
                       (StructField
                        ((Reference
                          (self
-                          (StructType
-                           ((struct_fields
-                             ((integer ((field_type (Value (Type IntegerType)))))))
-                            (struct_id <opaque>)))))
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>)))))))
                         integer)))
                      (signed true)))))))))))))))) |}]
 
@@ -684,16 +710,20 @@ let%expect_test "duplicate type field" =
                 (((Return
                    (Primitive
                     (StoreInt
-                     (builder (Reference (builder (BuiltinType Builder))))
+                     (builder
+                      (Reference (builder (Value (Type (BuiltinType Builder))))))
                      (length (Value (Integer 257)))
                      (integer
                       (StructField
                        ((Reference
                          (self
-                          (StructType
-                           ((struct_fields
-                             ((integer ((field_type (Value (Type IntegerType)))))))
-                            (struct_id <opaque>)))))
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>)))))))
                         integer)))
                      (signed true))))))))))))
           ((Type (BuiltinType Builder))
@@ -742,7 +772,7 @@ let%expect_test "parametric struct instantiation" =
                   (Type
                    (StructType
                     ((struct_fields
-                      ((a ((field_type (Reference (A TypeType)))))))
+                      ((a ((field_type (Reference (A (Value (Type TypeType)))))))))
                      (struct_id <opaque>))))))))))))))))
       (methods
        (((Type
@@ -776,21 +806,26 @@ let%expect_test "parametric struct instantiation" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true))))))))))))
         ((Type
           (StructType
-           ((struct_fields ((a ((field_type (Reference (A TypeType)))))))
+           ((struct_fields
+             ((a ((field_type (Reference (A (Value (Type TypeType)))))))))
             (struct_id <opaque>))))
          ()))))) |}]
 
@@ -847,18 +882,22 @@ let%expect_test "scoping that `let` introduces in code" =
                  ((a
                    (Reference
                     (i
-                     (StructType
-                      ((struct_fields
-                        ((integer ((field_type (Value (Type IntegerType)))))))
-                       (struct_id <opaque>))))))))
+                     (Value
+                      (Type
+                       (StructType
+                        ((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_id <opaque>))))))))))
                 (Break
                  (Expr
                   (Reference
                    (a
-                    (StructType
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_id <opaque>)))))))))))))))))
+                    (Value
+                     (Type
+                      (StructType
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_id <opaque>)))))))))))))))))))
       (methods
        (((Type
           (StructType
@@ -891,16 +930,20 @@ let%expect_test "scoping that `let` introduces in code" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true))))))))))))))))
      |}]
@@ -944,21 +987,26 @@ let%expect_test "reference in function bodies" =
                     ((ResolvedReference (op <opaque>))
                      ((Reference
                        (x
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       (Reference
                        (x
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))))))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))))))))
                 (Let
                  ((b
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
-                     ((Reference (a HoleType)) (Reference (a HoleType))))))))))))))))
+                     ((Reference (a (Value (Type HoleType))))
+                      (Reference (a (Value (Type HoleType))))))))))))))))))
         (op
          (Value
           (Function
@@ -985,10 +1033,12 @@ let%expect_test "reference in function bodies" =
                  (Expr
                   (Reference
                    (i
-                    (StructType
-                     ((struct_fields
-                       ((integer ((field_type (Value (Type IntegerType)))))))
-                      (struct_id <opaque>)))))))))))))))))
+                    (Value
+                     (Type
+                      (StructType
+                       ((struct_fields
+                         ((integer ((field_type (Value (Type IntegerType)))))))
+                        (struct_id <opaque>)))))))))))))))))))
       (methods
        (((Type
           (StructType
@@ -1021,16 +1071,20 @@ let%expect_test "reference in function bodies" =
              (Fn
               (((Return
                  (Primitive
-                  (StoreInt (builder (Reference (builder (BuiltinType Builder))))
+                  (StoreInt
+                   (builder
+                    (Reference (builder (Value (Type (BuiltinType Builder))))))
                    (length (Value (Integer 257)))
                    (integer
                     (StructField
                      ((Reference
                        (self
-                        (StructType
-                         ((struct_fields
-                           ((integer ((field_type (Value (Type IntegerType)))))))
-                          (struct_id <opaque>)))))
+                        (Value
+                         (Type
+                          (StructType
+                           ((struct_fields
+                             ((integer ((field_type (Value (Type IntegerType)))))))
+                            (struct_id <opaque>)))))))
                       integer)))
                    (signed true)))))))))))))))) |}]
 
@@ -1088,7 +1142,8 @@ let%expect_test "method access" =
              ((function_params
                ((self (Value (Type TypeType))) (i (Value (Type IntegerType)))))
               (function_returns (Value (Type HoleType)))))
-            (function_impl (Fn (((Break (Expr (Reference (i IntegerType)))))))))))))))) |}]
+            (function_impl
+             (Fn (((Break (Expr (Reference (i (Value (Type IntegerType)))))))))))))))))) |}]
 
 let%expect_test "Self type resolution in methods" =
   let source =
@@ -1123,7 +1178,10 @@ let%expect_test "Self type resolution in methods" =
               (((Break
                  (Expr
                   (Reference
-                   (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))) |}]
+                   (self
+                    (Value
+                     (Type
+                      (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))))) |}]
 
 let%expect_test "struct instantiation" =
   let source =
@@ -1165,3 +1223,234 @@ let%expect_test "struct instantiation" =
               (b ((field_type (Value (Type IntegerType)))))))
             (struct_id <opaque>))))
          ()))))) |}]
+
+let%expect_test "type check error" =
+  let source = {|
+    fn foo(i: Int(32)) -> Int(64) { return i; }
+  |} in
+  pp source ;
+  [%expect
+    {|
+    (Error
+     (((TypeError
+        ((Value
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>)))))
+         (Value
+          (Type
+           (StructType
+            ((struct_fields
+              ((integer ((field_type (Value (Type IntegerType)))))))
+             (struct_id <opaque>)))))))
+       ((stmts
+         ((Let
+           ((foo
+             (Value
+              (Function
+               ((function_signature
+                 ((function_params
+                   ((i
+                     (Value
+                      (Type
+                       (StructType
+                        ((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_id <opaque>))))))))
+                  (function_returns
+                   (Value
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))))
+                (function_impl
+                 (Fn
+                  (((Return
+                     (Reference
+                      (i
+                       (Value
+                        (Type
+                         (StructType
+                          ((struct_fields
+                            ((integer ((field_type (Value (Type IntegerType)))))))
+                           (struct_id <opaque>))))))))))))))))))))
+        (bindings
+         ((foo
+           (Value
+            (Function
+             ((function_signature
+               ((function_params
+                 ((i
+                   (Value
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))))
+                (function_returns
+                 (Value
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
+              (function_impl
+               (Fn
+                (((Return
+                   (Reference
+                    (i
+                     (Value
+                      (Type
+                       (StructType
+                        ((struct_fields
+                          ((integer ((field_type (Value (Type IntegerType)))))))
+                         (struct_id <opaque>))))))))))))))))
+          (Builder (Value (Type (BuiltinType Builder))))
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((bits (Value (Type IntegerType)))))
+                (function_returns (Value (Type TypeType)))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Bool (Value (Builtin Bool))) (Type (Value (Type TypeType)))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (Value (Type TypeType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (FunctionType
+                    ((function_params
+                      ((t (Value (Type HoleType)))
+                       (builder (Value (Type (BuiltinType Builder))))))
+                     (function_returns (Value (Type VoidType))))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (methods
+         (((Type
+            (StructType
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_id <opaque>))))
+           ((new
+             ((function_signature
+               ((function_params ((integer (Value (Type IntegerType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self
+                   (Value
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))
+                  (builder (Value (Type (BuiltinType Builder))))))
+                (function_returns (Value (Type (BuiltinType Builder))))))
+              (function_impl
+               (Fn
+                (((Return
+                   (Primitive
+                    (StoreInt
+                     (builder
+                      (Reference (builder (Value (Type (BuiltinType Builder))))))
+                     (length (Value (Integer 64)))
+                     (integer
+                      (StructField
+                       ((Reference
+                         (self
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>)))))))
+                        integer)))
+                     (signed true))))))))))))
+          ((Type
+            (StructType
+             ((struct_fields
+               ((integer ((field_type (Value (Type IntegerType)))))))
+              (struct_id <opaque>))))
+           ((new
+             ((function_signature
+               ((function_params ((integer (Value (Type IntegerType)))))
+                (function_returns
+                 (Value
+                  (Type
+                   (StructType
+                    ((struct_fields
+                      ((integer ((field_type (Value (Type IntegerType)))))))
+                     (struct_id <opaque>))))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self
+                   (Value
+                    (Type
+                     (StructType
+                      ((struct_fields
+                        ((integer ((field_type (Value (Type IntegerType)))))))
+                       (struct_id <opaque>))))))
+                  (builder (Value (Type (BuiltinType Builder))))))
+                (function_returns (Value (Type (BuiltinType Builder))))))
+              (function_impl
+               (Fn
+                (((Return
+                   (Primitive
+                    (StoreInt
+                     (builder
+                      (Reference (builder (Value (Type (BuiltinType Builder))))))
+                     (length (Value (Integer 32)))
+                     (integer
+                      (StructField
+                       ((Reference
+                         (self
+                          (Value
+                           (Type
+                            (StructType
+                             ((struct_fields
+                               ((integer
+                                 ((field_type (Value (Type IntegerType)))))))
+                              (struct_id <opaque>)))))))
+                        integer)))
+                     (signed true))))))))))))
+          ((Type (BuiltinType Builder))
+           ((new
+             ((function_signature
+               ((function_params ())
+                (function_returns (Value (Type (BuiltinType Builder))))))
+              (function_impl (Fn (((Return (Primitive EmptyBuilder)))))))))))))))) |}]
+
+let%expect_test "type inference" =
+  let source = {|
+      fn foo(i: Integer) { return i; }
+    |} in
+  pp source ; [%expect {|
+    (Ok
+     ((bindings
+       ((foo
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((i (Value (Type IntegerType)))))
+              (function_returns (Value (Type IntegerType)))))
+            (function_impl
+             (Fn (((Return (Reference (i (Value (Type IntegerType))))))))))))))))) |}]


### PR DESCRIPTION
This PR also changes types of tact types from `type_` to `expr` due to details discussed in private conversation with @cmxog.