### PR TITLE
Rename StructInstance to Struct for brevity

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -61,7 +61,7 @@ let int_type =
             extract i 0 (numbits - bits)
           else i
         in
-        StructInstance (int_type_s p bits, [("integer", Value (Integer i))])
+        Struct (int_type_s p bits, [("integer", Value (Integer i))])
     | _ ->
         (* TODO: raise an error instead *)
         constructor_impl bits p [Integer (Zint.of_int 0)]

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -26,7 +26,7 @@ class constructor =
                let expr = self#cg_expr expr in
                (F.type_of expr, name, expr) ) )
 
-    method cg_StructInstance : T.struct_ * (string * T.expr) list -> F.expr =
+    method cg_Struct : T.struct_ * (string * T.expr) list -> F.expr =
       function
       | _, [(_, expr)] ->
           self#cg_expr expr
@@ -43,8 +43,8 @@ class constructor =
           F.Integer Zint.zero
       | StructField x ->
           self#cg_StructField x
-      | Value (StructInstance inst) ->
-          self#cg_StructInstance inst
+      | Value (Struct inst) ->
+          self#cg_Struct inst
       | ResolvedReference s ->
           self#cg_ResolvedReference s
       | Reference (name, ty) ->

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -85,7 +85,7 @@ class interpreter
               Void )
         | StructField (struct_, field) -> (
           match self#interpret_expr struct_ with
-          | StructInstance (struct_, struct') -> (
+          | Struct (struct_, struct') -> (
             match List.Assoc.find struct' ~equal:String.equal field with
             | Some field ->
                 self#interpret_expr field

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -178,7 +178,7 @@ functor
 
         method build_Struct _env s = Value (Type (StructType s))
 
-        method build_StructConstructor _env sc = Value (StructInstance sc)
+        method build_StructConstructor _env sc = Value (Struct sc)
 
         method build_Union _env _union = InvalidExpr
 
@@ -238,8 +238,8 @@ functor
               | None ->
                   errors#report `Error (`MethodNotFound (receiver', fn)) () ;
                   dummy )
-          | ResolvedReference (_, Value (StructInstance (struct', _)))
-          | Value (StructInstance (struct', _)) -> (
+          | ResolvedReference (_, Value (Struct (struct', _)))
+          | Value (Struct (struct', _)) -> (
               let receiver' = Value (Type (StructType struct')) in
               let methods =
                 List.Assoc.find program.methods ~equal:equal_value

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -50,8 +50,7 @@ and if_ = {if_condition : expr; if_then : stmt; if_else : stmt option}
 
 and value =
   | Void
-  (* Instance of a Struct *)
-  | StructInstance of (struct_ * (string * expr) list)
+  | Struct of (struct_ * (string * expr) list)
   | Function of function_
   | Integer of (Zint.t[@visitors.name "z"])
   | Bool of bool
@@ -134,7 +133,7 @@ let rec expr_to_type = function
       InvalidType
 
 let rec type_of = function
-  | Value (StructInstance (struct_, _)) ->
+  | Value (Struct (struct_, _)) ->
       Value (Type (StructType struct_))
   | Value (Function {function_signature; _}) ->
       Value (Type (FunctionType function_signature))

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -14,14 +14,14 @@ let%expect_test "Int(bits) constructor" =
      ((bindings
        ((overflow
          (Value
-          (StructInstance
+          (Struct
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>))
             ((integer (Value (Integer 1))))))))
         (i
          (Value
-          (StructInstance
+          (Struct
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>))
@@ -146,7 +146,7 @@ let%expect_test "Int(bits) serializer" =
                   ((Let
                     ((i
                       (Value
-                       (StructInstance
+                       (Struct
                         (((struct_fields
                            ((integer ((field_type (Value (Type IntegerType)))))))
                           (struct_id <opaque>))
@@ -238,7 +238,7 @@ let%expect_test "demo struct serializer" =
                   (FunctionCall
                    ((ResolvedReference (T_serializer <opaque>))
                     ((Value
-                      (StructInstance
+                      (Struct
                        (((struct_fields
                           ((a
                             ((field_type
@@ -261,7 +261,7 @@ let%expect_test "demo struct serializer" =
                          (struct_id <opaque>))
                         ((a
                           (Value
-                           (StructInstance
+                           (Struct
                             (((struct_fields
                                ((integer
                                  ((field_type (Value (Type IntegerType)))))))
@@ -269,7 +269,7 @@ let%expect_test "demo struct serializer" =
                              ((integer (Value (Integer 0))))))))
                          (b
                           (Value
-                           (StructInstance
+                           (Struct
                             (((struct_fields
                                ((integer
                                  ((field_type (Value (Type IntegerType)))))))

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -379,7 +379,7 @@ let%expect_test "Tact function evaluation" =
      ((bindings
        ((a
          (Value
-          (StructInstance
+          (Struct
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>))
@@ -865,7 +865,7 @@ let%expect_test "scoping that `let` introduces in code" =
      ((bindings
        ((b
          (Value
-          (StructInstance
+          (Struct
            (((struct_fields
               ((integer ((field_type (Value (Type IntegerType)))))))
              (struct_id <opaque>))
@@ -1169,8 +1169,7 @@ let%expect_test "method access" =
     (Ok
      ((bindings
        ((res (Value (Integer 1)))
-        (foo
-         (Value (StructInstance (((struct_fields ()) (struct_id <opaque>)) ()))))
+        (foo (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
         (Foo
          (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
       (methods
@@ -1245,7 +1244,7 @@ let%expect_test "struct instantiation" =
      ((bindings
        ((t
          (Value
-          (StructInstance
+          (Struct
            (((struct_fields
               ((a ((field_type (Value (Type IntegerType)))))
                (b ((field_type (Value (Type IntegerType)))))))


### PR DESCRIPTION
The reason why it was called StructInstance in the first place was that
initially we had both Struct (a type) as a value, too. Now that we got
rid of that notion, there's no more conflict and we can simply have
StructType and Struct.