### PR TITLE
Fix dependent types

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -91,13 +91,12 @@ let int_type =
   Value
     (Function
        { function_signature =
-           { function_params = [("bits", IntegerType)];
-             function_returns = TypeType };
+           {function_params = [("bits", IntegerType)]; function_returns = type0};
          function_impl = BuiltinFn (builtin_fun function_impl) } )
 
 let serializer =
   let function_signature =
-    { function_params = [("t", TypeType)];
+    { function_params = [("t", type0)];
       function_returns =
         FunctionType
           { function_params = [("t", HoleType); ("b", builder)];
@@ -167,7 +166,7 @@ let bin_op_intf =
 
 let from_intf =
   let function_signature =
-    {function_params = [("T", TypeType)]; function_returns = HoleType}
+    {function_params = [("T", type0)]; function_returns = HoleType}
   in
   let make_from t =
     Type
@@ -188,7 +187,7 @@ let default_bindings =
     ("Integer", Value (Type IntegerType));
     ("Int", int_type);
     ("Bool", Value (Type BoolType));
-    ("Type", Value (Type TypeType));
+    ("Type", Value (Type type0));
     ("Void", Value Void);
     (* TODO: re-design the serialization API surface; this is more for demonstration
      * purposes

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -206,6 +206,11 @@ class interpreter
         | Some (Error ()) ->
             Sexplib.Sexp.pp_hum Caml.Format.std_formatter (sexp_of_string ref) ;
             Sexplib.Sexp.pp_hum Caml.Format.std_formatter
+              (sexp_of_list
+                 (sexp_of_list
+                    (Stdppx.sexp_of_pair sexp_of_string sexp_of_value) )
+                 vars_scope ) ;
+            Sexplib.Sexp.pp_hum Caml.Format.std_formatter
               (sexp_of_list (sexp_of_list sexp_of_tbinding) global_bindings) ;
             raise Errors.InternalCompilerError
         | Some (Ok v) ->

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -74,7 +74,7 @@ and stmt =
 and builtin = string
 
 and type_ =
-  | TypeType
+  | TypeN of int
   | IntegerType
   | BoolType
   | StringType
@@ -124,6 +124,8 @@ and primitive =
     visitors {variety = "reduce"; ancestors = ["base_reduce"]},
     visitors {variety = "fold"; name = "visitor"; ancestors = ["base_visitor"]}]
 
+let type0 = TypeN 0
+
 let make_runtime (x, type_) = (x, Runtime type_)
 
 let make_comptime (x, value) = (x, Comptime value)
@@ -172,8 +174,8 @@ let rec type_of = function
       VoidType
   | Value (Type (Dependent (_, ty))) ->
       ty
-  | Value (Type _) ->
-      TypeType
+  | Value (Type t) ->
+      type_of_type t
   | Hole ->
       HoleType
   | FunctionCall
@@ -196,6 +198,8 @@ let rec type_of = function
       type_of e
   | expr ->
       InvalidType expr
+
+and type_of_type = function TypeN x -> TypeN (x + 1) | _otherwise -> TypeN 0
 
 and type_of_call args arg_types returns =
   let associated =

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -215,7 +215,16 @@ and type_of_call args arg_types returns =
 
       method! visit_Dependent _ ref _ =
         List.find_map associated ~f:(fun (name, x) ->
-            if equal_string name ref then Some (type_of x) else None )
+            if equal_string name ref then
+              Some
+                ( match x with
+                (* If we depend on reference, it means we depend on function argument,
+                   so type must be dependent. *)
+                | Reference (r, t) ->
+                    Dependent (r, t)
+                | x ->
+                    type_of x )
+            else None )
         |> Option.value_exn
     end
   in

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -51,8 +51,10 @@ functor
           pp_print_string f "<anonymous>"
 
     and pp_type f = function
-      | TypeType ->
+      | TypeN 0 ->
           pp_print_string f "Type"
+      | TypeN n ->
+          pp_print_string f "Type" ; pp_print_int f n
       | IntegerType ->
           pp_print_string f "Integer"
       | BoolType ->

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -2027,7 +2027,8 @@ let%expect_test "dependent types" =
   let source =
     {|
       fn identity(X: Type) {
-        fn(x: X) -> X { x }
+        let f = fn(x: X) -> X { x };
+        f
       }
       fn test(Y: Type) {
         identity(Y)
@@ -2046,7 +2047,8 @@ let%expect_test "dependent types" =
              ((function_params ((Y (TypeN 0))))
               (function_returns
                (FunctionType
-                ((function_params ((x (TypeN 0)))) (function_returns (TypeN 0)))))))
+                ((function_params ((x (Dependent Y (TypeN 0)))))
+                 (function_returns (Dependent Y (TypeN 0))))))))
             (function_impl
              (Fn
               ((Block
@@ -2067,20 +2069,22 @@ let%expect_test "dependent types" =
             (function_impl
              (Fn
               ((Block
-                ((Break
-                  (Expr
-                   (Value
-                    (Function
-                     ((function_signature
-                       ((function_params
-                         ((x (ExprType (Reference (X (TypeN 0)))))))
-                        (function_returns (ExprType (Reference (X (TypeN 0)))))))
-                      (function_impl
-                       (Fn
-                        ((Block
-                          ((Break
-                            (Expr
-                             (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))))))))))) |}]
+                ((Let
+                  ((f
+                    (Value
+                     (Function
+                      ((function_signature
+                        ((function_params
+                          ((x (ExprType (Reference (X (TypeN 0)))))))
+                         (function_returns (ExprType (Reference (X (TypeN 0)))))))
+                       (function_impl
+                        (Fn
+                         ((Block
+                           ((Break
+                             (Expr
+                              (Reference
+                               (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
+                 (Break (Expr (ResolvedReference (f <opaque>))))))))))))))))) |}]
 
 let%expect_test "TypeN" =
   let source =

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -149,15 +149,15 @@ let%expect_test "failed scope resolution" =
             (Function
              ((function_signature
                ((function_params ((bits IntegerType)))
-                (function_returns TypeType)))
+                (function_returns (TypeN 0))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type TypeType)))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
           (Void (Value Void))
           (serializer
            (Value
             (Function
              ((function_signature
-               ((function_params ((t TypeType)))
+               ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
                   ((function_params ((t HoleType) (b (BuiltinType Builder))))
@@ -175,7 +175,7 @@ let%expect_test "failed scope resolution" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((T TypeType))) (function_returns HoleType)))
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
          (((Type (BuiltinType Builder))
@@ -567,15 +567,15 @@ let%expect_test "duplicate type field" =
             (Function
              ((function_signature
                ((function_params ((bits IntegerType)))
-                (function_returns TypeType)))
+                (function_returns (TypeN 0))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type TypeType)))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
           (Void (Value Void))
           (serializer
            (Value
             (Function
              ((function_signature
-               ((function_params ((t TypeType)))
+               ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
                   ((function_params ((t HoleType) (b (BuiltinType Builder))))
@@ -593,7 +593,7 @@ let%expect_test "duplicate type field" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((T TypeType))) (function_returns HoleType)))
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
          (((Type
@@ -688,7 +688,7 @@ let%expect_test "parametric struct instantiation" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((A TypeType))) (function_returns TypeType)))
+             ((function_params ((A (TypeN 0)))) (function_returns (TypeN 0))))
             (function_impl
              (Fn
               ((Expr
@@ -696,7 +696,7 @@ let%expect_test "parametric struct instantiation" =
                  (Type
                   (StructType
                    ((struct_fields
-                     ((a ((field_type (ExprType (Reference (A TypeType))))))))
+                     ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
                     (struct_id <opaque>)))))))))))))))
       (methods
        (((Type
@@ -738,14 +738,14 @@ let%expect_test "parametric struct instantiation" =
         ((Type
           (StructType
            ((struct_fields
-             ((a ((field_type (ExprType (Reference (A TypeType))))))))
+             ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
             (struct_id <opaque>))))
          ())))
       (impls
        (((Type
           (StructType
            ((struct_fields
-             ((a ((field_type (ExprType (Reference (A TypeType))))))))
+             ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
             (struct_id <opaque>))))
          ()))))) |}]
 
@@ -1165,15 +1165,15 @@ let%expect_test "type check error" =
             (Function
              ((function_signature
                ((function_params ((bits IntegerType)))
-                (function_returns TypeType)))
+                (function_returns (TypeN 0))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type TypeType)))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
           (Void (Value Void))
           (serializer
            (Value
             (Function
              ((function_signature
-               ((function_params ((t TypeType)))
+               ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
                   ((function_params ((t HoleType) (b (BuiltinType Builder))))
@@ -1191,7 +1191,7 @@ let%expect_test "type check error" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((T TypeType))) (function_returns HoleType)))
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
          (((Type
@@ -1369,15 +1369,15 @@ let%expect_test "type check error" =
             (Function
              ((function_signature
                ((function_params ((bits IntegerType)))
-                (function_returns TypeType)))
+                (function_returns (TypeN 0))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type TypeType)))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
           (Void (Value Void))
           (serializer
            (Value
             (Function
              ((function_signature
-               ((function_params ((t TypeType)))
+               ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
                   ((function_params ((t HoleType) (b (BuiltinType Builder))))
@@ -1395,7 +1395,7 @@ let%expect_test "type check error" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((T TypeType))) (function_returns HoleType)))
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (methods
          (((Type
@@ -2000,11 +2000,11 @@ let%expect_test "reference resolving in inner functions" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((X TypeType)))
+             ((function_params ((X (TypeN 0))))
               (function_returns
                (FunctionType
-                ((function_params ((x (Dependent X TypeType))))
-                 (function_returns (Dependent X TypeType)))))))
+                ((function_params ((x (Dependent X (TypeN 0)))))
+                 (function_returns (Dependent X (TypeN 0))))))))
             (function_impl
              (Fn
               ((Block
@@ -2014,14 +2014,14 @@ let%expect_test "reference resolving in inner functions" =
                     (Function
                      ((function_signature
                        ((function_params
-                         ((x (ExprType (Reference (X TypeType))))))
-                        (function_returns (ExprType (Reference (X TypeType))))))
+                         ((x (ExprType (Reference (X (TypeN 0)))))))
+                        (function_returns (ExprType (Reference (X (TypeN 0)))))))
                       (function_impl
                        (Fn
                         ((Block
                           ((Break
                             (Expr
-                             (Reference (x (ExprType (Reference (X TypeType)))))))))))))))))))))))))))))) |}]
+                             (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))))))))))) |}]
 
 let%expect_test "dependent types" =
   let source =
