### PR TITLE
Generalize allowed methods and impls definitions.

### DIFF
--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -136,16 +136,19 @@ class constructor (program : T.program) =
         F.FunctionCall (name, [struct_ty], field_ty)
       in
       match T.type_of from_expr with
-      (* TODO: return linealizing *)
-      | StructType s ->
+      | StructType s -> (
           let s = T.Program.get_struct program s in
-          let field_id, (_, field) =
-            Option.value_exn
-              (List.findi s.struct_fields ~f:(fun _ (name, _) ->
-                   equal_string name field ) )
-          in
-          build_access (self#cg_expr from_expr) field_id
-            (self#lang_type_to_type field.field_type)
+          match s.struct_fields with
+          | [_] ->
+              self#cg_expr from_expr
+          | _ ->
+              let field_id, (_, field) =
+                Option.value_exn
+                  (List.findi s.struct_fields ~f:(fun _ (name, _) ->
+                       equal_string name field ) )
+              in
+              build_access (self#cg_expr from_expr) field_id
+                (self#lang_type_to_type field.field_type) )
       | _ ->
           raise Invalid
 

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -100,9 +100,7 @@ and compile_from_string ?(codegen = Codegen_func.codegen)
   match Parser.program Lexer.token lexbuf with
   | stx -> (
       let errors = new Errors.errors Show.show_error in
-      let constructor =
-        new Lang.constructor Lang.default_bindings Lang.default_infos errors
-      in
+      let constructor = new Lang.constructor Lang.default_bindings errors in
       let program = constructor#visit_program () stx in
       match errors#to_result program with
       | Error _ ->

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -101,7 +101,7 @@ and compile_from_string ?(codegen = Codegen_func.codegen)
   | stx -> (
       let errors = new Errors.errors Show.show_error in
       let constructor =
-        new Lang.constructor Lang.default_bindings Lang.default_methods errors
+        new Lang.constructor Lang.default_bindings Lang.default_infos errors
       in
       let program = constructor#visit_program () stx in
       match errors#to_result program with

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -100,7 +100,9 @@ and compile_from_string ?(codegen = Codegen_func.codegen)
   match Parser.program Lexer.token lexbuf with
   | stx -> (
       let errors = new Errors.errors Show.show_error in
-      let constructor = new Lang.constructor Lang.default_bindings errors in
+      let constructor =
+        new Lang.constructor Lang.default_bindings Lang.default_structs errors
+      in
       let program = constructor#visit_program () stx in
       match errors#to_result program with
       | Error _ ->

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -105,12 +105,7 @@ class interpreter
               self#interpret_expr expr'
           | None ->
               errors#report `Error (`UnresolvedIdentifier name) () ;
-              Sexplib.Sexp.pp_hum Caml.Format.std_formatter
-                (sexp_of_list
-                   (sexp_of_list
-                      (Stdppx.sexp_of_pair sexp_of_string sexp_of_value) )
-                   vars_scope ) ;
-              raise InternalCompilerError )
+              Void )
         | StructField (struct_, field) -> (
           match self#interpret_expr struct_ with
           | Struct (struct_, struct') -> (

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -6,9 +6,30 @@ type error =
   [ `UnresolvedIdentifier of string
   | `UninterpretableStatement of stmt
   | `UnexpectedType of type_
-  | `FieldNotFound of struct_ * string
+  | `FieldNotFound of int * string
   | `ArgumentNumberMismatch ]
 [@@deriving equal, sexp_of]
+
+class ['s] struct_updater (old : int) (new_s : int) =
+  object
+    inherit ['s] map
+
+    method! visit_StructType _ s =
+      if equal_int s old then StructType new_s else StructType s
+  end
+
+let get_memoized_or_execute p (f, args) ~execute =
+  match
+    List.Assoc.find p.memoized_fcalls (f, args)
+      ~equal:(fun (f1, args1) (f2, args2) ->
+        equal_value f1 f2 && equal_list equal_value args1 args2 )
+  with
+  | Some v ->
+      v
+  | None ->
+      let res = execute f args in
+      p.memoized_fcalls <- ((f, args), res) :: p.memoized_fcalls ;
+      res
 
 (*TODO: type checks for arguments*)
 class interpreter
@@ -109,6 +130,52 @@ class interpreter
                so we do not need to check if union can be built from the expr. *)
             let data = self#interpret_expr expr in
             UnionVariant (data, union)
+        | MkStructDef {mk_struct_fields; mk_methods; mk_impls; mk_struct_id} ->
+            let struct_fields =
+              List.map mk_struct_fields ~f:(fun (name, field_type) ->
+                  ( name,
+                    { field_type =
+                        expr_to_type (Value (self#interpret_expr field_type)) }
+                  ) )
+            in
+            let struct_id = program.struct_counter in
+            program.struct_counter <- program.struct_counter + 1 ;
+            let struct_ty = struct_id in
+            let struct_ =
+              {struct_fields; struct_methods = []; struct_impls = []; struct_id}
+            in
+            let struct_updater = new struct_updater mk_struct_id struct_id in
+            let s =
+              Program.with_struct program struct_ (fun _ ->
+                  let struct_methods =
+                    List.map mk_methods ~f:(fun (name, fn) ->
+                        let prev_scope = vars_scope in
+                        vars_scope <-
+                          [("Self", Type (StructType struct_ty))] :: vars_scope ;
+                        let output =
+                          self#interpret_function
+                            (struct_updater#visit_function_ () fn)
+                        in
+                        vars_scope <- prev_scope ;
+                        (name, output) )
+                  in
+                  let struct_impls =
+                    List.map mk_impls ~f:(fun impl ->
+                        { impl_interface =
+                            Value (self#interpret_expr impl.impl_interface);
+                          impl_methods =
+                            List.map impl.impl_methods ~f:(fun (n, x) ->
+                                ( n,
+                                  Value
+                                    (self#interpret_expr
+                                       (struct_updater#visit_expr () x) ) ) ) } )
+                  in
+                  Ok {struct_fields; struct_methods; struct_impls; struct_id} )
+            in
+            let _ =
+              match s with Ok t -> t | Error _ -> raise InternalCompilerError
+            in
+            Type (StructType struct_ty)
         | Primitive _ | InvalidExpr | Hole ->
             errors#report `Error (`UninterpretableStatement (Expr expr)) () ;
             Void
@@ -117,16 +184,6 @@ class interpreter
       function
       | ExprType ex ->
           expr_to_type (Value (self#interpret_expr ex))
-      | StructType {struct_fields; struct_id} ->
-          let struct_fields =
-            List.map struct_fields ~f:(fun (name, {field_type}) ->
-                (name, {field_type = self#interpret_type field_type}) )
-          in
-          let s = {struct_fields; struct_id} in
-          if not (List.exists adding_structs ~f:(equal_struct_ s)) then
-            if is_immediate_expr (Value (Type (StructType s))) then
-              self#add_struct_to_program s ;
-          StructType {struct_fields; struct_id}
       | UnionType u ->
           UnionType {cases = List.map u.cases ~f:self#interpret_type}
       | ty ->
@@ -157,6 +214,7 @@ class interpreter
                   ~f:(fun (name, x) -> (name, self#interpret_type x));
               function_returns =
                 self#interpret_type f.function_signature.function_returns };
+          (* TODO: partial evaluation of fn *)
           function_impl = (match f.function_impl with Fn b -> Fn b | x -> x) }
 
     method interpret_fc : function_call -> value =
@@ -172,40 +230,35 @@ class interpreter
           | _ ->
               Error mk_err
         in
-        match self#interpret_expr func with
-        | Function f -> (
-          match f with
-          | { function_signature = {function_params; _};
-              function_impl = Fn function_impl;
-              _ } -> (
-              let args_scope = args_to_list function_params args' in
-              match args_scope with
-              | Ok args_scope -> (
-                match function_impl with
-                | Some body ->
-                    let prev_scope = vars_scope in
-                    vars_scope <- args_scope :: vars_scope ;
-                    let output = self#interpret_stmt body [] in
-                    vars_scope <- prev_scope ;
-                    output
-                | None ->
-                    Void )
-              | Error _ ->
+        let f = self#interpret_expr func in
+        get_memoized_or_execute program (f, args') ~execute:(fun f args' ->
+            match f with
+            | Function f -> (
+              match f with
+              | { function_signature = {function_params; _};
+                  function_impl = Fn function_impl;
+                  _ } -> (
+                  let args_scope = args_to_list function_params args' in
+                  match args_scope with
+                  | Ok args_scope -> (
+                    match function_impl with
+                    | Some body ->
+                        let prev_scope = vars_scope in
+                        vars_scope <- args_scope :: vars_scope ;
+                        let output = self#interpret_stmt body [] in
+                        vars_scope <- prev_scope ;
+                        output
+                    | None ->
+                        Void )
+                  | Error _ ->
+                      Void )
+              | {function_impl = BuiltinFn (function_impl, _); _} ->
+                  let value = function_impl program args' in
+                  value
+              | _ ->
                   Void )
-          | {function_impl = BuiltinFn (function_impl, _); _} ->
-              let program' =
-                { program with
-                  bindings =
-                    extract_comptime_bindings
-                      (Option.value (List.hd global_bindings) ~default:[]) }
-              in
-              let value = function_impl program' args' in
-              program.infos <- program'.infos ;
-              value
-          | _ ->
-              Void )
-        | _ ->
-            Void
+            | _ ->
+                Void )
 
     method private find_ref : string -> expr option =
       fun ref ->
@@ -236,45 +289,4 @@ class interpreter
             Some v
         | None ->
             None
-
-    method private add_struct_to_program struct_ =
-      let prev_structs = adding_structs in
-      adding_structs <- struct_ :: adding_structs ;
-      let add_infos () =
-        if
-          not
-            (List.exists program.infos ~f:(fun (s, _) ->
-                 equal_value s (Type (StructType struct_)) ) )
-        then
-          match
-            List.find_map program.def_infos ~f:(fun (v, info) ->
-                match v with
-                | Type (StructType s) ->
-                    if equal_struct_ s struct_ then Some info else None
-                | _ ->
-                    None )
-          with
-          | Some info ->
-              let methods_monomorphed =
-                List.map info.methods ~f:(fun (name, f) ->
-                    (name, self#interpret_function f) )
-              in
-              let impls_monomorphed =
-                List.map info.impls ~f:(fun impl ->
-                    { impl_interface =
-                        Value (self#interpret_expr impl.impl_interface);
-                      impl_methods =
-                        List.map impl.impl_methods ~f:(fun (n, x) ->
-                            (n, Value (self#interpret_expr x)) ) } )
-              in
-              program.infos <-
-                ( Type (StructType struct_),
-                  {impls = impls_monomorphed; methods = methods_monomorphed} )
-                :: program.infos
-          | None ->
-              ()
-      in
-      add_infos () ;
-      adding_structs <- prev_structs ;
-      ()
   end

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -64,8 +64,8 @@ functor
           {function_params; function_returns}
       end
 
-    class ['s] constructor (bindings : (string * expr) list) (errors : _ errors)
-      =
+    class ['s] constructor (bindings : (string * expr) list)
+      (structs : (int * struct_) list) (errors : _ errors) =
       object (s : 's)
         inherit ['s] Syntax.visitor as super
 
@@ -78,9 +78,10 @@ functor
         val mutable functions = 0
 
         (* TODO: can we remove duplicating bindings here and the above? *)
-        (* Program handle we pass to builtin functions *)
+        (* Program handle we pass to builtin functions. *)
+        (* IDs from 0 to 99 inlusevily is reserved for built-in structs. *)
         val mutable program =
-          {bindings; structs = []; struct_counter = 0; memoized_fcalls = []}
+          {bindings; structs; struct_counter = 100; memoized_fcalls = []}
 
         method build_CodeBlock _env code_block =
           Block (s#of_located_list code_block)

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -467,23 +467,7 @@ functor
             ( Type (StructType struct_),
               {methods = struct_methods @ impl_methods; impls} )
             :: program.def_infos ;
-          match
-            is_immediate_expr (Value (Type (StructType struct_)))
-            && List.for_all struct_methods ~f:(fun (_, x) ->
-                   is_immediate_expr (Value (Function x)) )
-            && List.for_all impls ~f:(fun i ->
-                   is_immediate_expr i.impl_interface
-                   && List.for_all i.impl_methods ~f:(fun (_, x) ->
-                          is_immediate_expr x ) )
-          with
-          | true ->
-              program.infos <-
-                ( Type (StructType struct_),
-                  {methods = struct_methods @ impl_methods; impls} )
-                :: program.infos ;
-              struct_
-          | false ->
-              struct_
+          struct_
 
         method build_struct_field _env field_name field_type =
           ( Syntax.value field_name,

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -12,7 +12,7 @@ functor
     module Syntax = Syntax.Make (Config)
 
     type error =
-      [ `DuplicateField of string * struct_
+      [ `DuplicateField of string * mk_struct
       | `UnresolvedIdentifier of string
       | `MethodNotFound of expr * string
       | `UnexpectedType of type_
@@ -64,8 +64,8 @@ functor
           {function_params; function_returns}
       end
 
-    class ['s] constructor (bindings : (string * expr) list)
-      (infos : (value * struct_info) list) (errors : _ errors) =
+    class ['s] constructor (bindings : (string * expr) list) (errors : _ errors)
+      =
       object (s : 's)
         inherit ['s] Syntax.visitor as super
 
@@ -79,7 +79,8 @@ functor
 
         (* TODO: can we remove duplicating bindings here and the above? *)
         (* Program handle we pass to builtin functions *)
-        val program = {bindings; infos; def_infos = []}
+        val mutable program =
+          {bindings; structs = []; struct_counter = 0; memoized_fcalls = []}
 
         method build_CodeBlock _env code_block =
           Block (s#of_located_list code_block)
@@ -121,7 +122,8 @@ functor
                       new interpreter
                         (program, current_bindings, errors, functions)
                     in
-                    Value (inter#interpret_fc fc)
+                    let fc = inter#interpret_fc fc in
+                    Value fc
                   else FunctionCall fc
               | _ ->
                   Value Void )
@@ -219,7 +221,7 @@ functor
           | stmt ->
               Break stmt
 
-        method build_Struct _env s = Value (Type (StructType s))
+        method build_Struct _env s = MkStructDef s
 
         method build_StructConstructor _env sc = Value (Struct sc)
 
@@ -267,53 +269,27 @@ functor
                    } ),
               [] )
           in
+          let make_call receiver ~mk_args =
+            let receiver' = Value (Type (StructType receiver)) in
+            match
+              (Program.get_struct program receiver).struct_methods
+              |> fun ms -> List.Assoc.find ms fn ~equal:String.equal
+            with
+            | Some fn' ->
+                ( ResolvedReference (fn, Value (Function fn')),
+                  mk_args (s#of_located_list args) )
+            | None ->
+                errors#report `Error (`MethodNotFound (receiver', fn)) () ;
+                dummy
+          in
           (* TODO: check method signatures *)
           match receiver with
-          | ResolvedReference (_, Value (Type ty)) | Value (Type ty) -> (
-              let receiver' = Value (Type ty) in
-              let info =
-                List.Assoc.find program.infos ~equal:equal_value (Type ty)
-              in
-              match
-                Option.bind info ~f:(fun info ->
-                    List.Assoc.find info.methods ~equal:String.equal fn )
-              with
-              | Some fn' ->
-                  ( ResolvedReference (fn, Value (Function fn')),
-                    s#of_located_list args )
-              | None ->
-                  errors#report `Error (`MethodNotFound (receiver', fn)) () ;
-                  dummy )
-          | ResolvedReference (_, Value (Struct (struct', _)))
-          | Value (Struct (struct', _)) -> (
-              let receiver' = Value (Type (StructType struct')) in
-              let info =
-                List.Assoc.find program.infos ~equal:equal_value
-                  (Type (StructType struct'))
-              in
-              match
-                Option.bind info ~f:(fun info ->
-                    List.Assoc.find info.methods ~equal:String.equal fn )
-              with
-              | Some fn' ->
-                  ( ResolvedReference (fn, Value (Function fn')),
-                    receiver :: s#of_located_list args )
-              | None ->
-                  errors#report `Error (`MethodNotFound (receiver', fn)) () ;
-                  dummy )
-          | ResolvedReference (_, Value v) | Value v -> (
-              let receiver' = Value v in
-              let info = List.Assoc.find program.infos ~equal:equal_value v in
-              match
-                Option.bind info ~f:(fun info ->
-                    List.Assoc.find info.methods ~equal:String.equal fn )
-              with
-              | Some fn' ->
-                  ( ResolvedReference (fn, Value (Function fn')),
-                    receiver :: s#of_located_list args )
-              | None ->
-                  errors#report `Error (`MethodNotFound (receiver', fn)) () ;
-                  dummy )
+          | ResolvedReference (_, Value (Type (StructType st)))
+          | Value (Type (StructType st)) ->
+              make_call st ~mk_args:(fun x -> x)
+          | ResolvedReference (_, Value (Struct (st, _)))
+          | Value (Struct (st, _)) ->
+              make_call st ~mk_args:(fun args -> receiver :: args)
           | receiver' ->
               errors#report `Error (`UnexpectedType (type_of receiver')) () ;
               dummy
@@ -405,46 +381,11 @@ functor
                     (Syntax.value name, Syntax.value expr) ) )
           | e ->
               errors#report `Error (`UnexpectedType (type_of e)) () ;
-              ({struct_fields = []; struct_id = 0}, [])
+              (-1, [])
 
-        method build_struct_definition _env struct_fields _bindings _intfs =
-          let struct_fields = s#of_located_list struct_fields in
-          let s' = {struct_fields; struct_id = !struct_counter} in
-          (* Check for duplicate fields *)
-          ( match
-              List.find_a_dup struct_fields
-                ~compare:(fun (name1, _) (name2, _) ->
-                  String.compare name1 name2 )
-            with
-          | Some (name, _) ->
-              errors#report `Error (`DuplicateField (name, s')) ()
-          | None ->
-              () ) ;
-          (* Increment next struct's ID *)
-          struct_counter := !struct_counter + 1 ;
-          s'
-
-        method! visit_struct_definition env _visitors_this =
-          let _visitors_r0 =
-            s#visit_list
-              (s#visit_located s#visit_struct_field)
-              env _visitors_this.fields
-          in
-          let struct_ = s#build_struct_definition env _visitors_r0 [] [] in
-          let bindings =
-            s#with_bindings
-              [make_comptime ("Self", Value (Type (StructType struct_)))]
-              (fun _ ->
-                s#visit_list
-                  (s#visit_located s#visit_binding)
-                  env _visitors_this.struct_bindings )
-          in
-          let impls =
-            s#with_bindings
-              [make_comptime ("Self", Value (Type (StructType struct_)))]
-              (fun _ -> s#visit_list s#visit_impl env _visitors_this.impls)
-          in
-          let struct_methods =
+        method build_struct_definition _env struct_fields bindings impls =
+          let mk_struct_fields = s#of_located_list struct_fields in
+          let mk_methods =
             List.filter_map bindings ~f:(fun binding ->
                 let name, expr = Syntax.value binding in
                 match expr with
@@ -463,15 +404,73 @@ functor
                        | _ ->
                            None ) ) )
           in
-          program.def_infos <-
-            ( Type (StructType struct_),
-              {methods = struct_methods @ impl_methods; impls} )
-            :: program.def_infos ;
-          struct_
+          let s' =
+            { mk_struct_fields;
+              mk_methods = mk_methods @ impl_methods;
+              mk_impls = impls;
+              mk_struct_id = -1 }
+          in
+          (* Check for duplicate fields *)
+          ( match
+              List.find_a_dup mk_struct_fields
+                ~compare:(fun (name1, _) (name2, _) ->
+                  String.compare name1 name2 )
+            with
+          | Some (name, _) ->
+              errors#report `Error (`DuplicateField (name, s')) ()
+          | None ->
+              () ) ;
+          s'
 
-        method build_struct_field _env field_name field_type =
-          ( Syntax.value field_name,
-            {field_type = expr_to_type (Syntax.value field_type)} )
+        method! visit_struct_definition env syn_struct_def =
+          let fields =
+            s#visit_list
+              (s#visit_located s#visit_struct_field)
+              env syn_struct_def.fields
+          in
+          let struct_ =
+            { struct_fields =
+                List.map (s#of_located_list fields) ~f:(fun (name, expr) ->
+                    (name, {field_type = ExprType expr}) );
+              struct_methods = [];
+              struct_impls = [];
+              struct_id = program.struct_counter }
+          in
+          program.struct_counter <- program.struct_counter + 1 ;
+          let mk_struct =
+            Program.with_struct program struct_ (fun _ ->
+                let methods =
+                  s#with_bindings
+                    [ make_comptime
+                        ("Self", Value (Type (StructType struct_.struct_id))) ]
+                    (fun _ ->
+                      s#visit_list
+                        (s#visit_located s#visit_binding)
+                        env syn_struct_def.struct_bindings )
+                in
+                let impls =
+                  s#with_bindings
+                    [ make_comptime
+                        ("Self", Value (Type (StructType struct_.struct_id))) ]
+                    (fun _ -> s#visit_list s#visit_impl env syn_struct_def.impls)
+                in
+                let mk_struct =
+                  s#build_struct_definition env fields methods impls
+                in
+                Error {mk_struct with mk_struct_id = struct_.struct_id} )
+          in
+          let mk_struct =
+            match mk_struct with
+            | Error mk ->
+                mk
+            | Ok _ ->
+                raise InternalCompilerError
+          in
+          mk_struct
+
+        method build_struct_field : _ -> _ -> _ -> string * expr =
+          fun _env field_name field_type ->
+            (Syntax.value field_name, Syntax.value field_type)
 
         method build_union_definition _env members _bindings =
           {cases = List.map (s#of_located_list members) ~f:expr_to_type}

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -365,4 +365,13 @@ module Program = struct
     let new_s = f () in
     p.structs <- update_list s.struct_id new_s p.structs ;
     new_s
+
+  (* Creates new struct id, calls function with this new id and then
+     places returning struct to the program.structs *)
+  let with_id p f =
+    let id = p.struct_counter in
+    p.struct_counter <- p.struct_counter + 1 ;
+    let new_s = f id in
+    p.structs <- (id, new_s) :: p.structs ;
+    new_s
 end

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -35,11 +35,12 @@ and binding_scope = Comptime of expr | Runtime of type_
 
 and program =
   { bindings : (string * expr) list;
-    mutable methods : (value * (string * function_) list) list; [@sexp.list]
-    mutable impls : (value * impl list) list; [@sexp.list]
-    mutable methods_defs : (value * (string * function_) list) list;
-        [@sexp.list]
-    mutable impls_defs : (value * impl list) list [@sexp.list] }
+    mutable infos : (value * struct_info) list;
+    mutable def_infos : (value * struct_info) list }
+
+and struct_info =
+  { mutable methods : (string * function_) list; [@sexp.list]
+    mutable impls : impl list [@sexp.list] }
 
 and expr =
   | FunctionCall of function_call

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -69,9 +69,8 @@ functor
           pp_print_string f "<anonymous>"
 
     let show_error : error -> string = function
-      | `DuplicateField (field, s) ->
-          Printf.sprintf "Duplicate field `%s` in the `%i` struct." field
-            s.struct_id
+      | `DuplicateField (field, _) ->
+          Printf.sprintf "Duplicate field `%s`." field
       | `UnresolvedIdentifier id ->
           Printf.sprintf "Unresolved identifier `%s`." id
       | `MethodNotFound (e, m) ->

--- a/lib/type_check.ml
+++ b/lib/type_check.ml
@@ -52,10 +52,10 @@ class type_checker (errors : _) (functions : _) =
             Value (inter#interpret_fc (from_intf, [Value (Type actual)]))
           in
           let impl =
-            List.find_map program.impls ~f:(fun (s, impls) ->
+            List.find_map program.infos ~f:(fun (s, info) ->
                 match equal_value s (Type x) with
                 | true ->
-                    List.find_map impls ~f:(fun i ->
+                    List.find_map info.impls ~f:(fun i ->
                         if equal_expr i.impl_interface from_intf_ then
                           Some i.impl_methods
                         else None )

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -12,32 +12,33 @@ let%expect_test "Int(bits) constructor" =
     {|
     (Ok
      ((bindings
-       ((overflow (Value (Struct (0 ((integer (Value (Integer 513))))))))
-        (i (Value (Struct (0 ((integer (Value (Integer 100))))))))))
+       ((overflow (Value (Struct (100 ((integer (Value (Integer 513))))))))
+        (i (Value (Struct (100 ((integer (Value (Integer 100))))))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
@@ -58,42 +59,42 @@ let%expect_test "Int(bits) serializer" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((b (BuiltinType Builder))))
-              (function_returns HoleType)))
+             ((function_params ((b (StructType 0)))) (function_returns HoleType)))
             (function_impl
              (Fn
               ((Block
                 ((Let
-                  ((i (Value (Struct (0 ((integer (Value (Integer 100))))))))))
+                  ((i (Value (Struct (100 ((integer (Value (Integer 100))))))))))
                  (Expr
                   (FunctionCall
                    ((ResolvedReference (serialize <opaque>))
                     ((ResolvedReference (i <opaque>))
-                     (Reference (b (BuiltinType Builder))))))))))))))))))
+                     (Reference (b (StructType 0))))))))))))))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 32)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "demo struct serializer" =
@@ -114,267 +115,119 @@ let%expect_test "demo struct serializer" =
   pp source ;
   [%expect
     {|
-    (Error
-     (((UnexpectedType (TypeN 0))
-       ((bindings
-         ((test
-           (Value
-            (Function
+    (Ok
+     ((bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ()) (function_returns HoleType)))
+            (function_impl
+             (Fn
+              ((Block
+                ((Let
+                  ((b (FunctionCall ((ResolvedReference (new <opaque>)) ())))))
+                 (Expr
+                  (FunctionCall
+                   ((ResolvedReference (T_serializer <opaque>))
+                    ((Value
+                      (Struct
+                       (101
+                        ((a
+                          (Value (Struct (100 ((integer (Value (Integer 0))))))))
+                         (b
+                          (Value (Struct (100 ((integer (Value (Integer 1))))))))))))
+                     (Reference (b (StructType 0))))))))))))))))
+        (T_serializer
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((self (StructType 101)) (b (StructType 0))))
+              (function_returns (StructType 0))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Let
+                  ((b
+                    (FunctionCall
+                     ((Value
+                       (Function
+                        ((function_signature
+                          ((function_params
+                            ((self (StructType 100)) (b (StructType 0))))
+                           (function_returns (StructType 0))))
+                         (function_impl
+                          (Fn
+                           ((Return
+                             (Primitive
+                              (StoreInt
+                               (builder
+                                (StructField
+                                 ((Reference (b (StructType 0))) builder)))
+                               (length (Value (Integer 32)))
+                               (integer
+                                (StructField
+                                 ((Reference (self (StructType 100))) integer)))
+                               (signed true))))))))))
+                      ((StructField ((Reference (self (StructType 101))) a))
+                       (Reference (b (StructType 0)))))))))
+                 (Let
+                  ((b
+                    (FunctionCall
+                     ((Value
+                       (Function
+                        ((function_signature
+                          ((function_params
+                            ((self (StructType 100)) (b (StructType 0))))
+                           (function_returns (StructType 0))))
+                         (function_impl
+                          (Fn
+                           ((Return
+                             (Primitive
+                              (StoreInt
+                               (builder
+                                (StructField
+                                 ((Reference (b (StructType 0))) builder)))
+                               (length (Value (Integer 32)))
+                               (integer
+                                (StructField
+                                 ((Reference (self (StructType 100))) integer)))
+                               (signed true))))))))))
+                      ((StructField ((Reference (self (StructType 101))) b))
+                       (Reference (b (StructType 0)))))))))
+                 (Return (Reference (b (StructType 0)))))))))))))
+        (T (Value (Type (StructType 101))))))
+      (structs
+       ((101
+         ((struct_fields
+           ((a ((field_type (StructType 100))))
+            (b ((field_type (StructType 100))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 101)))
+        (100
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
              ((function_signature
-               ((function_params ()) (function_returns HoleType)))
-              (function_impl
-               (Fn ((Block ((Let ((b (Value Void)))) (Expr (Value Void)))))))))))
-          (T_serializer
-           (Value
-            (Function
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 100))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 1)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Block
-                  ((Let
-                    ((b
-                      (FunctionCall
-                       ((Value
-                         (Function
-                          ((function_signature
-                            ((function_params
-                              ((self (StructType 0)) (b (BuiltinType Builder))))
-                             (function_returns (BuiltinType Builder))))
-                           (function_impl
-                            (Fn
-                             ((Return
-                               (Primitive
-                                (StoreInt
-                                 (builder (Reference (b (BuiltinType Builder))))
-                                 (length (Value (Integer 32)))
-                                 (integer
-                                  (StructField
-                                   ((Reference (self (StructType 0))) integer)))
-                                 (signed true))))))))))
-                        ((StructField ((Reference (self (StructType 1))) a))
-                         (Reference (b (BuiltinType Builder)))))))))
-                   (Let
-                    ((b
-                      (FunctionCall
-                       ((Value
-                         (Function
-                          ((function_signature
-                            ((function_params
-                              ((self (StructType 0)) (b (BuiltinType Builder))))
-                             (function_returns (BuiltinType Builder))))
-                           (function_impl
-                            (Fn
-                             ((Return
-                               (Primitive
-                                (StoreInt
-                                 (builder (Reference (b (BuiltinType Builder))))
-                                 (length (Value (Integer 32)))
-                                 (integer
-                                  (StructField
-                                   ((Reference (self (StructType 0))) integer)))
-                                 (signed true))))))))))
-                        ((StructField ((Reference (self (StructType 1))) b))
-                         (Reference (b (BuiltinType Builder)))))))))
-                   (Return (Reference (b (BuiltinType Builder)))))))))))))
-          (T (Value (Type (StructType 1))))
-          (Builder (Value (Type (BuiltinType Builder))))
-          (Integer (Value (Type IntegerType)))
-          (Int
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((bits IntegerType)))
-                (function_returns (TypeN 0))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
-          (Void (Value Void))
-          (serializer
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((t (TypeN 0))))
-                (function_returns
-                 (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (BinOp
-           (Value
-            (Type
-             (InterfaceType
-              ((interface_methods
-                ((op
-                  ((function_params ((left IntegerType) (right IntegerType)))
-                   (function_returns IntegerType))))))))))
-          (From
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (structs
-         ((1
-           ((struct_fields
-             ((a ((field_type (StructType 0))))
-              (b ((field_type (StructType 0))))))
-            (struct_methods ()) (struct_impls ()) (struct_id 1)))
-          (0
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_methods
-             ((new
-               ((function_signature
-                 ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
-                (function_impl (BuiltinFn (<fun> <opaque>)))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
-                (function_impl
-                 (Fn
-                  ((Return
-                    (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                      (length (Value (Integer 32)))
-                      (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
-                      (signed true)))))))))))
-            (struct_impls ()) (struct_id 0)))))
-        (struct_counter <opaque>) (memoized_fcalls <opaque>)))
-      ((TypeError ((BuiltinType Builder) VoidType))
-       ((bindings
-         ((test
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ()) (function_returns HoleType)))
-              (function_impl
-               (Fn ((Block ((Let ((b (Value Void)))) (Expr (Value Void)))))))))))
-          (T_serializer
-           (Value
-            (Function
-             ((function_signature
-               ((function_params
-                 ((self (StructType 1)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
-                ((Block
-                  ((Let
-                    ((b
-                      (FunctionCall
-                       ((Value
-                         (Function
-                          ((function_signature
-                            ((function_params
-                              ((self (StructType 0)) (b (BuiltinType Builder))))
-                             (function_returns (BuiltinType Builder))))
-                           (function_impl
-                            (Fn
-                             ((Return
-                               (Primitive
-                                (StoreInt
-                                 (builder (Reference (b (BuiltinType Builder))))
-                                 (length (Value (Integer 32)))
-                                 (integer
-                                  (StructField
-                                   ((Reference (self (StructType 0))) integer)))
-                                 (signed true))))))))))
-                        ((StructField ((Reference (self (StructType 1))) a))
-                         (Reference (b (BuiltinType Builder)))))))))
-                   (Let
-                    ((b
-                      (FunctionCall
-                       ((Value
-                         (Function
-                          ((function_signature
-                            ((function_params
-                              ((self (StructType 0)) (b (BuiltinType Builder))))
-                             (function_returns (BuiltinType Builder))))
-                           (function_impl
-                            (Fn
-                             ((Return
-                               (Primitive
-                                (StoreInt
-                                 (builder (Reference (b (BuiltinType Builder))))
-                                 (length (Value (Integer 32)))
-                                 (integer
-                                  (StructField
-                                   ((Reference (self (StructType 0))) integer)))
-                                 (signed true))))))))))
-                        ((StructField ((Reference (self (StructType 1))) b))
-                         (Reference (b (BuiltinType Builder)))))))))
-                   (Return (Reference (b (BuiltinType Builder)))))))))))))
-          (T (Value (Type (StructType 1))))
-          (Builder (Value (Type (BuiltinType Builder))))
-          (Integer (Value (Type IntegerType)))
-          (Int
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((bits IntegerType)))
-                (function_returns (TypeN 0))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
-          (Void (Value Void))
-          (serializer
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((t (TypeN 0))))
-                (function_returns
-                 (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))
-          (BinOp
-           (Value
-            (Type
-             (InterfaceType
-              ((interface_methods
-                ((op
-                  ((function_params ((left IntegerType) (right IntegerType)))
-                   (function_returns IntegerType))))))))))
-          (From
-           (Value
-            (Function
-             ((function_signature
-               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (structs
-         ((1
-           ((struct_fields
-             ((a ((field_type (StructType 0))))
-              (b ((field_type (StructType 0))))))
-            (struct_methods ()) (struct_impls ()) (struct_id 1)))
-          (0
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_methods
-             ((new
-               ((function_signature
-                 ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
-                (function_impl (BuiltinFn (<fun> <opaque>)))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
-                (function_impl
-                 (Fn
-                  ((Return
-                    (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                      (length (Value (Integer 32)))
-                      (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
-                      (signed true)))))))))))
-            (struct_impls ()) (struct_id 0)))))
-        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
+                ((Return
+                  (Primitive
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
+                    (length (Value (Integer 32)))
+                    (integer
+                     (StructField ((Reference (self (StructType 100))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 100)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "from interface" =
   let source =
@@ -397,29 +250,30 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var (Value (Struct (0 ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (100 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params ((y (StructType 1))))
-              (function_returns (StructType 1))))
+             ((function_params ((y (StructType 101))))
+              (function_returns (StructType 101))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (y (StructType 1))))))))))))))
-        (Value (Value (Type (StructType 1))))))
+             (Fn ((Block ((Break (Expr (Reference (y (StructType 101))))))))))))))
+        (Value (Value (Type (StructType 101))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ((a ((field_type IntegerType)))))
           (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns (StructType 1))))
+                (function_returns (StructType 101))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
-                    (Expr (Value (Struct (0 ((a (Reference (x IntegerType))))))))))))))))))
+                    (Expr
+                     (Value (Struct (100 ((a (Reference (x IntegerType))))))))))))))))))
           (struct_impls
            (((impl_interface
               (Value
@@ -435,12 +289,13 @@ let%expect_test "from interface" =
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns (StructType 1))))
+                     (function_returns (StructType 101))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
-                          (Value (Struct (0 ((a (Reference (x IntegerType)))))))))))))))))))))))
-          (struct_id 1)))))
+                          (Value
+                           (Struct (100 ((a (Reference (x IntegerType)))))))))))))))))))))))
+          (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -8,23 +8,36 @@ let%expect_test "Int(bits) constructor" =
     |}
   in
   pp source ;
-  [%expect
-    {|
+  [%expect{|
     (Ok
      ((bindings
-       ((overflow
-         (Value
-          (Struct
-           (((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((integer (Value (Integer 1))))))))
-        (i
-         (Value
-          (Struct
-           (((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((integer (Value (Integer 100))))))))))
-      (infos ()) (def_infos ()))) |}]
+       ((overflow (Value (Struct (0 ((integer (Value (Integer 513))))))))
+        (i (Value (Struct (0 ((integer (Value (Integer 100))))))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
   let source =
@@ -36,32 +49,50 @@ let%expect_test "Int(bits) serializer" =
     |}
   in
   pp source ;
-  [%expect
-    {|
-      (Ok
-       ((bindings
-         ((test
-           (Value
-            (Function
+  [%expect{|
+    (Ok
+     ((bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((b (BuiltinType Builder))))
+              (function_returns HoleType)))
+            (function_impl
+             (Fn
+              ((Block
+                ((Let
+                  ((i (Value (Struct (0 ((integer (Value (Integer 100))))))))))
+                 (Expr
+                  (FunctionCall
+                   ((ResolvedReference (serialize <opaque>))
+                    ((ResolvedReference (i <opaque>))
+                     (Reference (b (BuiltinType Builder))))))))))))))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
              ((function_signature
-               ((function_params ((b (BuiltinType Builder))))
-                (function_returns HoleType)))
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
               (function_impl
                (Fn
-                ((Block
-                  ((Let
-                    ((i
-                      (Value
-                       (Struct
-                        (((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))
-                         ((integer (Value (Integer 100))))))))))
-                   (Expr
-                    (FunctionCall
-                     ((ResolvedReference (serialize <opaque>))
-                      ((ResolvedReference (i <opaque>))
-                       (Reference (b (BuiltinType Builder))))))))))))))))))
-        (infos ()) (def_infos ()))) |}]
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 32)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "demo struct serializer" =
   let source =
@@ -79,214 +110,268 @@ let%expect_test "demo struct serializer" =
     |}
   in
   pp source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((test
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ()) (function_returns HoleType)))
-            (function_impl
-             (Fn
-              ((Block
-                ((Let
-                  ((b (FunctionCall ((ResolvedReference (new <opaque>)) ())))))
-                 (Expr
-                  (FunctionCall
-                   ((ResolvedReference (T_serializer <opaque>))
-                    ((Value
-                      (Struct
-                       (((struct_fields
-                          ((a
-                            ((field_type
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))))
-                           (b
-                            ((field_type
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))))))
-                         (struct_id <opaque>))
-                        ((a
-                          (Value
-                           (Struct
-                            (((struct_fields
-                               ((integer ((field_type IntegerType)))))
-                              (struct_id <opaque>))
-                             ((integer (Value (Integer 0))))))))
-                         (b
-                          (Value
-                           (Struct
-                            (((struct_fields
-                               ((integer ((field_type IntegerType)))))
-                              (struct_id <opaque>))
-                             ((integer (Value (Integer 1))))))))))))
-                     (Reference (b (BuiltinType Builder))))))))))))))))
-        (T_serializer
-         (Value
-          (Function
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields
-                    ((a
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))
-                     (b
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Let
-                  ((b
-                    (FunctionCall
-                     ((Value
-                       (Function
-                        ((function_signature
-                          ((function_params
-                            ((self
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))
-                             (b (BuiltinType Builder))))
-                           (function_returns (BuiltinType Builder))))
-                         (function_impl
-                          (Fn
-                           ((Return
-                             (Primitive
-                              (StoreInt
-                               (builder (Reference (b (BuiltinType Builder))))
-                               (length (Value (Integer 32)))
-                               (integer
-                                (StructField
-                                 ((Reference
-                                   (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer ((field_type IntegerType)))))
-                                      (struct_id <opaque>)))))
-                                  integer)))
-                               (signed true))))))))))
-                      ((StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((a
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))
-                               (b
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))))
-                             (struct_id <opaque>)))))
-                         a))
-                       (Reference (b (BuiltinType Builder)))))))))
-                 (Let
-                  ((b
-                    (FunctionCall
-                     ((Value
-                       (Function
-                        ((function_signature
-                          ((function_params
-                            ((self
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))
-                             (b (BuiltinType Builder))))
-                           (function_returns (BuiltinType Builder))))
-                         (function_impl
-                          (Fn
-                           ((Return
-                             (Primitive
-                              (StoreInt
-                               (builder (Reference (b (BuiltinType Builder))))
-                               (length (Value (Integer 16)))
-                               (integer
-                                (StructField
-                                 ((Reference
-                                   (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer ((field_type IntegerType)))))
-                                      (struct_id <opaque>)))))
-                                  integer)))
-                               (signed true))))))))))
-                      ((StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((a
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))
-                               (b
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))))
-                             (struct_id <opaque>)))))
-                         b))
-                       (Reference (b (BuiltinType Builder)))))))))
-                 (Return (Reference (b (BuiltinType Builder)))))))))))))
-        (T
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((a
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))
-               (b
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))))
-             (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
+  [%expect{|
+    (Error
+     (((UnexpectedType (TypeN 0))
+       ((bindings
+         ((test
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ()) (function_returns HoleType)))
+              (function_impl
+               (Fn ((Block ((Let ((b (Value Void)))) (Expr (Value Void)))))))))))
+          (T_serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params
+                 ((self (StructType 1)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((b
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((self (StructType 0)) (b (BuiltinType Builder))))
+                             (function_returns (BuiltinType Builder))))
+                           (function_impl
+                            (Fn
+                             ((Return
+                               (Primitive
+                                (StoreInt
+                                 (builder (Reference (b (BuiltinType Builder))))
+                                 (length (Value (Integer 32)))
+                                 (integer
+                                  (StructField
+                                   ((Reference (self (StructType 0))) integer)))
+                                 (signed true))))))))))
+                        ((StructField ((Reference (self (StructType 1))) a))
+                         (Reference (b (BuiltinType Builder)))))))))
+                   (Let
+                    ((b
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((self (StructType 0)) (b (BuiltinType Builder))))
+                             (function_returns (BuiltinType Builder))))
+                           (function_impl
+                            (Fn
+                             ((Return
+                               (Primitive
+                                (StoreInt
+                                 (builder (Reference (b (BuiltinType Builder))))
+                                 (length (Value (Integer 32)))
+                                 (integer
+                                  (StructField
+                                   ((Reference (self (StructType 0))) integer)))
+                                 (signed true))))))))))
+                        ((StructField ((Reference (self (StructType 1))) b))
+                         (Reference (b (BuiltinType Builder)))))))))
+                   (Return (Reference (b (BuiltinType Builder)))))))))))))
+          (T (Value (Type (StructType 1))))
+          (Builder (Value (Type (BuiltinType Builder))))
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((bits IntegerType)))
+                (function_returns (TypeN 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (TypeN 0))))
+                (function_returns
+                 (FunctionType
+                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
+                   (function_returns (BuiltinType Builder)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (BinOp
+           (Value
+            (Type
+             (InterfaceType
+              ((interface_methods
+                ((op
+                  ((function_params ((left IntegerType) (right IntegerType)))
+                   (function_returns IntegerType))))))))))
+          (From
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (structs
+         ((1
            ((struct_fields
-             ((a
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (b
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ()))))) |}]
+             ((a ((field_type (StructType 0))))
+              (b ((field_type (StructType 0))))))
+            (struct_methods ()) (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns (StructType 0))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 32)))
+                      (integer
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>)))
+      ((TypeError ((BuiltinType Builder) VoidType))
+       ((bindings
+         ((test
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ()) (function_returns HoleType)))
+              (function_impl
+               (Fn ((Block ((Let ((b (Value Void)))) (Expr (Value Void)))))))))))
+          (T_serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params
+                 ((self (StructType 1)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((b
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((self (StructType 0)) (b (BuiltinType Builder))))
+                             (function_returns (BuiltinType Builder))))
+                           (function_impl
+                            (Fn
+                             ((Return
+                               (Primitive
+                                (StoreInt
+                                 (builder (Reference (b (BuiltinType Builder))))
+                                 (length (Value (Integer 32)))
+                                 (integer
+                                  (StructField
+                                   ((Reference (self (StructType 0))) integer)))
+                                 (signed true))))))))))
+                        ((StructField ((Reference (self (StructType 1))) a))
+                         (Reference (b (BuiltinType Builder)))))))))
+                   (Let
+                    ((b
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((self (StructType 0)) (b (BuiltinType Builder))))
+                             (function_returns (BuiltinType Builder))))
+                           (function_impl
+                            (Fn
+                             ((Return
+                               (Primitive
+                                (StoreInt
+                                 (builder (Reference (b (BuiltinType Builder))))
+                                 (length (Value (Integer 32)))
+                                 (integer
+                                  (StructField
+                                   ((Reference (self (StructType 0))) integer)))
+                                 (signed true))))))))))
+                        ((StructField ((Reference (self (StructType 1))) b))
+                         (Reference (b (BuiltinType Builder)))))))))
+                   (Return (Reference (b (BuiltinType Builder)))))))))))))
+          (T (Value (Type (StructType 1))))
+          (Builder (Value (Type (BuiltinType Builder))))
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((bits IntegerType)))
+                (function_returns (TypeN 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (TypeN 0))))
+                (function_returns
+                 (FunctionType
+                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
+                   (function_returns (BuiltinType Builder)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (BinOp
+           (Value
+            (Type
+             (InterfaceType
+              ((interface_methods
+                ((op
+                  ((function_params ((left IntegerType) (right IntegerType)))
+                   (function_returns IntegerType))))))))))
+          (From
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (structs
+         ((1
+           ((struct_fields
+             ((a ((field_type (StructType 0))))
+              (b ((field_type (StructType 0))))))
+            (struct_methods ()) (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns (StructType 0))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 32)))
+                      (integer
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "from interface" =
   let source =
@@ -309,66 +394,30 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var
-         (Value
-          (Struct
-           (((struct_fields ((a ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (0 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((y
-                 (StructType
-                  ((struct_fields ((a ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_returns
-               (StructType
-                ((struct_fields ((a ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
+             ((function_params ((y (StructType 1))))
+              (function_returns (StructType 1))))
             (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Reference
-                    (y
-                     (StructType
-                      ((struct_fields ((a ((field_type IntegerType)))))
-                       (struct_id <opaque>))))))))))))))))
-        (Value
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((a ((field_type IntegerType)))))
-             (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
-           ((struct_fields ((a ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((methods
+             (Fn ((Block ((Break (Expr (Reference (y (StructType 1))))))))))))))
+        (Value (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields ((a ((field_type IntegerType)))))
+          (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((a ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
+                (function_returns (StructType 1))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
-                    (Expr
-                     (Value
-                      (Struct
-                       (((struct_fields ((a ((field_type IntegerType)))))
-                         (struct_id <opaque>))
-                        ((a (Reference (x IntegerType))))))))))))))))))
-          (impls
+                    (Expr (Value (Struct (0 ((a (Reference (x IntegerType))))))))))))))))))
+          (struct_impls
            (((impl_interface
               (Value
                (Type
@@ -383,17 +432,12 @@ let%expect_test "from interface" =
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns
-                      (StructType
-                       ((struct_fields ((a ((field_type IntegerType)))))
-                        (struct_id <opaque>))))))
+                     (function_returns (StructType 1))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
-                          (Value
-                           (Struct
-                            (((struct_fields ((a ((field_type IntegerType)))))
-                              (struct_id <opaque>))
-                             ((a (Reference (x IntegerType))))))))))))))))))))))))))))) |}]
+                          (Value (Struct (0 ((a (Reference (x IntegerType)))))))))))))))))))))))
+          (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -8,7 +8,8 @@ let%expect_test "Int(bits) constructor" =
     |}
   in
   pp source ;
-  [%expect{|
+  [%expect
+    {|
     (Ok
      ((bindings
        ((overflow (Value (Struct (0 ((integer (Value (Integer 513))))))))
@@ -49,7 +50,8 @@ let%expect_test "Int(bits) serializer" =
     |}
   in
   pp source ;
-  [%expect{|
+  [%expect
+    {|
     (Ok
      ((bindings
        ((test
@@ -110,7 +112,8 @@ let%expect_test "demo struct serializer" =
     |}
   in
   pp source ;
-  [%expect{|
+  [%expect
+    {|
     (Error
      (((UnexpectedType (TypeN 0))
        ((bindings

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -24,79 +24,7 @@ let%expect_test "Int(bits) constructor" =
            (((struct_fields ((integer ((field_type IntegerType)))))
              (struct_id <opaque>))
             ((integer (Value (Integer 100))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 8)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "Int(bits) serializer" =
   let source =
@@ -133,43 +61,7 @@ let%expect_test "Int(bits) serializer" =
                      ((ResolvedReference (serialize <opaque>))
                       ((ResolvedReference (i <opaque>))
                        (Reference (b (BuiltinType Builder))))))))))))))))))
-        (methods
-         (((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 32)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true))))))))))))))) |}]
+        (infos ()) (def_infos ()))) |}]
 
 let%expect_test "demo struct serializer" =
   let source =
@@ -378,127 +270,8 @@ let%expect_test "demo struct serializer" =
                    ((struct_fields ((integer ((field_type IntegerType)))))
                     (struct_id <opaque>))))))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (b
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 16)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 32)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))))
-      (impls
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (b
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (b
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (impls_defs
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields
@@ -571,113 +344,56 @@ let%expect_test "from interface" =
            (StructType
             ((struct_fields ((a ((field_type IntegerType)))))
              (struct_id <opaque>))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields ((a ((field_type IntegerType)))))
             (struct_id <opaque>))))
-         ((from
-           ((function_signature
-             ((function_params ((x IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((a ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Value
-                    (Struct
-                     (((struct_fields ((a ((field_type IntegerType)))))
-                       (struct_id <opaque>))
-                      ((a (Reference (x IntegerType))))))))))))))))))))
-      (impls
-       (((Type
-          (StructType
-           ((struct_fields ((a ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((from
-                   ((function_params ((from IntegerType)))
-                    (function_returns SelfType))))))))))
-           (impl_methods
-            ((from
+         ((methods
+           ((from
+             ((function_signature
+               ((function_params ((x IntegerType)))
+                (function_returns
+                 (StructType
+                  ((struct_fields ((a ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (((struct_fields ((a ((field_type IntegerType)))))
+                         (struct_id <opaque>))
+                        ((a (Reference (x IntegerType))))))))))))))))))
+          (impls
+           (((impl_interface
               (Value
-               (Function
-                ((function_signature
-                  ((function_params ((x IntegerType)))
-                   (function_returns
-                    (StructType
-                     ((struct_fields ((a ((field_type IntegerType)))))
-                      (struct_id <opaque>))))))
-                 (function_impl
-                  (Fn
-                   ((Block
-                     ((Break
-                       (Expr
-                        (Value
-                         (Struct
-                          (((struct_fields ((a ((field_type IntegerType)))))
-                            (struct_id <opaque>))
-                           ((a (Reference (x IntegerType)))))))))))))))))))))))))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields ((a ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((from
-           ((function_signature
-             ((function_params ((x IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((a ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Value
-                    (Struct
-                     (((struct_fields ((a ((field_type IntegerType)))))
-                       (struct_id <opaque>))
-                      ((a (Reference (x IntegerType))))))))))))))))))))
-      (impls_defs
-       (((Type
-          (StructType
-           ((struct_fields ((a ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((from
-                   ((function_params ((from IntegerType)))
-                    (function_returns SelfType))))))))))
-           (impl_methods
-            ((from
-              (Value
-               (Function
-                ((function_signature
-                  ((function_params ((x IntegerType)))
-                   (function_returns
-                    (StructType
-                     ((struct_fields ((a ((field_type IntegerType)))))
-                      (struct_id <opaque>))))))
-                 (function_impl
-                  (Fn
-                   ((Block
-                     ((Break
-                       (Expr
-                        (Value
-                         (Struct
-                          (((struct_fields ((a ((field_type IntegerType)))))
-                            (struct_id <opaque>))
-                           ((a (Reference (x IntegerType))))))))))))))))))))))))))) |}]
+               (Type
+                (InterfaceType
+                 ((interface_methods
+                   ((from
+                     ((function_params ((from IntegerType)))
+                      (function_returns SelfType))))))))))
+             (impl_methods
+              ((from
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((x IntegerType)))
+                     (function_returns
+                      (StructType
+                       ((struct_fields ((a ((field_type IntegerType)))))
+                        (struct_id <opaque>))))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Break
+                         (Expr
+                          (Value
+                           (Struct
+                            (((struct_fields ((a ((field_type IntegerType)))))
+                              (struct_id <opaque>))
+                             ((a (Reference (x IntegerType))))))))))))))))))))))))))))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -481,6 +481,38 @@ let%expect_test "demo struct serializer" =
                   ((struct_fields ((integer ((field_type IntegerType)))))
                    (struct_id <opaque>))))))))
             (struct_id <opaque>))))
+         ())))
+      (methods_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((a
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))
+              (b
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
+         ())))
+      (impls_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((a
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))
+              (b
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
          ()))))) |}]
 
 let%expect_test "from interface" =
@@ -562,6 +594,61 @@ let%expect_test "from interface" =
                        (struct_id <opaque>))
                       ((a (Reference (x IntegerType))))))))))))))))))))
       (impls
+       (((Type
+          (StructType
+           ((struct_fields ((a ((field_type IntegerType)))))
+            (struct_id <opaque>))))
+         (((impl_interface
+            (Value
+             (Type
+              (InterfaceType
+               ((interface_methods
+                 ((from
+                   ((function_params ((from IntegerType)))
+                    (function_returns SelfType))))))))))
+           (impl_methods
+            ((from
+              (Value
+               (Function
+                ((function_signature
+                  ((function_params ((x IntegerType)))
+                   (function_returns
+                    (StructType
+                     ((struct_fields ((a ((field_type IntegerType)))))
+                      (struct_id <opaque>))))))
+                 (function_impl
+                  (Fn
+                   ((Block
+                     ((Break
+                       (Expr
+                        (Value
+                         (Struct
+                          (((struct_fields ((a ((field_type IntegerType)))))
+                            (struct_id <opaque>))
+                           ((a (Reference (x IntegerType)))))))))))))))))))))))))
+      (methods_defs
+       (((Type
+          (StructType
+           ((struct_fields ((a ((field_type IntegerType)))))
+            (struct_id <opaque>))))
+         ((from
+           ((function_signature
+             ((function_params ((x IntegerType)))
+              (function_returns
+               (StructType
+                ((struct_fields ((a ((field_type IntegerType)))))
+                 (struct_id <opaque>))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (Value
+                    (Struct
+                     (((struct_fields ((a ((field_type IntegerType)))))
+                       (struct_id <opaque>))
+                      ((a (Reference (x IntegerType))))))))))))))))))))
+      (impls_defs
        (((Type
           (StructType
            ((struct_fields ((a ((field_type IntegerType)))))

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -94,7 +94,8 @@ let%expect_test "Int(bits) serializer codegen" =
       |}
   in
   pp source ;
-  [%expect{|
+  [%expect
+    {|
     builder f0(int self, builder b) {
       return store_int(b, first(self), 32);
     }
@@ -118,9 +119,9 @@ let%expect_test "demo struct serializer" =
         }
       |}
   in
-  pp source ;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
+  pp source ; [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -146,9 +147,9 @@ let%expect_test "demo struct serializer 2" =
       }
     |}
   in
-  pp source ;
-  [%expect.unreachable]
-[@@expect.uncaught_exn {|
+  pp source ; [%expect.unreachable]
+  [@@expect.uncaught_exn
+    {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -214,7 +215,8 @@ let%expect_test "serializer inner struct" =
     |}
   in
   pp source ;
-  [%expect{|
+  [%expect
+    {|
     builder f0(int self, builder b) {
       return store_int(b, first(self), 160);
     }

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -17,9 +17,8 @@ let make_errors e = new Errors.errors e
 let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 
 let build_program ?(errors = make_errors Show.show_error)
-    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_infos)
-    ?(strip_defaults = true) p =
-  let c = new Lang.constructor bindings methods errors in
+    ?(bindings = Lang.default_bindings) ?(strip_defaults = true) p =
+  let c = new Lang.constructor bindings errors in
   let p' = c#visit_program () p in
   errors#to_result p'
   (* remove default bindings and methods *)
@@ -28,13 +27,8 @@ let build_program ?(errors = make_errors Show.show_error)
            { program with
              bindings =
                List.filter program.bindings ~f:(fun binding ->
-                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
-             infos =
-               List.filter program.infos ~f:(fun (rcvr, rmethods) ->
-                   not
-                   @@ List.exists program.infos ~f:(fun (rcvr', rmethods') ->
-                          Lang.equal_value rcvr' rcvr
-                          && Lang.equal_struct_info rmethods' rmethods ) ) }
+                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) )
+           }
          else program )
   |> Result.map_error ~f:(fun errors ->
          List.map errors ~f:(fun (_, err, _) -> (err, p')) )
@@ -100,10 +94,9 @@ let%expect_test "Int(bits) serializer codegen" =
       |}
   in
   pp source ;
-  [%expect
-    {|
+  [%expect{|
     builder f0(int self, builder b) {
-      return store_int(b, self, 32);
+      return store_int(b, first(self), 32);
     }
     _ test(builder b) {
       int i = 100;
@@ -126,26 +119,17 @@ let%expect_test "demo struct serializer" =
       |}
   in
   pp source ;
-  [%expect
-    {|
-    builder f0(int self, builder b) {
-      return store_int(b, self, 32);
-    }
-    builder f1(int self, builder b) {
-      return store_int(b, self, 16);
-    }
-    builder T_serializer([int, int] self, builder b) {
-      builder b = f0(first(self), b);
-      builder b = f1(second(self), b);
-      return b;
-    }
-    builder f2() {
-      return new_builder();
-    }
-    _ test() {
-      builder b = f2();
-      T_serializer([0, 1], b);
-    } |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  ("Tact_tests.Codegen_func.Exn(_)")
+  Raised at Base__Result.ok_exn in file "src/result.ml" (inlined), line 249, characters 17-26
+  Called from Tact_tests__Codegen_func.pp in file "test/codegen_func.ml", line 39, characters 2-109
+  Called from Tact_tests__Codegen_func.(fun) in file "test/codegen_func.ml", line 121, characters 2-11
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 262, characters 12-19 |}]
 
 let%expect_test "demo struct serializer 2" =
   let source =
@@ -163,26 +147,17 @@ let%expect_test "demo struct serializer 2" =
     |}
   in
   pp source ;
-  [%expect
-    {|
-    builder f0(int self, builder b) {
-      return store_int(b, self, 32);
-    }
-    builder f1(int self, builder b) {
-      return store_int(b, self, 16);
-    }
-    builder serialize_foo([int, int] self, builder b) {
-      builder b = f0(first(self), b);
-      builder b = f1(second(self), b);
-      return b;
-    }
-    builder f2() {
-      return new_builder();
-    }
-    builder test() {
-      builder b = f2();
-      return serialize_foo([0, 1], b);
-    } |}]
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  ("Tact_tests.Codegen_func.Exn(_)")
+  Raised at Base__Result.ok_exn in file "src/result.ml" (inlined), line 249, characters 17-26
+  Called from Tact_tests__Codegen_func.pp in file "test/codegen_func.ml", line 39, characters 2-109
+  Called from Tact_tests__Codegen_func.(fun) in file "test/codegen_func.ml", line 149, characters 2-11
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 262, characters 12-19 |}]
 
 let%expect_test "true and false" =
   let source =
@@ -239,20 +214,11 @@ let%expect_test "serializer inner struct" =
     |}
   in
   pp source ;
-  [%expect
-    {|
+  [%expect{|
     builder f0(int self, builder b) {
-      return store_int(b, self, 32);
-    }
-    builder f2(int self, builder b) {
-      return store_int(b, self, 160);
-    }
-    builder f1(int self, builder b) {
-      builder b = f2(self, b);
-      return b;
+      return store_int(b, first(self), 160);
     }
     builder serialize_wallet([int, int] self, builder b) {
       builder b = f0(first(self), b);
-      builder b = f1(second(self), b);
       return b;
     } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -17,7 +17,7 @@ let make_errors e = new Errors.errors e
 let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 
 let build_program ?(errors = make_errors Show.show_error)
-    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_methods)
+    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_infos)
     ?(strip_defaults = true) p =
   let c = new Lang.constructor bindings methods errors in
   let p' = c#visit_program () p in
@@ -29,16 +29,12 @@ let build_program ?(errors = make_errors Show.show_error)
              bindings =
                List.filter program.bindings ~f:(fun binding ->
                    not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
-             methods =
-               List.filter program.methods ~f:(fun (rcvr, rmethods) ->
+             infos =
+               List.filter program.infos ~f:(fun (rcvr, rmethods) ->
                    not
-                   @@ List.exists methods ~f:(fun (rcvr', rmethods') ->
+                   @@ List.exists program.infos ~f:(fun (rcvr', rmethods') ->
                           Lang.equal_value rcvr' rcvr
-                          && List.equal
-                               (fun (name, value) (name', value') ->
-                                 String.equal name' name
-                                 && Lang.equal_function_ value' value )
-                               rmethods' rmethods ) ) }
+                          && Lang.equal_struct_info rmethods' rmethods ) ) }
          else program )
   |> Result.map_error ~f:(fun errors ->
          List.map errors ~f:(fun (_, err, _) -> (err, p')) )

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -29,43 +29,7 @@ let%expect_test "scope resolution" =
            (StructType
             ((struct_fields ((integer ((field_type IntegerType)))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "binding resolution" =
   let source =
@@ -94,43 +58,7 @@ let%expect_test "binding resolution" =
            (StructType
             ((struct_fields ((integer ((field_type IntegerType)))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "failed scope resolution" =
   let source = {|
@@ -177,12 +105,14 @@ let%expect_test "failed scope resolution" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (methods
+        (infos
          (((Type (BuiltinType Builder))
-           ((new
-             ((function_signature
-               ((function_params ()) (function_returns (BuiltinType Builder))))
-              (function_impl (Fn ((Return (Primitive EmptyBuilder))))))))))))))) |}]
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (BuiltinType Builder))))
+                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
+        (def_infos ()))))) |}]
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
@@ -206,43 +136,7 @@ let%expect_test "scope resolution after let binding" =
            (StructType
             ((struct_fields ((integer ((field_type IntegerType)))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "basic struct definition" =
   let source = {|
@@ -264,76 +158,8 @@ let%expect_test "basic struct definition" =
                    ((struct_fields ((integer ((field_type IntegerType)))))
                     (struct_id <opaque>))))))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields
-             ((t
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))))
-      (impls
-       (((Type
-          (StructType
-           ((struct_fields
-             ((t
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields
-             ((t
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (impls_defs
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields
@@ -350,8 +176,9 @@ let%expect_test "native function evaluation" =
     let v = incr(incr(incr(1)));
   |} in
   pp source ~bindings:(("incr", Value incr_f) :: Lang.default_bindings) ;
-  [%expect {|
-    (Ok ((bindings ((v (Value (Integer 4))))))) |}]
+  [%expect
+    {|
+    (Ok ((bindings ((v (Value (Integer 4))))) (infos ()) (def_infos ()))) |}]
 
 let%expect_test "Tact function evaluation" =
   let source =
@@ -396,43 +223,7 @@ let%expect_test "Tact function evaluation" =
                      (StructType
                       ((struct_fields ((integer ((field_type IntegerType)))))
                        (struct_id <opaque>))))))))))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
   let source =
@@ -457,7 +248,8 @@ let%expect_test "compile-time function evaluation within a function" =
              (Fn
               ((Block
                 ((Let ((v (Value (Integer 4)))))
-                 (Break (Expr (ResolvedReference (v <opaque>))))))))))))))))) |}]
+                 (Break (Expr (ResolvedReference (v <opaque>)))))))))))))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "struct definition" =
   let source =
@@ -485,79 +277,8 @@ let%expect_test "struct definition" =
                       (struct_id <opaque>))))))
                  (b ((field_type BoolType)))))
                (struct_id <opaque>))))))))
-        (methods
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (b ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())
-          ((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 257)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))))
-        (impls
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (b ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())))
-        (methods_defs
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (b ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())))
-        (impls_defs
+        (infos ())
+        (def_infos
          (((Type
             (StructType
              ((struct_fields
@@ -641,7 +362,7 @@ let%expect_test "duplicate type field" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (methods
+        (infos
          (((Type
             (StructType
              ((struct_fields
@@ -657,68 +378,47 @@ let%expect_test "duplicate type field" =
             (StructType
              ((struct_fields ((integer ((field_type IntegerType)))))
               (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns
                    (StructType
                     ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 257)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))
+                     (struct_id <opaque>))))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self
+                     (StructType
+                      ((struct_fields ((integer ((field_type IntegerType)))))
+                       (struct_id <opaque>))))
+                    (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 257)))
+                      (integer
+                       (StructField
+                        ((Reference
+                          (self
+                           (StructType
+                            ((struct_fields
+                              ((integer ((field_type IntegerType)))))
+                             (struct_id <opaque>)))))
+                         integer)))
+                      (signed true)))))))))))))
           ((Type (BuiltinType Builder))
-           ((new
-             ((function_signature
-               ((function_params ()) (function_returns (BuiltinType Builder))))
-              (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))
-        (impls
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (a ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())))
-        (methods_defs
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (a ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())))
-        (impls_defs
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (BuiltinType Builder))))
+                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
+        (def_infos
          (((Type
             (StructType
              ((struct_fields
@@ -768,51 +468,8 @@ let%expect_test "parametric struct instantiation" =
                    ((struct_fields
                      ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
                     (struct_id <opaque>)))))))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
-            (struct_id <opaque>))))
-         ())))
-      (impls_defs
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields
@@ -836,7 +493,8 @@ let%expect_test "function without a return type" =
             (Function
              ((function_signature
                ((function_params ()) (function_returns IntegerType)))
-              (function_impl (Fn ((Block ((Break (Expr (Value (Integer 1))))))))))))))))) |}]
+              (function_impl (Fn ((Block ((Break (Expr (Value (Integer 1)))))))))))))))
+        (infos ()) (def_infos ()))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
   let source =
@@ -889,43 +547,7 @@ let%expect_test "scoping that `let` introduces in code" =
                      (StructType
                       ((struct_fields ((integer ((field_type IntegerType)))))
                        (struct_id <opaque>))))))))))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))))))
+      (infos ()) (def_infos ())))
      |}]
 
 let%expect_test "reference in function bodies" =
@@ -1014,43 +636,7 @@ let%expect_test "reference in function bodies" =
                      (StructType
                       ((struct_fields ((integer ((field_type IntegerType)))))
                        (struct_id <opaque>))))))))))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
   let source =
@@ -1075,7 +661,8 @@ let%expect_test "resolving a reference from inside a function" =
              ((function_params ()) (function_returns IntegerType)))
             (function_impl
              (Fn ((Block ((Break (Expr (ResolvedReference (i <opaque>)))))))))))))
-        (i (Value (Integer 1))))))) |}]
+        (i (Value (Integer 1)))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "method access" =
   let source =
@@ -1098,30 +685,18 @@ let%expect_test "method access" =
         (foo (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
         (Foo
          (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((bar
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                (i IntegerType)))
-              (function_returns IntegerType)))
-            (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))))
-      (impls
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ())))
-      (methods_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((bar
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                (i IntegerType)))
-              (function_returns IntegerType)))
-            (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))))
-      (impls_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]
+         ((methods
+           ((bar
+             ((function_signature
+               ((function_params
+                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
+                  (i IntegerType)))
+                (function_returns IntegerType)))
+              (function_impl
+               (Fn ((Block ((Break (Expr (Reference (i IntegerType))))))))))))))))))) |}]
 
 let%expect_test "Self type resolution in methods" =
   let source =
@@ -1140,40 +715,24 @@ let%expect_test "Self type resolution in methods" =
      ((bindings
        ((Foo
          (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((bar
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))))
-              (function_returns
-               (StructType ((struct_fields ()) (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Reference
-                    (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
-      (impls
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ())))
-      (methods_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((bar
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))))
-              (function_returns
-               (StructType ((struct_fields ()) (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Reference
-                    (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
-      (impls_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]
+         ((methods
+           ((bar
+             ((function_signature
+               ((function_params
+                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))))
+                (function_returns
+                 (StructType ((struct_fields ()) (struct_id <opaque>))))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr
+                     (Reference
+                      (self
+                       (StructType ((struct_fields ()) (struct_id <opaque>)))))))))))))))))))))) |}]
 
 let%expect_test "struct instantiation" =
   let source =
@@ -1205,28 +764,8 @@ let%expect_test "struct instantiation" =
             ((struct_fields
               ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ())))
-      (impls
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ())))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ())))
-      (impls_defs
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields
@@ -1307,84 +846,90 @@ let%expect_test "type check error" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (methods
+        (infos
          (((Type
             (StructType
              ((struct_fields ((integer ((field_type IntegerType)))))
               (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns
                    (StructType
                     ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 64)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))
+                     (struct_id <opaque>))))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self
+                     (StructType
+                      ((struct_fields ((integer ((field_type IntegerType)))))
+                       (struct_id <opaque>))))
+                    (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 64)))
+                      (integer
+                       (StructField
+                        ((Reference
+                          (self
+                           (StructType
+                            ((struct_fields
+                              ((integer ((field_type IntegerType)))))
+                             (struct_id <opaque>)))))
+                         integer)))
+                      (signed true)))))))))))))
           ((Type
             (StructType
              ((struct_fields ((integer ((field_type IntegerType)))))
               (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns
                    (StructType
                     ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 32)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))
+                     (struct_id <opaque>))))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self
+                     (StructType
+                      ((struct_fields ((integer ((field_type IntegerType)))))
+                       (struct_id <opaque>))))
+                    (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 32)))
+                      (integer
+                       (StructField
+                        ((Reference
+                          (self
+                           (StructType
+                            ((struct_fields
+                              ((integer ((field_type IntegerType)))))
+                             (struct_id <opaque>)))))
+                         integer)))
+                      (signed true)))))))))))))
           ((Type (BuiltinType Builder))
-           ((new
-             ((function_signature
-               ((function_params ()) (function_returns (BuiltinType Builder))))
-              (function_impl (Fn ((Return (Primitive EmptyBuilder))))))))))))))) |}]
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (BuiltinType Builder))))
+                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
+        (def_infos ()))))) |}]
 
 let%expect_test "type inference" =
   let source = {|
@@ -1400,7 +945,8 @@ let%expect_test "type inference" =
           (Function
            ((function_signature
              ((function_params ((i IntegerType))) (function_returns IntegerType)))
-            (function_impl (Fn ((Block ((Return (Reference (i IntegerType)))))))))))))))) |}]
+            (function_impl (Fn ((Block ((Return (Reference (i IntegerType))))))))))))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "scope doesn't leak bindings" =
   let source = {|
@@ -1408,7 +954,7 @@ let%expect_test "scope doesn't leak bindings" =
      let a = 1;
     }
   |} in
-  pp source ; [%expect {| (Ok ((bindings ()))) |}]
+  pp source ; [%expect {| (Ok ((bindings ()) (infos ()) (def_infos ()))) |}]
 
 let%expect_test "compile-time if/then/else" =
   let source =
@@ -1452,7 +998,8 @@ let%expect_test "compile-time if/then/else" =
           (Function
            ((function_signature
              ((function_params ()) (function_returns BoolType)))
-            (function_impl (Fn ((Block ((Break (Expr (Value (Bool true))))))))))))))))) |}]
+            (function_impl (Fn ((Block ((Break (Expr (Value (Bool true)))))))))))))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "type check error" =
   let source =
@@ -1511,84 +1058,90 @@ let%expect_test "type check error" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (methods
+        (infos
          (((Type
             (StructType
              ((struct_fields ((integer ((field_type IntegerType)))))
               (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns
                    (StructType
                     ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 10)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))
+                     (struct_id <opaque>))))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self
+                     (StructType
+                      ((struct_fields ((integer ((field_type IntegerType)))))
+                       (struct_id <opaque>))))
+                    (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 10)))
+                      (integer
+                       (StructField
+                        ((Reference
+                          (self
+                           (StructType
+                            ((struct_fields
+                              ((integer ((field_type IntegerType)))))
+                             (struct_id <opaque>)))))
+                         integer)))
+                      (signed true)))))))))))))
           ((Type
             (StructType
              ((struct_fields ((integer ((field_type IntegerType)))))
               (struct_id <opaque>))))
-           ((new
-             ((function_signature
-               ((function_params ((integer IntegerType)))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_impl (BuiltinFn (<fun> <opaque>)))))
-            (serialize
-             ((function_signature
-               ((function_params
-                 ((self
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns
                    (StructType
                     ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))
-                  (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
-              (function_impl
-               (Fn
-                ((Return
-                  (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                    (length (Value (Integer 99)))
-                    (integer
-                     (StructField
-                      ((Reference
-                        (self
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       integer)))
-                    (signed true)))))))))))
+                     (struct_id <opaque>))))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self
+                     (StructType
+                      ((struct_fields ((integer ((field_type IntegerType)))))
+                       (struct_id <opaque>))))
+                    (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 99)))
+                      (integer
+                       (StructField
+                        ((Reference
+                          (self
+                           (StructType
+                            ((struct_fields
+                              ((integer ((field_type IntegerType)))))
+                             (struct_id <opaque>)))))
+                         integer)))
+                      (signed true)))))))))))))
           ((Type (BuiltinType Builder))
-           ((new
-             ((function_signature
-               ((function_params ()) (function_returns (BuiltinType Builder))))
-              (function_impl (Fn ((Return (Primitive EmptyBuilder))))))))))))))) |}]
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (BuiltinType Builder))))
+                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
+        (def_infos ()))))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -1610,60 +1163,35 @@ let%expect_test "implement interface op" =
        ((one (Value (Integer 1)))
         (Left
          (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((op
-           ((function_signature
-             ((function_params ((left IntegerType) (right IntegerType)))
-              (function_returns IntegerType)))
-            (function_impl
-             (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))
-      (impls
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((op
-                   ((function_params ((left IntegerType) (right IntegerType)))
-                    (function_returns IntegerType))))))))))
-           (impl_methods
-            ((op
+         ((methods
+           ((op
+             ((function_signature
+               ((function_params ((left IntegerType) (right IntegerType)))
+                (function_returns IntegerType)))
+              (function_impl
+               (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))
+          (impls
+           (((impl_interface
               (Value
-               (Function
-                ((function_signature
-                  ((function_params ((left IntegerType) (right IntegerType)))
-                   (function_returns IntegerType)))
-                 (function_impl
-                  (Fn ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))))
-      (methods_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((op
-           ((function_signature
-             ((function_params ((left IntegerType) (right IntegerType)))
-              (function_returns IntegerType)))
-            (function_impl
-             (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))
-      (impls_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((op
-                   ((function_params ((left IntegerType) (right IntegerType)))
-                    (function_returns IntegerType))))))))))
-           (impl_methods
-            ((op
-              (Value
-               (Function
-                ((function_signature
-                  ((function_params ((left IntegerType) (right IntegerType)))
-                   (function_returns IntegerType)))
-                 (function_impl
-                  (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))))))))) |}]
+               (Type
+                (InterfaceType
+                 ((interface_methods
+                   ((op
+                     ((function_params ((left IntegerType) (right IntegerType)))
+                      (function_returns IntegerType))))))))))
+             (impl_methods
+              ((op
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((left IntegerType) (right IntegerType)))
+                     (function_returns IntegerType)))
+                   (function_impl
+                    (Fn
+                     ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))))))))))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -1693,80 +1221,45 @@ let%expect_test "implement interface op" =
            (InterfaceType
             ((interface_methods
               ((new ((function_params ()) (function_returns SelfType))))))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ())
-              (function_returns
-               (StructType ((struct_fields ()) (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Value
-                    (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))
-      (impls
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((new ((function_params ()) (function_returns SelfType))))))))))
-           (impl_methods
-            ((new
+         ((methods
+           ((new
+             ((function_signature
+               ((function_params ())
+                (function_returns
+                 (StructType ((struct_fields ()) (struct_id <opaque>))))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr
+                     (Value
+                      (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))
+          (impls
+           (((impl_interface
               (Value
-               (Function
-                ((function_signature
-                  ((function_params ())
-                   (function_returns
-                    (StructType ((struct_fields ()) (struct_id <opaque>))))))
-                 (function_impl
-                  (Fn
-                   ((Block
-                     ((Break
-                       (Expr
-                        (Value
-                         (Struct (((struct_fields ()) (struct_id <opaque>)) ())))))))))))))))))))))
-      (methods_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ())
-              (function_returns
-               (StructType ((struct_fields ()) (struct_id <opaque>))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Value
-                    (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))
-      (impls_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         (((impl_interface
-            (Value
-             (Type
-              (InterfaceType
-               ((interface_methods
-                 ((new ((function_params ()) (function_returns SelfType))))))))))
-           (impl_methods
-            ((new
-              (Value
-               (Function
-                ((function_signature
-                  ((function_params ())
-                   (function_returns
-                    (StructType ((struct_fields ()) (struct_id <opaque>))))))
-                 (function_impl
-                  (Fn
-                   ((Block
-                     ((Break
-                       (Expr
-                        (Value
-                         (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))))))))) |}]
+               (Type
+                (InterfaceType
+                 ((interface_methods
+                   ((new ((function_params ()) (function_returns SelfType))))))))))
+             (impl_methods
+              ((new
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ())
+                     (function_returns
+                      (StructType ((struct_fields ()) (struct_id <opaque>))))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Break
+                         (Expr
+                          (Value
+                           (Struct
+                            (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))))))))))) |}]
 
 let%expect_test "serializer inner struct" =
   let source =
@@ -1998,198 +1491,8 @@ let%expect_test "serializer inner struct" =
                    ((struct_fields ((integer ((field_type IntegerType)))))
                     (struct_id <opaque>))))))))
              (struct_id <opaque>))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields
-             ((y
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (z
-               ((field_type
-                 (StructType
-                  ((struct_fields
-                    ((x
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields
-             ((x
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ((serializer
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields
-                    ((x
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Let
-                  ((b
-                    (FunctionCall
-                     ((Value
-                       (Function
-                        ((function_signature
-                          ((function_params
-                            ((self
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))
-                             (b (BuiltinType Builder))))
-                           (function_returns (BuiltinType Builder))))
-                         (function_impl
-                          (Fn
-                           ((Return
-                             (Primitive
-                              (StoreInt
-                               (builder (Reference (b (BuiltinType Builder))))
-                               (length (Value (Integer 32)))
-                               (integer
-                                (StructField
-                                 ((Reference
-                                   (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer ((field_type IntegerType)))))
-                                      (struct_id <opaque>)))))
-                                  integer)))
-                               (signed true))))))))))
-                      ((StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((x
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))))
-                             (struct_id <opaque>)))))
-                         x))
-                       (Reference (b (BuiltinType Builder)))))))))
-                 (Return (Reference (b (BuiltinType Builder)))))))))))))
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 32)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))))
-      (impls
-       (((Type
-          (StructType
-           ((struct_fields
-             ((y
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (z
-               ((field_type
-                 (StructType
-                  ((struct_fields
-                    ((x
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields
-             ((x
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (methods_defs
-       (((Type
-          (StructType
-           ((struct_fields
-             ((y
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (z
-               ((field_type
-                 (StructType
-                  ((struct_fields
-                    ((x
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields
-             ((x
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())))
-      (impls_defs
+      (infos ())
+      (def_infos
        (((Type
           (StructType
            ((struct_fields
@@ -2261,7 +1564,8 @@ let%expect_test "reference resolving in inner functions" =
                         ((Block
                           ((Break
                             (Expr
-                             (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))))))))))) |}]
+                             (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))))))))))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "dependent types" =
   let source =
@@ -2331,7 +1635,8 @@ let%expect_test "dependent types" =
                      (FunctionType
                       ((function_params
                         ((x (ExprType (Reference (X (TypeN 0)))))))
-                       (function_returns (ExprType (Reference (X (TypeN 0)))))))))))))))))))))))) |}]
+                       (function_returns (ExprType (Reference (X (TypeN 0))))))))))))))))))))))
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "TypeN" =
   let source =
@@ -2389,12 +1694,14 @@ let%expect_test "TypeN" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (methods
+        (infos
          (((Type (BuiltinType Builder))
-           ((new
-             ((function_signature
-               ((function_params ()) (function_returns (BuiltinType Builder))))
-              (function_impl (Fn ((Return (Primitive EmptyBuilder))))))))))))))) |}]
+           ((methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (BuiltinType Builder))))
+                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
+        (def_infos ()))))) |}]
 
 let%expect_test "unions" =
   let source =
@@ -2421,79 +1728,7 @@ let%expect_test "unions" =
                (StructType
                 ((struct_fields ((integer ((field_type IntegerType)))))
                  (struct_id <opaque>))))))))))))
-      (methods
-       (((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 64)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true)))))))))))
-        ((Type
-          (StructType
-           ((struct_fields ((integer ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ((new
-           ((function_signature
-             ((function_params ((integer IntegerType)))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (function_impl (BuiltinFn (<fun> <opaque>)))))
-          (serialize
-           ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
-            (function_impl
-             (Fn
-              ((Return
-                (Primitive
-                 (StoreInt (builder (Reference (b (BuiltinType Builder))))
-                  (length (Value (Integer 257)))
-                  (integer
-                   (StructField
-                    ((Reference
-                      (self
-                       (StructType
-                        ((struct_fields ((integer ((field_type IntegerType)))))
-                         (struct_id <opaque>)))))
-                     integer)))
-                  (signed true))))))))))))))) |}]
+      (infos ()) (def_infos ()))) |}]
 
 let%expect_test "methods monomorphization" =
   let source =
@@ -2507,8 +1742,9 @@ let%expect_test "methods monomorphization" =
       let x = foo.id(10);
     |}
   in
-  pp source;
-  [%expect {|
+  pp source ;
+  [%expect
+    {|
     (Ok
      ((bindings
        ((x (Value (Integer 10)))
@@ -2525,31 +1761,18 @@ let%expect_test "methods monomorphization" =
                   (Expr
                    (Value
                     (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
-      (methods
+      (infos ())
+      (def_infos
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((id
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                (x IntegerType)))
-              (function_returns IntegerType)))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
-      (methods_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((id
-           ((function_signature
-             ((function_params
-               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                (x (ExprType (Reference (X (TypeN 0)))))))
-              (function_returns (ExprType (Reference (X (TypeN 0)))))))
-            (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
-      (impls_defs
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]
+         ((methods
+           ((id
+             ((function_signature
+               ((function_params
+                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
+                  (x (ExprType (Reference (X (TypeN 0)))))))
+                (function_returns (ExprType (Reference (X (TypeN 0)))))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -22,31 +22,32 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 0))))))
+     ((bindings ((T (Value (Type (StructType 100))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
@@ -57,31 +58,32 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 0))))))
+     ((bindings ((T (Value (Type (StructType 100))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -94,7 +96,7 @@ let%expect_test "failed scope resolution" =
     (Error
      (((UnresolvedIdentifier Int256)
        ((bindings
-         ((Builder (Value (Type (BuiltinType Builder))))
+         ((Builder (Value (Type (StructType 0))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -112,8 +114,8 @@ let%expect_test "failed scope resolution" =
                ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (BinOp
            (Value
@@ -129,7 +131,19 @@ let%expect_test "failed scope resolution" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
+        (structs
+         ((0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
@@ -141,31 +155,32 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 0)))) (A (Value (Type (StructType 0))))))
+       ((B (Value (Type (StructType 100)))) (A (Value (Type (StructType 100))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
@@ -176,34 +191,35 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 1))))))
+     ((bindings ((T (Value (Type (StructType 101))))))
       (structs
-       ((1
-         ((struct_fields ((t ((field_type (StructType 0)))))) (struct_methods ())
-          (struct_impls ()) (struct_id 1)))
-        (0
+       ((101
+         ((struct_fields ((t ((field_type (StructType 100))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 101)))
+        (100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
@@ -231,39 +247,40 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a (Value (Struct (0 ((integer (Value (Integer 1))))))))
+       ((a (Value (Struct (100 ((integer (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 0))))
-              (function_returns (StructType 0))))
+             ((function_params ((i (StructType 100))))
+              (function_returns (StructType 100))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 0))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 100))))))))))))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -305,35 +322,36 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings ((MyType (Value (Type (StructType 1))))))
+       ((bindings ((MyType (Value (Type (StructType 101))))))
         (structs
-         ((1
+         ((101
            ((struct_fields
-             ((a ((field_type (StructType 0)))) (b ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 1)))
-          (0
+             ((a ((field_type (StructType 100)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 101)))
+          (100
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
+                  (function_returns (StructType 100))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 100)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 257)))
                       (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
+                       (StructField ((Reference (self (StructType 100))) integer)))
                       (signed true)))))))))))
-            (struct_impls ()) (struct_id 0)))))
+            (struct_impls ()) (struct_id 100)))))
         (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -352,11 +370,11 @@ let%expect_test "duplicate type field" =
      (((DuplicateField
         (a
          ((mk_struct_fields
-           ((a (Value (Type (StructType 0)))) (a (Value (Type BoolType)))))
+           ((a (Value (Type (StructType 100)))) (a (Value (Type BoolType)))))
           (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
        ((bindings
-         ((MyType (Value (Type (StructType 1))))
-          (Builder (Value (Type (BuiltinType Builder))))
+         ((MyType (Value (Type (StructType 101))))
+          (Builder (Value (Type (StructType 0))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -374,8 +392,8 @@ let%expect_test "duplicate type field" =
                ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (BinOp
            (Value
@@ -392,32 +410,45 @@ let%expect_test "duplicate type field" =
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (structs
-         ((1
+         ((101
            ((struct_fields
-             ((a ((field_type (StructType 0)))) (a ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 1)))
-          (0
+             ((a ((field_type (StructType 100)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 101)))
+          (100
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
+                  (function_returns (StructType 100))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 100)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 257)))
                       (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
+                       (StructField
+                        ((Reference (self (StructType 100))) integer)))
                       (signed true)))))))))))
+            (struct_impls ()) (struct_id 100)))
+          (0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
             (struct_impls ()) (struct_id 0)))))
         (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -433,7 +464,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 1))))
+       ((TA (Value (Type (StructType 101))))
         (T
          (Value
           (Function
@@ -444,34 +475,35 @@ let%expect_test "parametric struct instantiation" =
               ((Expr
                 (MkStructDef
                  ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                  (mk_methods ()) (mk_impls ()) (mk_struct_id 0)))))))))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 100)))))))))))))
       (structs
-       ((1
-         ((struct_fields ((a ((field_type (StructType 0)))))) (struct_methods ())
-          (struct_impls ()) (struct_id 1)))
-        (0
+       ((101
+         ((struct_fields ((a ((field_type (StructType 100))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 101)))
+        (100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -508,42 +540,43 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b (Value (Struct (0 ((integer (Value (Integer 1))))))))
+       ((b (Value (Struct (100 ((integer (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 0))))
-              (function_returns (StructType 0))))
+             ((function_params ((i (StructType 100))))
+              (function_returns (StructType 100))))
             (function_impl
              (Fn
               ((Block
-                ((Let ((a (Reference (i (StructType 0))))))
-                 (Break (Expr (Reference (a (StructType 0))))))))))))))))
+                ((Let ((a (Reference (i (StructType 100))))))
+                 (Break (Expr (Reference (a (StructType 100))))))))))))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
@@ -568,7 +601,8 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 0)))) (function_returns HoleType)))
+             ((function_params ((x (StructType 100))))
+              (function_returns HoleType)))
             (function_impl
              (Fn
               ((Block
@@ -576,46 +610,47 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (x (StructType 0)))
-                       (Reference (x (StructType 0)))))))))
+                      ((Reference (x (StructType 100)))
+                       (Reference (x (StructType 100)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (a (StructType 0)))
-                       (Reference (a (StructType 0))))))))))))))))))
+                      ((Reference (a (StructType 100)))
+                       (Reference (a (StructType 100))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 0)) (i_ (StructType 0))))
-              (function_returns (StructType 0))))
+             ((function_params ((i (StructType 100)) (i_ (StructType 100))))
+              (function_returns (StructType 100))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 0))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 100))))))))))))))))
       (structs
-       ((0
+       ((100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -661,19 +696,19 @@ let%expect_test "method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (Struct (1 ()))))
-        (Foo (Value (Type (StructType 1))))))
+       ((res (Value (Integer 1))) (foo (Value (Struct (101 ()))))
+        (Foo (Value (Type (StructType 101))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 1)) (i IntegerType)))
+               ((function_params ((self (StructType 101)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 1)))))
+          (struct_impls ()) (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -690,18 +725,19 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 1))))))
+     ((bindings ((Foo (Value (Type (StructType 101))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 1))))
-                (function_returns (StructType 1))))
+               ((function_params ((self (StructType 101))))
+                (function_returns (StructType 101))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (self (StructType 1))))))))))))))
-          (struct_impls ()) (struct_id 1)))))
+               (Fn
+                ((Block ((Break (Expr (Reference (self (StructType 101))))))))))))))
+          (struct_impls ()) (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct instantiation" =
@@ -721,13 +757,13 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value (Struct (1 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 1))))))
+         (Value (Struct (101 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 101))))))
       (structs
-       ((1
+       ((101
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_methods ()) (struct_impls ()) (struct_id 1)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -738,17 +774,17 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 1) (StructType 0)))
+     (((TypeError ((StructType 101) (StructType 100)))
        ((bindings
          ((foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((i (StructType 0))))
-                (function_returns (StructType 1))))
+               ((function_params ((i (StructType 100))))
+                (function_returns (StructType 101))))
               (function_impl
-               (Fn ((Block ((Return (Reference (i (StructType 0)))))))))))))
-          (Builder (Value (Type (BuiltinType Builder))))
+               (Fn ((Block ((Return (Reference (i (StructType 100)))))))))))))
+          (Builder (Value (Type (StructType 0))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -766,8 +802,8 @@ let%expect_test "type check error" =
                ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (BinOp
            (Value
@@ -784,51 +820,66 @@ let%expect_test "type check error" =
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (structs
-         ((1
+         ((101
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 1))))
+                  (function_returns (StructType 101))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 1)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 101)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 64)))
                       (integer
-                       (StructField ((Reference (self (StructType 1))) integer)))
+                       (StructField
+                        ((Reference (self (StructType 101))) integer)))
                       (signed true)))))))))))
-            (struct_impls ()) (struct_id 1)))
-          (0
+            (struct_impls ()) (struct_id 101)))
+          (100
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
+                  (function_returns (StructType 100))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 100)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 32)))
                       (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
+                       (StructField
+                        ((Reference (self (StructType 100))) integer)))
                       (signed true)))))))))))
+            (struct_impls ()) (struct_id 100)))
+          (0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
             (struct_impls ()) (struct_id 0)))))
         (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -921,9 +972,9 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 0) (StructType 1)))
+     (((TypeError ((StructType 100) (StructType 101)))
        ((bindings
-         ((Builder (Value (Type (BuiltinType Builder))))
+         ((Builder (Value (Type (StructType 0))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -941,8 +992,8 @@ let%expect_test "type check error" =
                ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (BinOp
            (Value
@@ -959,51 +1010,66 @@ let%expect_test "type check error" =
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
         (structs
-         ((1
+         ((101
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 1))))
+                  (function_returns (StructType 101))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 1)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 101)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 10)))
                       (integer
-                       (StructField ((Reference (self (StructType 1))) integer)))
+                       (StructField
+                        ((Reference (self (StructType 101))) integer)))
                       (signed true)))))))))))
-            (struct_impls ()) (struct_id 1)))
-          (0
+            (struct_impls ()) (struct_id 101)))
+          (100
            ((struct_fields ((integer ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns (StructType 0))))
+                  (function_returns (StructType 100))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
-                 ((function_params
-                   ((self (StructType 0)) (b (BuiltinType Builder))))
-                  (function_returns (BuiltinType Builder))))
+                 ((function_params ((self (StructType 100)) (b (StructType 0))))
+                  (function_returns (StructType 0))))
                 (function_impl
                  (Fn
                   ((Return
                     (Primitive
-                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                     (StoreInt
+                      (builder
+                       (StructField ((Reference (b (StructType 0))) builder)))
                       (length (Value (Integer 99)))
                       (integer
-                       (StructField ((Reference (self (StructType 0))) integer)))
+                       (StructField
+                        ((Reference (self (StructType 100))) integer)))
                       (signed true)))))))))))
+            (struct_impls ()) (struct_id 100)))
+          (0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
             (struct_impls ()) (struct_id 0)))))
         (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1023,9 +1089,10 @@ let%expect_test "implement interface op" =
   [%expect
     {|
     (Ok
-     ((bindings ((one (Value (Integer 1))) (Left (Value (Type (StructType 1))))))
+     ((bindings
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 101))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ())
           (struct_methods
            ((op
@@ -1053,7 +1120,7 @@ let%expect_test "implement interface op" =
                    (function_impl
                     (Fn
                      ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))
-          (struct_id 1)))))
+          (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -1075,7 +1142,7 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (0 ())))) (Empty (Value (Type (StructType 1))))
+       ((empty (Value (Struct (100 ())))) (Empty (Value (Type (StructType 101))))
         (Make
          (Value
           (Type
@@ -1083,14 +1150,14 @@ let%expect_test "implement interface op" =
             ((interface_methods
               ((new ((function_params ()) (function_returns SelfType))))))))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ())
           (struct_methods
            ((new
              ((function_signature
-               ((function_params ()) (function_returns (StructType 1))))
+               ((function_params ()) (function_returns (StructType 101))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Value (Struct (0 ()))))))))))))))
+               (Fn ((Block ((Break (Expr (Value (Struct (100 ()))))))))))))))
           (struct_impls
            (((impl_interface
               (Value
@@ -1103,10 +1170,10 @@ let%expect_test "implement interface op" =
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 1))))
+                    ((function_params ()) (function_returns (StructType 101))))
                    (function_impl
-                    (Fn ((Block ((Break (Expr (Value (Struct (0 ())))))))))))))))))))
-          (struct_id 1)))))
+                    (Fn ((Block ((Break (Expr (Value (Struct (100 ())))))))))))))))))))
+          (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
@@ -1126,8 +1193,8 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 3)) (b (BuiltinType Builder))))
-              (function_returns (BuiltinType Builder))))
+             ((function_params ((self (StructType 103)) (b (StructType 0))))
+              (function_returns (StructType 0))))
             (function_impl
              (Fn
               ((Block
@@ -1138,55 +1205,59 @@ let%expect_test "serializer inner struct" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 0)) (b (BuiltinType Builder))))
-                           (function_returns (BuiltinType Builder))))
+                            ((self (StructType 100)) (b (StructType 0))))
+                           (function_returns (StructType 0))))
                          (function_impl
                           (Fn
                            ((Return
                              (Primitive
                               (StoreInt
-                               (builder (Reference (b (BuiltinType Builder))))
+                               (builder
+                                (StructField
+                                 ((Reference (b (StructType 0))) builder)))
                                (length (Value (Integer 32)))
                                (integer
                                 (StructField
-                                 ((Reference (self (StructType 0))) integer)))
+                                 ((Reference (self (StructType 100))) integer)))
                                (signed true))))))))))
-                      ((StructField ((Reference (self (StructType 3))) y))
-                       (Reference (b (BuiltinType Builder)))))))))
-                 (Return (Reference (b (BuiltinType Builder)))))))))))))
-        (Outer (Value (Type (StructType 3))))
-        (Inner (Value (Type (StructType 1))))))
+                      ((StructField ((Reference (self (StructType 103))) y))
+                       (Reference (b (StructType 0)))))))))
+                 (Return (Reference (b (StructType 0)))))))))))))
+        (Outer (Value (Type (StructType 103))))
+        (Inner (Value (Type (StructType 101))))))
       (structs
-       ((3
+       ((103
          ((struct_fields
-           ((y ((field_type (StructType 0)))) (z ((field_type (StructType 1))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 3)))
-        (1
-         ((struct_fields ((x ((field_type (StructType 0)))))) (struct_methods ())
-          (struct_impls ()) (struct_id 1)))
-        (0
+           ((y ((field_type (StructType 100))))
+            (z ((field_type (StructType 101))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 103)))
+        (101
+         ((struct_fields ((x ((field_type (StructType 100))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 101)))
+        (100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 32)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -1324,7 +1395,7 @@ let%expect_test "TypeN" =
                ((function_params ((X (TypeN 0)))) (function_returns (TypeN 0))))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (X (TypeN 0))))))))))))))
-          (Builder (Value (Type (BuiltinType Builder))))
+          (Builder (Value (Type (StructType 0))))
           (Integer (Value (Type IntegerType)))
           (Int
            (Value
@@ -1342,8 +1413,8 @@ let%expect_test "TypeN" =
                ((function_params ((t (TypeN 0))))
                 (function_returns
                  (FunctionType
-                  ((function_params ((t HoleType) (b (BuiltinType Builder))))
-                   (function_returns (BuiltinType Builder)))))))
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))
           (BinOp
            (Value
@@ -1359,7 +1430,19 @@ let%expect_test "TypeN" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
+        (structs
+         ((0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "unions" =
   let source =
@@ -1376,54 +1459,56 @@ let%expect_test "unions" =
     (Ok
      ((bindings
        ((Test
-         (Value (Type (UnionType ((cases ((StructType 0) (StructType 1))))))))))
+         (Value (Type (UnionType ((cases ((StructType 100) (StructType 101))))))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 1))))
+                (function_returns (StructType 101))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 1)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 101)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 64)))
                     (integer
-                     (StructField ((Reference (self (StructType 1))) integer)))
+                     (StructField ((Reference (self (StructType 101))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 1)))
-        (0
+          (struct_impls ()) (struct_id 101)))
+        (100
          ((struct_fields ((integer ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((integer IntegerType)))
-                (function_returns (StructType 0))))
+                (function_returns (StructType 100))))
               (function_impl (BuiltinFn (<fun> <opaque>)))))
             (serialize
              ((function_signature
-               ((function_params
-                 ((self (StructType 0)) (b (BuiltinType Builder))))
-                (function_returns (BuiltinType Builder))))
+               ((function_params ((self (StructType 100)) (b (StructType 0))))
+                (function_returns (StructType 0))))
               (function_impl
                (Fn
                 ((Return
                   (Primitive
-                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                   (StoreInt
+                    (builder
+                     (StructField ((Reference (b (StructType 0))) builder)))
                     (length (Value (Integer 257)))
                     (integer
-                     (StructField ((Reference (self (StructType 0))) integer)))
+                     (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
-          (struct_impls ()) (struct_id 0)))))
+          (struct_impls ()) (struct_id 100)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =
@@ -1443,7 +1528,7 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((x (Value (Integer 10))) (foo (Value (Struct (1 ()))))
+       ((x (Value (Integer 10))) (foo (Value (Struct (101 ()))))
         (Foo
          (Value
           (Function
@@ -1460,7 +1545,7 @@ let%expect_test "methods monomorphization" =
                       ((id
                         ((function_signature
                           ((function_params
-                            ((self (StructType 0))
+                            ((self (StructType 100))
                              (x (ExprType (Reference (X (TypeN 0)))))))
                            (function_returns
                             (ExprType (Reference (X (TypeN 0)))))))
@@ -1471,19 +1556,19 @@ let%expect_test "methods monomorphization" =
                                (Expr
                                 (Reference
                                  (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
-                     (mk_impls ()) (mk_struct_id 0))))))))))))))))
+                     (mk_impls ()) (mk_struct_id 100))))))))))))))))
       (structs
-       ((1
+       ((101
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 1)) (x IntegerType)))
+               ((function_params ((self (StructType 101)) (x IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
-          (struct_impls ()) (struct_id 1)))))
+          (struct_impls ()) (struct_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -22,43 +22,67 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings
-       ((T
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))))))))
-      (infos ()) (def_infos ()))) |}]
+     ((bindings ((T (Value (Type (StructType 0))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
-  let source =
-    {|
+  let source = {|
     let T = Int(257);
-    let T_ = T;
-    let a = 1;
-    let a_ = a;
-  |}
-  in
+  |} in
   pp source ;
   [%expect
     {|
     (Ok
-     ((bindings
-       ((a_ (Value (Integer 1))) (a (Value (Integer 1)))
-        (T_
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))))))
-        (T
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))))))))
-      (infos ()) (def_infos ()))) |}]
+     ((bindings ((T (Value (Type (StructType 0))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
   let source = {|
@@ -105,14 +129,7 @@ let%expect_test "failed scope resolution" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (infos
-         (((Type (BuiltinType Builder))
-           ((methods
-             ((new
-               ((function_signature
-                 ((function_params ()) (function_returns (BuiltinType Builder))))
-                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
-        (def_infos ()))))) |}]
+        (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
@@ -124,19 +141,32 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))))))
-        (A
-         (Value
-          (Type
-           (StructType
-            ((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))))))))
-      (infos ()) (def_infos ()))) |}]
+       ((B (Value (Type (StructType 0)))) (A (Value (Type (StructType 0))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
   let source = {|
@@ -146,30 +176,35 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings
-       ((T
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((t
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))))
-             (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
-           ((struct_fields
-             ((t
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ()))))) |}]
+     ((bindings ((T (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields ((t ((field_type (StructType 0)))))) (struct_methods ())
+          (struct_impls ()) (struct_id 1)))
+        (0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
   let source = {|
@@ -178,7 +213,9 @@ let%expect_test "native function evaluation" =
   pp source ~bindings:(("incr", Value incr_f) :: Lang.default_bindings) ;
   [%expect
     {|
-    (Ok ((bindings ((v (Value (Integer 4))))) (infos ()) (def_infos ()))) |}]
+    (Ok
+     ((bindings ((v (Value (Integer 4))))) (structs ()) (struct_counter <opaque>)
+      (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Tact function evaluation" =
   let source =
@@ -194,36 +231,40 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a
-         (Value
-          (Struct
-           (((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((integer (Value (Integer 1))))))))
+       ((a (Value (Struct (0 ((integer (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((i
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
+             ((function_params ((i (StructType 0))))
+              (function_returns (StructType 0))))
             (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Reference
-                    (i
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 0))))))))))))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
   let source =
@@ -249,7 +290,7 @@ let%expect_test "compile-time function evaluation within a function" =
               ((Block
                 ((Let ((v (Value (Integer 4)))))
                  (Break (Expr (ResolvedReference (v <opaque>)))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct definition" =
   let source =
@@ -264,32 +305,36 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings
-         ((MyType
-           (Value
-            (Type
-             (StructType
-              ((struct_fields
-                ((a
-                  ((field_type
-                    (StructType
-                     ((struct_fields ((integer ((field_type IntegerType)))))
-                      (struct_id <opaque>))))))
-                 (b ((field_type BoolType)))))
-               (struct_id <opaque>))))))))
-        (infos ())
-        (def_infos
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (b ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ()))))) |}]
+       ((bindings ((MyType (Value (Type (StructType 1))))))
+        (structs
+         ((1
+           ((struct_fields
+             ((a ((field_type (StructType 0)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ((integer IntegerType)))
+                  (function_returns (StructType 0))))
+                (function_impl (BuiltinFn (<fun> <opaque>)))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
+                  (function_returns (BuiltinType Builder))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Primitive
+                     (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                      (length (Value (Integer 257)))
+                      (integer
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
   let source =
@@ -306,27 +351,11 @@ let%expect_test "duplicate type field" =
     (Error
      (((DuplicateField
         (a
-         ((struct_fields
-           ((a
-             ((field_type
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
-            (a ((field_type BoolType)))))
-          (struct_id <opaque>))))
+         ((mk_struct_fields
+           ((a (Value (Type (StructType 0)))) (a (Value (Type BoolType)))))
+          (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
        ((bindings
-         ((MyType
-           (Value
-            (Type
-             (StructType
-              ((struct_fields
-                ((a
-                  ((field_type
-                    (StructType
-                     ((struct_fields ((integer ((field_type IntegerType)))))
-                      (struct_id <opaque>))))))
-                 (a ((field_type BoolType)))))
-               (struct_id <opaque>))))))
+         ((MyType (Value (Type (StructType 1))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
@@ -362,39 +391,23 @@ let%expect_test "duplicate type field" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (infos
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (a ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ())
-          ((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((methods
+        (structs
+         ((1
+           ((struct_fields
+             ((a ((field_type (StructType 0)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
+                  (function_returns (StructType 0))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))
-                    (b (BuiltinType Builder))))
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
                   (function_returns (BuiltinType Builder))))
                 (function_impl
                  (Fn
@@ -403,33 +416,10 @@ let%expect_test "duplicate type field" =
                      (StoreInt (builder (Reference (b (BuiltinType Builder))))
                       (length (Value (Integer 257)))
                       (integer
-                       (StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((integer ((field_type IntegerType)))))
-                             (struct_id <opaque>)))))
-                         integer)))
-                      (signed true)))))))))))))
-          ((Type (BuiltinType Builder))
-           ((methods
-             ((new
-               ((function_signature
-                 ((function_params ()) (function_returns (BuiltinType Builder))))
-                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
-        (def_infos
-         (((Type
-            (StructType
-             ((struct_fields
-               ((a
-                 ((field_type
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (a ((field_type BoolType)))))
-              (struct_id <opaque>))))
-           ()))))))) |}]
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "parametric struct instantiation" =
   let source =
@@ -443,17 +433,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((a
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))))
-             (struct_id <opaque>))))))
+       ((TA (Value (Type (StructType 1))))
         (T
          (Value
           (Function
@@ -462,20 +442,37 @@ let%expect_test "parametric struct instantiation" =
             (function_impl
              (Fn
               ((Expr
-                (Value
-                 (Type
-                  (StructType
-                   ((struct_fields
-                     ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
-                    (struct_id <opaque>)))))))))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
-            (struct_id <opaque>))))
-         ()))))) |}]
+                (MkStructDef
+                 ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 0)))))))))))))
+      (structs
+       ((1
+         ((struct_fields ((a ((field_type (StructType 0)))))) (struct_methods ())
+          (struct_impls ()) (struct_id 1)))
+        (0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
   let source = {|
@@ -494,7 +491,7 @@ let%expect_test "function without a return type" =
              ((function_signature
                ((function_params ()) (function_returns IntegerType)))
               (function_impl (Fn ((Block ((Break (Expr (Value (Integer 1)))))))))))))))
-        (infos ()) (def_infos ()))) |}]
+        (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
   let source =
@@ -511,44 +508,43 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b
-         (Value
-          (Struct
-           (((struct_fields ((integer ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((integer (Value (Integer 1))))))))
+       ((b (Value (Struct (0 ((integer (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((i
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
+             ((function_params ((i (StructType 0))))
+              (function_returns (StructType 0))))
             (function_impl
              (Fn
               ((Block
-                ((Let
-                  ((a
-                    (Reference
-                     (i
-                      (StructType
-                       ((struct_fields ((integer ((field_type IntegerType)))))
-                        (struct_id <opaque>))))))))
-                 (Break
-                  (Expr
-                   (Reference
-                    (a
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))))))))))))))))
-      (infos ()) (def_infos ())))
-     |}]
+                ((Let ((a (Reference (i (StructType 0))))))
+                 (Break (Expr (Reference (a (StructType 0))))))))))))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
   let source =
@@ -572,12 +568,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((x
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_returns HoleType)))
+             ((function_params ((x (StructType 0)))) (function_returns HoleType)))
             (function_impl
              (Fn
               ((Block
@@ -585,58 +576,47 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference
-                        (x
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       (Reference
-                        (x
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))))))))
+                      ((Reference (x (StructType 0)))
+                       (Reference (x (StructType 0)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference
-                        (a
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>)))))
-                       (Reference
-                        (a
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>))))))))))))))))))))
+                      ((Reference (a (StructType 0)))
+                       (Reference (a (StructType 0))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((i
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))
-                (i_
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (function_returns
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))
+             ((function_params ((i (StructType 0)) (i_ (StructType 0))))
+              (function_returns (StructType 0))))
             (function_impl
-             (Fn
-              ((Block
-                ((Break
-                  (Expr
-                   (Reference
-                    (i
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 0))))))))))))))))
+      (structs
+       ((0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
   let source =
@@ -662,7 +642,7 @@ let%expect_test "resolving a reference from inside a function" =
             (function_impl
              (Fn ((Block ((Break (Expr (ResolvedReference (i <opaque>)))))))))))))
         (i (Value (Integer 1)))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "method access" =
   let source =
@@ -681,22 +661,20 @@ let%expect_test "method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1)))
-        (foo (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
-        (Foo
-         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((methods
+       ((res (Value (Integer 1))) (foo (Value (Struct (1 ()))))
+        (Foo (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields ())
+          (struct_methods
            ((bar
              ((function_signature
-               ((function_params
-                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                  (i IntegerType)))
+               ((function_params ((self (StructType 1)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (i IntegerType))))))))))))))))))) |}]
+               (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
+          (struct_impls ()) (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
   let source =
@@ -712,27 +690,19 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings
-       ((Foo
-         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((methods
+     ((bindings ((Foo (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields ())
+          (struct_methods
            ((bar
              ((function_signature
-               ((function_params
-                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))))
-                (function_returns
-                 (StructType ((struct_fields ()) (struct_id <opaque>))))))
+               ((function_params ((self (StructType 1))))
+                (function_returns (StructType 1))))
               (function_impl
-               (Fn
-                ((Block
-                  ((Break
-                    (Expr
-                     (Reference
-                      (self
-                       (StructType ((struct_fields ()) (struct_id <opaque>)))))))))))))))))))))) |}]
+               (Fn ((Block ((Break (Expr (Reference (self (StructType 1))))))))))))))
+          (struct_impls ()) (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct instantiation" =
   let source =
@@ -751,27 +721,14 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value
-          (Struct
-           (((struct_fields
-              ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-             (struct_id <opaque>))
-            ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-             (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
-           ((struct_fields
-             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-            (struct_id <opaque>))))
-         ()))))) |}]
+         (Value (Struct (1 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields
+           ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
   let source = {|
@@ -781,36 +738,16 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError
-        ((StructType
-          ((struct_fields ((integer ((field_type IntegerType)))))
-           (struct_id <opaque>)))
-         (StructType
-          ((struct_fields ((integer ((field_type IntegerType)))))
-           (struct_id <opaque>)))))
+     (((TypeError ((StructType 1) (StructType 0)))
        ((bindings
          ((foo
            (Value
             (Function
              ((function_signature
-               ((function_params
-                 ((i
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
-                (function_returns
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
+               ((function_params ((i (StructType 0))))
+                (function_returns (StructType 1))))
               (function_impl
-               (Fn
-                ((Block
-                  ((Return
-                    (Reference
-                     (i
-                      (StructType
-                       ((struct_fields ((integer ((field_type IntegerType)))))
-                        (struct_id <opaque>)))))))))))))))
+               (Fn ((Block ((Return (Reference (i (StructType 0)))))))))))))
           (Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
           (Int
@@ -846,28 +783,19 @@ let%expect_test "type check error" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (infos
-         (((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((methods
+        (structs
+         ((1
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
+                  (function_returns (StructType 1))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))
-                    (b (BuiltinType Builder))))
+                   ((self (StructType 1)) (b (BuiltinType Builder))))
                   (function_returns (BuiltinType Builder))))
                 (function_impl
                  (Fn
@@ -876,36 +804,21 @@ let%expect_test "type check error" =
                      (StoreInt (builder (Reference (b (BuiltinType Builder))))
                       (length (Value (Integer 64)))
                       (integer
-                       (StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((integer ((field_type IntegerType)))))
-                             (struct_id <opaque>)))))
-                         integer)))
-                      (signed true)))))))))))))
-          ((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((methods
+                       (StructField ((Reference (self (StructType 1))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
+                  (function_returns (StructType 0))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))
-                    (b (BuiltinType Builder))))
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
                   (function_returns (BuiltinType Builder))))
                 (function_impl
                  (Fn
@@ -914,22 +827,10 @@ let%expect_test "type check error" =
                      (StoreInt (builder (Reference (b (BuiltinType Builder))))
                       (length (Value (Integer 32)))
                       (integer
-                       (StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((integer ((field_type IntegerType)))))
-                             (struct_id <opaque>)))))
-                         integer)))
-                      (signed true)))))))))))))
-          ((Type (BuiltinType Builder))
-           ((methods
-             ((new
-               ((function_signature
-                 ((function_params ()) (function_returns (BuiltinType Builder))))
-                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
-        (def_infos ()))))) |}]
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "type inference" =
   let source = {|
@@ -946,7 +847,7 @@ let%expect_test "type inference" =
            ((function_signature
              ((function_params ((i IntegerType))) (function_returns IntegerType)))
             (function_impl (Fn ((Block ((Return (Reference (i IntegerType))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "scope doesn't leak bindings" =
   let source = {|
@@ -954,7 +855,12 @@ let%expect_test "scope doesn't leak bindings" =
      let a = 1;
     }
   |} in
-  pp source ; [%expect {| (Ok ((bindings ()) (infos ()) (def_infos ()))) |}]
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ()) (structs ()) (struct_counter <opaque>)
+      (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time if/then/else" =
   let source =
@@ -999,7 +905,7 @@ let%expect_test "compile-time if/then/else" =
            ((function_signature
              ((function_params ()) (function_returns BoolType)))
             (function_impl (Fn ((Block ((Break (Expr (Value (Bool true)))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
   let source =
@@ -1015,13 +921,7 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError
-        ((StructType
-          ((struct_fields ((integer ((field_type IntegerType)))))
-           (struct_id <opaque>)))
-         (StructType
-          ((struct_fields ((integer ((field_type IntegerType)))))
-           (struct_id <opaque>)))))
+     (((TypeError ((StructType 0) (StructType 1)))
        ((bindings
          ((Builder (Value (Type (BuiltinType Builder))))
           (Integer (Value (Type IntegerType)))
@@ -1058,28 +958,19 @@ let%expect_test "type check error" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (infos
-         (((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((methods
+        (structs
+         ((1
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
+                  (function_returns (StructType 1))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))
-                    (b (BuiltinType Builder))))
+                   ((self (StructType 1)) (b (BuiltinType Builder))))
                   (function_returns (BuiltinType Builder))))
                 (function_impl
                  (Fn
@@ -1088,36 +979,21 @@ let%expect_test "type check error" =
                      (StoreInt (builder (Reference (b (BuiltinType Builder))))
                       (length (Value (Integer 10)))
                       (integer
-                       (StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((integer ((field_type IntegerType)))))
-                             (struct_id <opaque>)))))
-                         integer)))
-                      (signed true)))))))))))))
-          ((Type
-            (StructType
-             ((struct_fields ((integer ((field_type IntegerType)))))
-              (struct_id <opaque>))))
-           ((methods
+                       (StructField ((Reference (self (StructType 1))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 1)))
+          (0
+           ((struct_fields ((integer ((field_type IntegerType)))))
+            (struct_methods
              ((new
                ((function_signature
                  ((function_params ((integer IntegerType)))
-                  (function_returns
-                   (StructType
-                    ((struct_fields ((integer ((field_type IntegerType)))))
-                     (struct_id <opaque>))))))
+                  (function_returns (StructType 0))))
                 (function_impl (BuiltinFn (<fun> <opaque>)))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self
-                     (StructType
-                      ((struct_fields ((integer ((field_type IntegerType)))))
-                       (struct_id <opaque>))))
-                    (b (BuiltinType Builder))))
+                   ((self (StructType 0)) (b (BuiltinType Builder))))
                   (function_returns (BuiltinType Builder))))
                 (function_impl
                  (Fn
@@ -1126,22 +1002,10 @@ let%expect_test "type check error" =
                      (StoreInt (builder (Reference (b (BuiltinType Builder))))
                       (length (Value (Integer 99)))
                       (integer
-                       (StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((integer ((field_type IntegerType)))))
-                             (struct_id <opaque>)))))
-                         integer)))
-                      (signed true)))))))))))))
-          ((Type (BuiltinType Builder))
-           ((methods
-             ((new
-               ((function_signature
-                 ((function_params ()) (function_returns (BuiltinType Builder))))
-                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
-        (def_infos ()))))) |}]
+                       (StructField ((Reference (self (StructType 0))) integer)))
+                      (signed true)))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -1159,21 +1023,18 @@ let%expect_test "implement interface op" =
   [%expect
     {|
     (Ok
-     ((bindings
-       ((one (Value (Integer 1)))
-        (Left
-         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((methods
+     ((bindings ((one (Value (Integer 1))) (Left (Value (Type (StructType 1))))))
+      (structs
+       ((1
+         ((struct_fields ())
+          (struct_methods
            ((op
              ((function_signature
                ((function_params ((left IntegerType) (right IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))
-          (impls
+          (struct_impls
            (((impl_interface
               (Value
                (Type
@@ -1191,7 +1052,9 @@ let%expect_test "implement interface op" =
                      (function_returns IntegerType)))
                    (function_impl
                     (Fn
-                     ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))))))))))) |}]
+                     ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))
+          (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -1212,32 +1075,23 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
-        (Empty
-         (Value (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))
+       ((empty (Value (Struct (0 ())))) (Empty (Value (Type (StructType 1))))
         (Make
          (Value
           (Type
            (InterfaceType
             ((interface_methods
               ((new ((function_params ()) (function_returns SelfType))))))))))))
-      (infos ())
-      (def_infos
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((methods
+      (structs
+       ((1
+         ((struct_fields ())
+          (struct_methods
            ((new
              ((function_signature
-               ((function_params ())
-                (function_returns
-                 (StructType ((struct_fields ()) (struct_id <opaque>))))))
+               ((function_params ()) (function_returns (StructType 1))))
               (function_impl
-               (Fn
-                ((Block
-                  ((Break
-                    (Expr
-                     (Value
-                      (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))
-          (impls
+               (Fn ((Block ((Break (Expr (Value (Struct (0 ()))))))))))))))
+          (struct_impls
            (((impl_interface
               (Value
                (Type
@@ -1249,17 +1103,11 @@ let%expect_test "implement interface op" =
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ())
-                     (function_returns
-                      (StructType ((struct_fields ()) (struct_id <opaque>))))))
+                    ((function_params ()) (function_returns (StructType 1))))
                    (function_impl
-                    (Fn
-                     ((Block
-                       ((Break
-                         (Expr
-                          (Value
-                           (Struct
-                            (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))))))))))) |}]
+                    (Fn ((Block ((Break (Expr (Value (Struct (0 ())))))))))))))))))))
+          (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
   let source =
@@ -1278,28 +1126,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params
-               ((self
-                 (StructType
-                  ((struct_fields
-                    ((y
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))
-                     (z
-                      ((field_type
-                        (StructType
-                         ((struct_fields
-                           ((x
-                             ((field_type
-                               (StructType
-                                ((struct_fields
-                                  ((integer ((field_type IntegerType)))))
-                                 (struct_id <opaque>))))))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))
-                (b (BuiltinType Builder))))
+             ((function_params ((self (StructType 3)) (b (BuiltinType Builder))))
               (function_returns (BuiltinType Builder))))
             (function_impl
              (Fn
@@ -1311,12 +1138,7 @@ let%expect_test "serializer inner struct" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self
-                              (StructType
-                               ((struct_fields
-                                 ((integer ((field_type IntegerType)))))
-                                (struct_id <opaque>))))
-                             (b (BuiltinType Builder))))
+                            ((self (StructType 0)) (b (BuiltinType Builder))))
                            (function_returns (BuiltinType Builder))))
                          (function_impl
                           (Fn
@@ -1327,202 +1149,45 @@ let%expect_test "serializer inner struct" =
                                (length (Value (Integer 32)))
                                (integer
                                 (StructField
-                                 ((Reference
-                                   (self
-                                    (StructType
-                                     ((struct_fields
-                                       ((integer ((field_type IntegerType)))))
-                                      (struct_id <opaque>)))))
-                                  integer)))
+                                 ((Reference (self (StructType 0))) integer)))
                                (signed true))))))))))
-                      ((StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((y
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))
-                               (z
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((x
-                                       ((field_type
-                                         (StructType
-                                          ((struct_fields
-                                            ((integer ((field_type IntegerType)))))
-                                           (struct_id <opaque>))))))))
-                                    (struct_id <opaque>))))))))
-                             (struct_id <opaque>)))))
-                         y))
-                       (Reference (b (BuiltinType Builder)))))))))
-                 (Let
-                  ((b
-                    (FunctionCall
-                     ((Value
-                       (Function
-                        ((function_signature
-                          ((function_params
-                            ((self
-                              (StructType
-                               ((struct_fields
-                                 ((x
-                                   ((field_type
-                                     (StructType
-                                      ((struct_fields
-                                        ((integer ((field_type IntegerType)))))
-                                       (struct_id <opaque>))))))))
-                                (struct_id <opaque>))))
-                             (b (BuiltinType Builder))))
-                           (function_returns (BuiltinType Builder))))
-                         (function_impl
-                          (Fn
-                           ((Block
-                             ((Let
-                               ((b
-                                 (FunctionCall
-                                  ((Value
-                                    (Function
-                                     ((function_signature
-                                       ((function_params
-                                         ((self
-                                           (StructType
-                                            ((struct_fields
-                                              ((integer
-                                                ((field_type IntegerType)))))
-                                             (struct_id <opaque>))))
-                                          (b (BuiltinType Builder))))
-                                        (function_returns (BuiltinType Builder))))
-                                      (function_impl
-                                       (Fn
-                                        ((Return
-                                          (Primitive
-                                           (StoreInt
-                                            (builder
-                                             (Reference
-                                              (b (BuiltinType Builder))))
-                                            (length (Value (Integer 32)))
-                                            (integer
-                                             (StructField
-                                              ((Reference
-                                                (self
-                                                 (StructType
-                                                  ((struct_fields
-                                                    ((integer
-                                                      ((field_type IntegerType)))))
-                                                   (struct_id <opaque>)))))
-                                               integer)))
-                                            (signed true))))))))))
-                                   ((StructField
-                                     ((Reference
-                                       (self
-                                        (StructType
-                                         ((struct_fields
-                                           ((x
-                                             ((field_type
-                                               (StructType
-                                                ((struct_fields
-                                                  ((integer
-                                                    ((field_type IntegerType)))))
-                                                 (struct_id <opaque>))))))))
-                                          (struct_id <opaque>)))))
-                                      x))
-                                    (Reference (b (BuiltinType Builder)))))))))
-                              (Return (Reference (b (BuiltinType Builder))))))))))))
-                      ((StructField
-                        ((Reference
-                          (self
-                           (StructType
-                            ((struct_fields
-                              ((y
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((integer ((field_type IntegerType)))))
-                                    (struct_id <opaque>))))))
-                               (z
-                                ((field_type
-                                  (StructType
-                                   ((struct_fields
-                                     ((x
-                                       ((field_type
-                                         (StructType
-                                          ((struct_fields
-                                            ((integer ((field_type IntegerType)))))
-                                           (struct_id <opaque>))))))))
-                                    (struct_id <opaque>))))))))
-                             (struct_id <opaque>)))))
-                         z))
+                      ((StructField ((Reference (self (StructType 3))) y))
                        (Reference (b (BuiltinType Builder)))))))))
                  (Return (Reference (b (BuiltinType Builder)))))))))))))
-        (Outer
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((y
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))
-               (z
-                ((field_type
-                  (StructType
-                   ((struct_fields
-                     ((x
-                       ((field_type
-                         (StructType
-                          ((struct_fields ((integer ((field_type IntegerType)))))
-                           (struct_id <opaque>))))))))
-                    (struct_id <opaque>))))))))
-             (struct_id <opaque>))))))
-        (Inner
-         (Value
-          (Type
-           (StructType
-            ((struct_fields
-              ((x
-                ((field_type
-                  (StructType
-                   ((struct_fields ((integer ((field_type IntegerType)))))
-                    (struct_id <opaque>))))))))
-             (struct_id <opaque>))))))))
-      (infos ())
-      (def_infos
-       (((Type
-          (StructType
-           ((struct_fields
-             ((y
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))
-              (z
-               ((field_type
-                 (StructType
-                  ((struct_fields
-                    ((x
-                      ((field_type
-                        (StructType
-                         ((struct_fields ((integer ((field_type IntegerType)))))
-                          (struct_id <opaque>))))))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ())
-        ((Type
-          (StructType
-           ((struct_fields
-             ((x
-               ((field_type
-                 (StructType
-                  ((struct_fields ((integer ((field_type IntegerType)))))
-                   (struct_id <opaque>))))))))
-            (struct_id <opaque>))))
-         ()))))) |}]
+        (Outer (Value (Type (StructType 3))))
+        (Inner (Value (Type (StructType 1))))))
+      (structs
+       ((3
+         ((struct_fields
+           ((y ((field_type (StructType 0)))) (z ((field_type (StructType 1))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 3)))
+        (1
+         ((struct_fields ((x ((field_type (StructType 0)))))) (struct_methods ())
+          (struct_impls ()) (struct_id 1)))
+        (0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 32)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
   let source =
@@ -1565,7 +1230,7 @@ let%expect_test "reference resolving in inner functions" =
                           ((Break
                             (Expr
                              (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "dependent types" =
   let source =
@@ -1636,7 +1301,7 @@ let%expect_test "dependent types" =
                       ((function_params
                         ((x (ExprType (Reference (X (TypeN 0)))))))
                        (function_returns (ExprType (Reference (X (TypeN 0))))))))))))))))))))))
-      (infos ()) (def_infos ()))) |}]
+      (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "TypeN" =
   let source =
@@ -1694,14 +1359,7 @@ let%expect_test "TypeN" =
              ((function_signature
                ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
               (function_impl (BuiltinFn (<fun> <opaque>)))))))))
-        (infos
-         (((Type (BuiltinType Builder))
-           ((methods
-             ((new
-               ((function_signature
-                 ((function_params ()) (function_returns (BuiltinType Builder))))
-                (function_impl (Fn ((Return (Primitive EmptyBuilder)))))))))))))
-        (def_infos ()))))) |}]
+        (structs ()) (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "unions" =
   let source =
@@ -1718,17 +1376,55 @@ let%expect_test "unions" =
     (Ok
      ((bindings
        ((Test
-         (Value
-          (Type
-           (UnionType
-            ((cases
-              ((StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>)))
-               (StructType
-                ((struct_fields ((integer ((field_type IntegerType)))))
-                 (struct_id <opaque>))))))))))))
-      (infos ()) (def_infos ()))) |}]
+         (Value (Type (UnionType ((cases ((StructType 0) (StructType 1))))))))))
+      (structs
+       ((1
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 1))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 1)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 64)))
+                    (integer
+                     (StructField ((Reference (self (StructType 1))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 1)))
+        (0
+         ((struct_fields ((integer ((field_type IntegerType)))))
+          (struct_methods
+           ((new
+             ((function_signature
+               ((function_params ((integer IntegerType)))
+                (function_returns (StructType 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))
+            (serialize
+             ((function_signature
+               ((function_params
+                 ((self (StructType 0)) (b (BuiltinType Builder))))
+                (function_returns (BuiltinType Builder))))
+              (function_impl
+               (Fn
+                ((Return
+                  (Primitive
+                   (StoreInt (builder (Reference (b (BuiltinType Builder))))
+                    (length (Value (Integer 257)))
+                    (integer
+                     (StructField ((Reference (self (StructType 0))) integer)))
+                    (signed true)))))))))))
+          (struct_impls ()) (struct_id 0)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =
   let source =
@@ -1747,8 +1443,7 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((x (Value (Integer 10)))
-        (foo (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
+       ((x (Value (Integer 10))) (foo (Value (Struct (1 ()))))
         (Foo
          (Value
           (Function
@@ -1759,20 +1454,36 @@ let%expect_test "methods monomorphization" =
               ((Block
                 ((Break
                   (Expr
-                   (Value
-                    (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
-      (infos ())
-      (def_infos
-       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
-         ((methods
+                   (MkStructDef
+                    ((mk_struct_fields ())
+                     (mk_methods
+                      ((id
+                        ((function_signature
+                          ((function_params
+                            ((self (StructType 0))
+                             (x (ExprType (Reference (X (TypeN 0)))))))
+                           (function_returns
+                            (ExprType (Reference (X (TypeN 0)))))))
+                         (function_impl
+                          (Fn
+                           ((Block
+                             ((Break
+                               (Expr
+                                (Reference
+                                 (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
+                     (mk_impls ()) (mk_struct_id 0))))))))))))))))
+      (structs
+       ((1
+         ((struct_fields ())
+          (struct_methods
            ((id
              ((function_signature
-               ((function_params
-                 ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
-                  (x (ExprType (Reference (X (TypeN 0)))))))
-                (function_returns (ExprType (Reference (X (TypeN 0)))))))
+               ((function_params ((self (StructType 1)) (x IntegerType)))
+                (function_returns IntegerType)))
               (function_impl
                (Fn
                 ((Block
                   ((Break
-                    (Expr (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))))) |}]
+                    (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
+          (struct_impls ()) (struct_id 1)))))
+      (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -321,6 +321,28 @@ let%expect_test "basic struct definition" =
                   ((struct_fields ((integer ((field_type IntegerType)))))
                    (struct_id <opaque>))))))))
             (struct_id <opaque>))))
+         ())))
+      (methods_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((t
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
+         ())))
+      (impls_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((t
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
          ()))))) |}]
 
 let%expect_test "native function evaluation" =
@@ -522,6 +544,30 @@ let%expect_test "struct definition" =
                      (struct_id <opaque>))))))
                 (b ((field_type BoolType)))))
               (struct_id <opaque>))))
+           ())))
+        (methods_defs
+         (((Type
+            (StructType
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (StructType
+                    ((struct_fields ((integer ((field_type IntegerType)))))
+                     (struct_id <opaque>))))))
+                (b ((field_type BoolType)))))
+              (struct_id <opaque>))))
+           ())))
+        (impls_defs
+         (((Type
+            (StructType
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (StructType
+                    ((struct_fields ((integer ((field_type IntegerType)))))
+                     (struct_id <opaque>))))))
+                (b ((field_type BoolType)))))
+              (struct_id <opaque>))))
            ()))))) |}]
 
 let%expect_test "duplicate type field" =
@@ -659,6 +705,30 @@ let%expect_test "duplicate type field" =
                      (struct_id <opaque>))))))
                 (a ((field_type BoolType)))))
               (struct_id <opaque>))))
+           ())))
+        (methods_defs
+         (((Type
+            (StructType
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (StructType
+                    ((struct_fields ((integer ((field_type IntegerType)))))
+                     (struct_id <opaque>))))))
+                (a ((field_type BoolType)))))
+              (struct_id <opaque>))))
+           ())))
+        (impls_defs
+         (((Type
+            (StructType
+             ((struct_fields
+               ((a
+                 ((field_type
+                   (StructType
+                    ((struct_fields ((integer ((field_type IntegerType)))))
+                     (struct_id <opaque>))))))
+                (a ((field_type BoolType)))))
+              (struct_id <opaque>))))
            ()))))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -734,14 +804,15 @@ let%expect_test "parametric struct instantiation" =
                         ((struct_fields ((integer ((field_type IntegerType)))))
                          (struct_id <opaque>)))))
                      integer)))
-                  (signed true)))))))))))
-        ((Type
+                  (signed true)))))))))))))
+      (methods_defs
+       (((Type
           (StructType
            ((struct_fields
              ((a ((field_type (ExprType (Reference (A (TypeN 0)))))))))
             (struct_id <opaque>))))
          ())))
-      (impls
+      (impls_defs
        (((Type
           (StructType
            ((struct_fields
@@ -1038,6 +1109,18 @@ let%expect_test "method access" =
             (function_impl
              (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))))
       (impls
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ())))
+      (methods_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((bar
+           ((function_signature
+             ((function_params
+               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
+                (i IntegerType)))
+              (function_returns IntegerType)))
+            (function_impl
+             (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))))
+      (impls_defs
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -1073,6 +1156,23 @@ let%expect_test "Self type resolution in methods" =
                    (Reference
                     (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
       (impls
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ())))
+      (methods_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((bar
+           ((function_signature
+             ((function_params
+               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))))
+              (function_returns
+               (StructType ((struct_fields ()) (struct_id <opaque>))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (Reference
+                    (self (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
+      (impls_defs
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]
 
 let%expect_test "struct instantiation" =
@@ -1113,6 +1213,20 @@ let%expect_test "struct instantiation" =
             (struct_id <opaque>))))
          ())))
       (impls
+       (((Type
+          (StructType
+           ((struct_fields
+             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
+            (struct_id <opaque>))))
+         ())))
+      (methods_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
+            (struct_id <opaque>))))
+         ())))
+      (impls_defs
        (((Type
           (StructType
            ((struct_fields
@@ -1522,6 +1636,33 @@ let%expect_test "implement interface op" =
                   ((function_params ((left IntegerType) (right IntegerType)))
                    (function_returns IntegerType)))
                  (function_impl
+                  (Fn ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))))
+      (methods_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((op
+           ((function_signature
+             ((function_params ((left IntegerType) (right IntegerType)))
+              (function_returns IntegerType)))
+            (function_impl
+             (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))
+      (impls_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         (((impl_interface
+            (Value
+             (Type
+              (InterfaceType
+               ((interface_methods
+                 ((op
+                   ((function_params ((left IntegerType) (right IntegerType)))
+                    (function_returns IntegerType))))))))))
+           (impl_methods
+            ((op
+              (Value
+               (Function
+                ((function_signature
+                  ((function_params ((left IntegerType) (right IntegerType)))
+                   (function_returns IntegerType)))
+                 (function_impl
                   (Fn ((Block ((Break (Expr (Reference (left IntegerType)))))))))))))))))))))) |}]
 
 let%expect_test "implement interface op" =
@@ -1567,6 +1708,43 @@ let%expect_test "implement interface op" =
                    (Value
                     (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))
       (impls
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         (((impl_interface
+            (Value
+             (Type
+              (InterfaceType
+               ((interface_methods
+                 ((new ((function_params ()) (function_returns SelfType))))))))))
+           (impl_methods
+            ((new
+              (Value
+               (Function
+                ((function_signature
+                  ((function_params ())
+                   (function_returns
+                    (StructType ((struct_fields ()) (struct_id <opaque>))))))
+                 (function_impl
+                  (Fn
+                   ((Block
+                     ((Break
+                       (Expr
+                        (Value
+                         (Struct (((struct_fields ()) (struct_id <opaque>)) ())))))))))))))))))))))
+      (methods_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((new
+           ((function_signature
+             ((function_params ())
+              (function_returns
+               (StructType ((struct_fields ()) (struct_id <opaque>))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (Value
+                    (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))))))))))))))
+      (impls_defs
        (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
          (((impl_interface
             (Value
@@ -1979,6 +2157,68 @@ let%expect_test "serializer inner struct" =
                   ((struct_fields ((integer ((field_type IntegerType)))))
                    (struct_id <opaque>))))))))
             (struct_id <opaque>))))
+         ())))
+      (methods_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((y
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))
+              (z
+               ((field_type
+                 (StructType
+                  ((struct_fields
+                    ((x
+                      ((field_type
+                        (StructType
+                         ((struct_fields ((integer ((field_type IntegerType)))))
+                          (struct_id <opaque>))))))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
+         ())
+        ((Type
+          (StructType
+           ((struct_fields
+             ((x
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
+         ())))
+      (impls_defs
+       (((Type
+          (StructType
+           ((struct_fields
+             ((y
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))
+              (z
+               ((field_type
+                 (StructType
+                  ((struct_fields
+                    ((x
+                      ((field_type
+                        (StructType
+                         ((struct_fields ((integer ((field_type IntegerType)))))
+                          (struct_id <opaque>))))))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
+         ())
+        ((Type
+          (StructType
+           ((struct_fields
+             ((x
+               ((field_type
+                 (StructType
+                  ((struct_fields ((integer ((field_type IntegerType)))))
+                   (struct_id <opaque>))))))))
+            (struct_id <opaque>))))
          ()))))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -2084,7 +2324,14 @@ let%expect_test "dependent types" =
                              (Expr
                               (Reference
                                (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
-                 (Break (Expr (ResolvedReference (f <opaque>))))))))))))))))) |}]
+                 (Break
+                  (Expr
+                   (Reference
+                    (f
+                     (FunctionType
+                      ((function_params
+                        ((x (ExprType (Reference (X (TypeN 0)))))))
+                       (function_returns (ExprType (Reference (X (TypeN 0)))))))))))))))))))))))) |}]
 
 let%expect_test "TypeN" =
   let source =
@@ -2247,3 +2494,62 @@ let%expect_test "unions" =
                          (struct_id <opaque>)))))
                      integer)))
                   (signed true))))))))))))))) |}]
+
+let%expect_test "methods monomorphization" =
+  let source =
+    {|
+      fn Foo(X: Type) -> Type {
+        struct {
+          fn id(self: Self, x: X) -> X { x }
+        }
+      }
+      let foo = Foo(Integer) {};
+      let x = foo.id(10);
+    |}
+  in
+  pp source;
+  [%expect {|
+    (Ok
+     ((bindings
+       ((x (Value (Integer 10)))
+        (foo (Value (Struct (((struct_fields ()) (struct_id <opaque>)) ()))))
+        (Foo
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((X (TypeN 0)))) (function_returns (TypeN 0))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr
+                   (Value
+                    (Type (StructType ((struct_fields ()) (struct_id <opaque>))))))))))))))))))
+      (methods
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((id
+           ((function_signature
+             ((function_params
+               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
+                (x IntegerType)))
+              (function_returns IntegerType)))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
+      (methods_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>))))
+         ((id
+           ((function_signature
+             ((function_params
+               ((self (StructType ((struct_fields ()) (struct_id <opaque>))))
+                (x (ExprType (Reference (X (TypeN 0)))))))
+              (function_returns (ExprType (Reference (X (TypeN 0)))))))
+            (function_impl
+             (Fn
+              ((Block
+                ((Break
+                  (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))))
+      (impls_defs
+       (((Type (StructType ((struct_fields ()) (struct_id <opaque>)))) ()))))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -1521,6 +1521,10 @@ let%expect_test "methods monomorphization" =
       }
       let foo = Foo(Integer) {};
       let x = foo.id(10);
+
+      struct Empty {}
+      let foo_empty = Foo(Empty) {};
+      let y = foo_empty.id(Empty{});
     |}
   in
   pp source ;
@@ -1528,7 +1532,9 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((x (Value (Integer 10))) (foo (Value (Struct (101 ()))))
+       ((y (Value (Struct (103 ())))) (foo_empty (Value (Struct (104 ()))))
+        (Empty (Value (Type (StructType 103)))) (x (Value (Integer 10)))
+        (foo (Value (Struct (101 ()))))
         (Foo
          (Value
           (Function
@@ -1558,7 +1564,23 @@ let%expect_test "methods monomorphization" =
                                  (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
                      (mk_impls ()) (mk_struct_id 100))))))))))))))))
       (structs
-       ((101
+       ((104
+         ((struct_fields ())
+          (struct_methods
+           ((id
+             ((function_signature
+               ((function_params ((self (StructType 104)) (x (StructType 103))))
+                (function_returns (StructType 103))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))))
+          (struct_impls ()) (struct_id 104)))
+        (103
+         ((struct_fields ()) (struct_methods ()) (struct_impls ())
+          (struct_id 103)))
+        (101
          ((struct_fields ())
           (struct_methods
            ((id

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -19,9 +19,8 @@ let make_errors e = new Errors.errors e
 let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 
 let build_program ?(errors = make_errors Show.show_error)
-    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_infos)
-    ?(strip_defaults = true) p =
-  let c = new Lang.constructor bindings methods errors in
+    ?(bindings = Lang.default_bindings) ?(strip_defaults = true) p =
+  let c = new Lang.constructor bindings errors in
   let p' = c#visit_program () p in
   errors#to_result p'
   (* remove default bindings and methods *)
@@ -30,13 +29,8 @@ let build_program ?(errors = make_errors Show.show_error)
            { program with
              bindings =
                List.filter program.bindings ~f:(fun binding ->
-                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
-             infos =
-               List.filter program.infos ~f:(fun (rcvr, rmethods) ->
-                   not
-                   @@ List.exists program.infos ~f:(fun (rcvr', rmethods') ->
-                          Lang.equal_value rcvr' rcvr
-                          && Lang.equal_struct_info rmethods' rmethods ) ) }
+                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) )
+           }
          else program )
   |> Result.map_error ~f:(fun errors ->
          List.map errors ~f:(fun (_, err, _) -> (err, p')) )

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -19,7 +19,7 @@ let make_errors e = new Errors.errors e
 let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 
 let build_program ?(errors = make_errors Show.show_error)
-    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_methods)
+    ?(bindings = Lang.default_bindings) ?(methods = Lang.default_infos)
     ?(strip_defaults = true) p =
   let c = new Lang.constructor bindings methods errors in
   let p' = c#visit_program () p in
@@ -31,16 +31,12 @@ let build_program ?(errors = make_errors Show.show_error)
              bindings =
                List.filter program.bindings ~f:(fun binding ->
                    not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
-             methods =
-               List.filter program.methods ~f:(fun (rcvr, rmethods) ->
+             infos =
+               List.filter program.infos ~f:(fun (rcvr, rmethods) ->
                    not
-                   @@ List.exists methods ~f:(fun (rcvr', rmethods') ->
+                   @@ List.exists program.infos ~f:(fun (rcvr', rmethods') ->
                           Lang.equal_value rcvr' rcvr
-                          && List.equal
-                               (fun (name, value) (name', value') ->
-                                 String.equal name' name
-                                 && Lang.equal_function_ value' value )
-                               rmethods' rmethods ) ) }
+                          && Lang.equal_struct_info rmethods' rmethods ) ) }
          else program )
   |> Result.map_error ~f:(fun errors ->
          List.map errors ~f:(fun (_, err, _) -> (err, p')) )

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -19,8 +19,9 @@ let make_errors e = new Errors.errors e
 let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 
 let build_program ?(errors = make_errors Show.show_error)
-    ?(bindings = Lang.default_bindings) ?(strip_defaults = true) p =
-  let c = new Lang.constructor bindings errors in
+    ?(bindings = Lang.default_bindings) ?(structs = Lang.default_structs)
+    ?(strip_defaults = true) p =
+  let c = new Lang.constructor bindings structs errors in
   let p' = c#visit_program () p in
   errors#to_result p'
   (* remove default bindings and methods *)
@@ -29,7 +30,11 @@ let build_program ?(errors = make_errors Show.show_error)
            { program with
              bindings =
                List.filter program.bindings ~f:(fun binding ->
-                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) )
+                   not @@ List.exists bindings ~f:(Lang.equal_binding binding) );
+             structs =
+               List.filter program.structs ~f:(fun (id1, _) ->
+                   not
+                   @@ List.exists structs ~f:(fun (id2, _) -> equal_int id1 id2) )
            }
          else program )
   |> Result.map_error ~f:(fun errors ->


### PR DESCRIPTION
It is possible situation when method can depend on the input argument of generic function, like in the following:
```
fn Foo(X: Type) {
 struct {
  fn id(self: Self, x: X) -> X { x }
 }
}
```
In this case we need to postpound function generation to times when it will be possible to know the type.

This commit implements this. In this commit was added fields program.methods_defs and program.impls_def. These fields contains yet unknown methods and impls that must be resolved later when function `Foo` will called.

Current implementation is bad, so we will try to found another solution. One possible solution is to add fields `methods` and `impls` back to the `struct` type, but it may cause problems with self-referential types.