@@ -2034,18 +2034,19 @@ let%expect_test "dependent types" =
       }
     |}
   in
-  pp source;
-  [%expect {|
+  pp source ;
+  [%expect
+    {|
     (Ok
      ((bindings
        ((test
          (Value
           (Function
            ((function_signature
-             ((function_params ((Y TypeType)))
+             ((function_params ((Y (TypeN 0))))
               (function_returns
                (FunctionType
-                ((function_params ((x TypeType))) (function_returns TypeType))))))
+                ((function_params ((x (TypeN 0)))) (function_returns (TypeN 0)))))))
             (function_impl
              (Fn
               ((Block
@@ -2053,16 +2054,16 @@ let%expect_test "dependent types" =
                   (Expr
                    (FunctionCall
                     ((ResolvedReference (identity <opaque>))
-                     ((Reference (Y TypeType))))))))))))))))
+                     ((Reference (Y (TypeN 0)))))))))))))))))
         (identity
          (Value
           (Function
            ((function_signature
-             ((function_params ((X TypeType)))
+             ((function_params ((X (TypeN 0))))
               (function_returns
                (FunctionType
-                ((function_params ((x (Dependent X TypeType))))
-                 (function_returns (Dependent X TypeType)))))))
+                ((function_params ((x (Dependent X (TypeN 0)))))
+                 (function_returns (Dependent X (TypeN 0))))))))
             (function_impl
              (Fn
               ((Block
@@ -2072,11 +2073,74 @@ let%expect_test "dependent types" =
                     (Function
                      ((function_signature
                        ((function_params
-                         ((x (ExprType (Reference (X TypeType))))))
-                        (function_returns (ExprType (Reference (X TypeType))))))
+                         ((x (ExprType (Reference (X (TypeN 0)))))))
+                        (function_returns (ExprType (Reference (X (TypeN 0)))))))
                       (function_impl
                        (Fn
                         ((Block
                           ((Break
                             (Expr
-                             (Reference (x (ExprType (Reference (X TypeType)))))))))))))))))))))))))))))) |}]
+                             (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))))))))))) |}]
+
+let%expect_test "TypeN" =
+  let source =
+    {|
+      fn id(X: Type) { X }
+      let must_fail = id(Type);
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Error
+     (((TypeError ((TypeN 0) (TypeN 1)))
+       ((bindings
+         ((must_fail (Value Void))
+          (id
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((X (TypeN 0)))) (function_returns (TypeN 0))))
+              (function_impl
+               (Fn ((Block ((Break (Expr (Reference (X (TypeN 0))))))))))))))
+          (Builder (Value (Type (BuiltinType Builder))))
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((bits IntegerType)))
+                (function_returns (TypeN 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (TypeN 0))))
+                (function_returns
+                 (FunctionType
+                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
+                   (function_returns (BuiltinType Builder)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (BinOp
+           (Value
+            (Type
+             (InterfaceType
+              ((interface_methods
+                ((op
+                  ((function_params ((left IntegerType) (right IntegerType)))
+                   (function_returns IntegerType))))))))))
+          (From
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (methods
+         (((Type (BuiltinType Builder))
+           ((new
+             ((function_signature
+               ((function_params ()) (function_returns (BuiltinType Builder))))
+              (function_impl (Fn ((Return (Primitive EmptyBuilder))))))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -2003,8 +2003,66 @@ let%expect_test "reference resolving in inner functions" =
              ((function_params ((X TypeType)))
               (function_returns
                (FunctionType
-                ((function_params ((x (ExprType (Reference (X TypeType))))))
-                 (function_returns (ExprType (Reference (X TypeType)))))))))
+                ((function_params ((x (Dependent X TypeType))))
+                 (function_returns (Dependent X TypeType)))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (Value
+                    (Function
+                     ((function_signature
+                       ((function_params
+                         ((x (ExprType (Reference (X TypeType))))))
+                        (function_returns (ExprType (Reference (X TypeType))))))
+                      (function_impl
+                       (Fn
+                        ((Block
+                          ((Break
+                            (Expr
+                             (Reference (x (ExprType (Reference (X TypeType)))))))))))))))))))))))))))))) |}]
+
+let%expect_test "dependent types" =
+  let source =
+    {|
+      fn identity(X: Type) {
+        fn(x: X) -> X { x }
+      }
+      fn test(Y: Type) {
+        identity(Y)
+      }
+    |}
+  in
+  pp source;
+  [%expect {|
+    (Ok
+     ((bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((Y TypeType)))
+              (function_returns
+               (FunctionType
+                ((function_params ((x TypeType))) (function_returns TypeType))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (FunctionCall
+                    ((ResolvedReference (identity <opaque>))
+                     ((Reference (Y TypeType))))))))))))))))
+        (identity
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((X TypeType)))
+              (function_returns
+               (FunctionType
+                ((function_params ((x (Dependent X TypeType))))
+                 (function_returns (Dependent X TypeType)))))))
             (function_impl
              (Fn
               ((Block


### PR DESCRIPTION
This PR fix dependent types resolving on function return type when this type must be depend on function argument from level higher.

Also this PR added initial type hierarchy.