### PR TITLE
Add fully-qualified unions support

### DIFF
--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -101,7 +101,8 @@ and compile_from_string ?(codegen = Codegen_func.codegen)
   | stx -> (
       let errors = new Errors.errors Show.show_error in
       let constructor =
-        new Lang.constructor Lang.default_bindings Lang.default_structs errors
+        new Lang.constructor
+          Lang.default_bindings Lang.default_structs [] errors
       in
       let program = constructor#visit_program () stx in
       match errors#to_result program with

--- a/lib/discriminator.ml
+++ b/lib/discriminator.ml
@@ -1,0 +1,11 @@
+open Lang_types
+open Base
+
+module LocalDiscriminators = struct
+  type t = unit
+
+  let choose_discriminators :
+      t -> int -> type_ list -> (type_ * discriminator) list =
+   fun _ _ cases ->
+    List.mapi cases ~f:(fun id case -> (case, Lang_types.Discriminator id))
+end

--- a/lib/dune
+++ b/lib/dune
@@ -31,7 +31,8 @@
   codegen_func
   show
   compiler
-  type_check)
+  type_check
+  discriminator)
  (name tact))
 
 (ocamllex asm_lexer)

--- a/lib/func.ml
+++ b/lib/func.ml
@@ -35,6 +35,7 @@ and type_ =
   | SliceType
   | BuilderType
   | TupleType of type_ list
+  | UnknownTuple
   | TensorType of type_ list
   | FunctionType of function_
   | ContType
@@ -197,6 +198,8 @@ and pp_type f = function
         ~f:(fun (t : type_) -> pp_type f t ; pp_print_string f ", ")
         ~flast:(pp_type f) ;
       pp_print_string f "]"
+  | UnknownTuple ->
+      pp_print_string f "tuple"
   | TensorType tuple ->
       pp_print_string f "(" ;
       list_iter tuple

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -199,8 +199,12 @@ class interpreter
             let union =
               Program.with_union_id program
                 (fun id ->
-                  {cases; union_methods = []; union_impls = []; union_id = id}
-                  )
+                  { cases =
+                      Discriminator.LocalDiscriminators.choose_discriminators ()
+                        id cases;
+                    union_methods = [];
+                    union_impls = [];
+                    union_id = id } )
                 (fun u_base ->
                   let union_updater =
                     new union_updater mk_union.mk_union_id u_base.union_id
@@ -230,7 +234,7 @@ class interpreter
                                        (union_updater#visit_expr () x) ) ) ) } )
                   in
                   Ok
-                    { cases;
+                    { cases = u_base.cases;
                       union_methods;
                       union_impls;
                       union_id = u_base.union_id } )

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -25,6 +25,14 @@ class ['s] union_updater (old : int) (new_s : int) =
 
     method! visit_UnionType _ s =
       if equal_int s old then UnionType new_s else UnionType s
+
+    method! visit_UnionVariant _ (expr, s) =
+      if equal_int s old then UnionVariant (expr, new_s)
+      else UnionVariant (expr, s)
+
+    method! visit_MakeUnionVariant _ (expr, s) =
+      if equal_int s old then MakeUnionVariant (expr, new_s)
+      else MakeUnionVariant (expr, s)
   end
 
 let get_memoized_or_execute p (f, args) ~execute =

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -483,7 +483,8 @@ functor
           let cases = s#of_located_list members in
           Program.with_union_id program
             (fun id ->
-              { cases = List.map cases ~f:expr_to_type;
+              { cases =
+                  List.map cases ~f:(fun x -> (expr_to_type x, Discriminator 0));
                 union_methods = [];
                 union_impls = [];
                 union_id = id } )

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -65,7 +65,8 @@ functor
       end
 
     class ['s] constructor (bindings : (string * expr) list)
-      (structs : (int * struct_) list) (errors : _ errors) =
+      (structs : (int * struct_) list) (unions : (int * union) list)
+      (errors : _ errors) =
       object (s : 's)
         inherit ['s] Syntax.visitor as super
 
@@ -81,7 +82,7 @@ functor
         (* Program handle we pass to builtin functions. *)
         (* IDs from 0 to 99 inlusevily is reserved for built-in structs. *)
         val mutable program =
-          {bindings; structs; struct_counter = 100; memoized_fcalls = []}
+          {bindings; structs; unions; struct_counter = 100; memoized_fcalls = []}
 
         method build_CodeBlock _env code_block =
           Block (s#of_located_list code_block)
@@ -226,7 +227,7 @@ functor
 
         method build_StructConstructor _env sc = Value (Struct sc)
 
-        method build_Union _env union = Value (Type (UnionType union))
+        method build_Union _env union = MkUnionDef union
 
         method build_Expr _env expr = Expr expr
 
@@ -473,8 +474,40 @@ functor
           fun _env field_name field_type ->
             (Syntax.value field_name, Syntax.value field_type)
 
-        method build_union_definition _env members _bindings =
-          {cases = List.map (s#of_located_list members) ~f:expr_to_type}
+        method build_union_definition _ _ _ = raise InternalCompilerError
+
+        method! visit_union_definition env def =
+          let members =
+            s#visit_list (s#visit_located s#visit_expr) env def.union_members
+          in
+          let cases = s#of_located_list members in
+          Program.with_union_id program
+            (fun id ->
+              { cases = List.map cases ~f:expr_to_type;
+                union_methods = [];
+                union_id = id } )
+            (fun u_base ->
+              let methods =
+                s#with_bindings
+                  [ make_comptime
+                      ("Self", Value (Type (UnionType u_base.union_id))) ]
+                  (fun _ ->
+                    s#visit_list
+                      (s#visit_located s#visit_binding)
+                      env def.union_bindings )
+                |> s#of_located_list
+                |> List.map ~f:(fun (name, e) ->
+                       match e with
+                       | Value (Function f) ->
+                           (name, f)
+                       | _ ->
+                           raise InternalCompilerError )
+              in
+              Error
+                { mk_cases = cases;
+                  mk_union_id = u_base.union_id;
+                  mk_union_methods = methods } )
+          |> Result.error |> Option.value_exn
 
         method private of_located_list : 'a. 'a Syntax.located list -> 'a list =
           List.map ~f:Syntax.value

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -485,6 +485,7 @@ functor
             (fun id ->
               { cases = List.map cases ~f:expr_to_type;
                 union_methods = [];
+                union_impls = [];
                 union_id = id } )
             (fun u_base ->
               let methods =
@@ -506,6 +507,7 @@ functor
               Error
                 { mk_cases = cases;
                   mk_union_id = u_base.union_id;
+                  mk_union_impls = [];
                   mk_union_methods = methods } )
           |> Result.error |> Option.value_exn
 

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -101,10 +101,14 @@ and type_ =
 and mk_union =
   { mk_cases : expr list;
     mk_union_methods : (string * function_) list;
+    mk_union_impls : impl list; [@sexp.list]
     mk_union_id : int }
 
 and union =
-  {cases : type_ list; union_methods : (string * function_) list; union_id : int}
+  { cases : type_ list;
+    union_methods : (string * function_) list;
+    union_impls : impl list; [@sexp.list]
+    union_id : int }
 
 and mk_struct =
   { mk_struct_fields : (string * expr) list;

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -36,6 +36,7 @@ and binding_scope = Comptime of expr | Runtime of type_
 and program =
   { bindings : (string * expr) list;
     mutable structs : (int * struct_) list;
+    mutable unions : (int * union) list; [@sexp.list]
     mutable struct_counter : (int[@sexp.opaque]);
     mutable memoized_fcalls : (((value * value list) * value) list[@sexp.opaque])
   }
@@ -43,7 +44,8 @@ and program =
 and expr =
   | FunctionCall of function_call
   | MkStructDef of mk_struct
-  | MakeUnionVariant of (expr * union)
+  | MkUnionDef of mk_union
+  | MakeUnionVariant of (expr * int)
   | Reference of (string * type_)
   | ResolvedReference of (string * (expr[@sexp.opaque]))
   | Value of value
@@ -60,7 +62,7 @@ and value =
   | Void
   | Struct of (int * (string * expr) list)
   | StructDef of struct_
-  | UnionVariant of (value * union)
+  | UnionVariant of (value * int)
   | Function of function_
   | Integer of (Zint.t[@visitors.name "z"])
   | Bool of bool
@@ -87,7 +89,7 @@ and type_ =
   | VoidType
   | BuiltinType of builtin
   | StructType of int
-  | UnionType of union
+  | UnionType of int
   | FunctionType of function_signature
   | InterfaceType of interface
   | HoleType
@@ -96,7 +98,13 @@ and type_ =
   | ExprType of expr
   | Dependent of string * type_
 
-and union = {cases : type_ list}
+and mk_union =
+  { mk_cases : expr list;
+    mk_union_methods : (string * function_) list;
+    mk_union_id : int }
+
+and union =
+  {cases : type_ list; union_methods : (string * function_) list; union_id : int}
 
 and mk_struct =
   { mk_struct_fields : (string * expr) list;
@@ -353,11 +361,7 @@ module Program = struct
         raise Errors.InternalCompilerError
     | (xid, old_s) :: xs ->
         if equal_int xid id then
-          match new_s with
-          | Ok new_s ->
-              (new_s.struct_id, new_s) :: xs
-          | Error _ ->
-              xs
+          match new_s with Ok new_s -> (id, new_s) :: xs | Error _ -> xs
         else (xid, old_s) :: update_list id new_s xs
 
   let with_struct p s f =
@@ -374,4 +378,21 @@ module Program = struct
     let new_s = f id in
     p.structs <- (id, new_s) :: p.structs ;
     new_s
+
+  let with_union p u f =
+    p.unions <- (u.union_id, u) :: p.unions ;
+    let new_u = f () in
+    p.unions <- update_list u.union_id new_u p.unions ;
+    new_u
+
+  (* Creates new struct id, calls function with this new id and then
+     places returning union to the program.unions *)
+  let with_union_id p mk_union f =
+    let id = p.struct_counter in
+    p.struct_counter <- p.struct_counter + 1 ;
+    let u = mk_union id in
+    p.unions <- (u.union_id, u) :: p.unions ;
+    let new_union = f u in
+    p.unions <- update_list id new_union p.unions ;
+    new_union
 end

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -105,7 +105,7 @@ and mk_union =
     mk_union_id : int }
 
 and union =
-  { cases : type_ list;
+  { cases : (type_ * discriminator) list;
     union_methods : (string * function_) list;
     union_impls : impl list; [@sexp.list]
     union_id : int }
@@ -121,6 +121,8 @@ and struct_ =
     struct_methods : (string * function_) list;
     struct_impls : impl list;
     struct_id : int }
+
+and discriminator = Discriminator of int
 
 and struct_field = {field_type : type_}
 

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -71,6 +71,9 @@ functor
     let show_error : error -> string = function
       | `DuplicateField (field, _) ->
           Printf.sprintf "Duplicate field `%s`." field
+      | `DuplicateVariant ty ->
+          Printf.sprintf "Duplicate variant with type `%s`."
+            (format_to_string ty pp_type)
       | `UnresolvedIdentifier id ->
           Printf.sprintf "Unresolved identifier `%s`." id
       | `MethodNotFound (e, m) ->

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -47,6 +47,7 @@ functor
       { enum_name : ident located;
         enum_value : expr located option [@sexp.option] }
 
+    (* TODO: union impls *)
     and union_definition =
       { union_members : expr located list; [@sexpa.list]
         union_bindings : binding located list [@sexp.list] }

--- a/lib/type_check.ml
+++ b/lib/type_check.ml
@@ -65,6 +65,26 @@ class type_checker (errors : _) (functions : _) =
               Error (NeedFromCall m)
           | _ ->
               Error (TypeError expected) )
+      | UnionType u -> (
+          let from_intf_ =
+            let inter =
+              new interpreter (program, current_bindings, errors, functions)
+            in
+            Value (inter#interpret_fc (from_intf, [Value (Type actual)]))
+          in
+          let impl =
+            (List.Assoc.find_exn program.unions u ~equal:equal_int).union_impls
+            |> List.find_map ~f:(fun i ->
+                   if equal_expr i.impl_interface from_intf_ then
+                     Some i.impl_methods
+                   else None )
+            |> Option.bind ~f:List.hd
+          in
+          match impl with
+          | Some (_, m) ->
+              Error (NeedFromCall m)
+          | _ ->
+              Error (TypeError expected) )
       | _otherwise ->
           Error (TypeError expected)
   end

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -241,3 +241,35 @@ let%expect_test "serializer inner struct" =
       builder b = f0(first(self), b);
       return b;
     } |}]
+
+let%expect_test "unions" =
+  let source =
+    {|
+    struct Empty{}
+    union Uni {
+      case Integer
+      case Empty
+    }
+    fn try(x: Uni) -> Uni { x }
+    fn test_try(x: Integer, y: Empty) {
+      let test1 = try(x);
+      let test2 = try(y);
+    }
+  |}
+  in
+  pp source ;
+  [%expect
+    {|
+    tuple try(tuple x) {
+      x;
+    }
+    tuple f0(int v) {
+      return [1, v];
+    }
+    tuple f1([] v) {
+      return [0, v];
+    }
+    _ test_try(int x, [] y) {
+      tuple test1 = try(f0(x));
+      tuple test2 = try(f1(y));
+    } |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -19,7 +19,7 @@ let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 let build_program ?(errors = make_errors Show.show_error)
     ?(bindings = Lang.default_bindings) ?(structs = Lang.default_structs)
     ?(strip_defaults = false) p =
-  let c = new Lang.constructor bindings structs errors in
+  let c = new Lang.constructor bindings structs [] errors in
   let p' = c#visit_program () p in
   errors#to_result p'
   (* remove default bindings and methods *)

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -1444,6 +1444,102 @@ let%expect_test "TypeN" =
             (struct_impls ()) (struct_id 0)))))
         (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
+let%expect_test "unions duplicate variant" =
+  let source =
+    {|
+      fn Test(T: Type) {
+        union {
+          case Integer
+          case T
+        }
+      }
+      let a = Test(Builder); // should be OK
+      let b = Test(Integer); // should fail
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Error
+     (((DuplicateVariant IntegerType)
+       ((bindings
+         ((b (Value (Type (UnionType 102)))) (a (Value (Type (UnionType 101))))
+          (Test
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((T (TypeN 0))))
+                (function_returns
+                 (InvalidType
+                  (MkUnionDef
+                   ((mk_cases
+                     ((ResolvedReference (Integer <opaque>))
+                      (Value (Type (Dependent T (TypeN 0))))))
+                    (mk_union_methods ()) (mk_union_id 100)))))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Break
+                    (Expr
+                     (MkUnionDef
+                      ((mk_cases
+                        ((ResolvedReference (Integer <opaque>))
+                         (Reference (T (TypeN 0)))))
+                       (mk_union_methods ()) (mk_union_id 100))))))))))))))
+          (Builder (Value (Type (StructType 0))))
+          (Integer (Value (Type IntegerType)))
+          (Int
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((bits IntegerType)))
+                (function_returns (TypeN 0))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (Bool (Value (Type BoolType))) (Type (Value (Type (TypeN 0))))
+          (Void (Value Void))
+          (serializer
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((t (TypeN 0))))
+                (function_returns
+                 (FunctionType
+                  ((function_params ((t HoleType) (b (StructType 0))))
+                   (function_returns (StructType 0)))))))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))
+          (BinOp
+           (Value
+            (Type
+             (InterfaceType
+              ((interface_methods
+                ((op
+                  ((function_params ((left IntegerType) (right IntegerType)))
+                   (function_returns IntegerType))))))))))
+          (From
+           (Value
+            (Function
+             ((function_signature
+               ((function_params ((T (TypeN 0)))) (function_returns HoleType)))
+              (function_impl (BuiltinFn (<fun> <opaque>)))))))))
+        (structs
+         ((0
+           ((struct_fields ((builder ((field_type (BuiltinType Builder))))))
+            (struct_methods
+             ((new
+               ((function_signature
+                 ((function_params ()) (function_returns (StructType 0))))
+                (function_impl
+                 (Fn
+                  ((Return
+                    (Value (Struct (0 ((builder (Primitive EmptyBuilder))))))))))))))
+            (struct_impls ()) (struct_id 0)))))
+        (unions
+         ((102 ((cases (IntegerType)) (union_methods ()) (union_id 102)))
+          (101
+           ((cases ((StructType 0) IntegerType)) (union_methods ())
+            (union_id 101)))))
+        (struct_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
+
 let%expect_test "unions" =
   let source =
     {|
@@ -1512,7 +1608,7 @@ let%expect_test "unions" =
           (struct_impls ()) (struct_id 100)))))
       (unions
        ((101
-         ((cases ((StructType 100) (StructType 101)))
+         ((cases ((StructType 101) (StructType 100)))
           (union_methods
            ((id
              ((function_signature

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -1450,6 +1450,9 @@ let%expect_test "unions" =
       union Test {
         case Int(257)
         case Int(64)
+        fn id(self: Self) -> Self {
+          self
+        }
       }
     |}
   in
@@ -1457,9 +1460,7 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings
-       ((Test
-         (Value (Type (UnionType ((cases ((StructType 100) (StructType 101))))))))))
+     ((bindings ((Test (Value (Type (UnionType 101))))))
       (structs
        ((101
          ((struct_fields ((integer ((field_type IntegerType)))))
@@ -1509,6 +1510,17 @@ let%expect_test "unions" =
                      (StructField ((Reference (self (StructType 100))) integer)))
                     (signed true)))))))))))
           (struct_impls ()) (struct_id 100)))))
+      (unions
+       ((101
+         ((cases ((StructType 100) (StructType 101)))
+          (union_methods
+           ((id
+             ((function_signature
+               ((function_params ((self (UnionType 101))))
+                (function_returns (UnionType 101))))
+              (function_impl
+               (Fn ((Block ((Break (Expr (Reference (self (UnionType 101))))))))))))))
+          (union_id 101)))))
       (struct_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -1503,7 +1503,9 @@ let%expect_test "union variants constructing" =
           (struct_impls ()) (struct_id 100)))))
       (unions
        ((101
-         ((cases ((StructType 100) IntegerType)) (union_methods ())
+         ((cases
+           (((StructType 100) (Discriminator 0)) (IntegerType (Discriminator 1))))
+          (union_methods ())
           (union_impls
            (((impl_interface
               (Value
@@ -1759,7 +1761,7 @@ let%expect_test "unions duplicate variant" =
             (struct_impls ()) (struct_id 0)))))
         (unions
          ((102
-           ((cases (IntegerType)) (union_methods ())
+           ((cases ((IntegerType (Discriminator 0)))) (union_methods ())
             (union_impls
              (((impl_interface
                 (Value
@@ -1806,7 +1808,9 @@ let%expect_test "unions duplicate variant" =
                            102)))))))))))))))
             (union_id 102)))
           (101
-           ((cases ((StructType 0) IntegerType)) (union_methods ())
+           ((cases
+             (((StructType 0) (Discriminator 0)) (IntegerType (Discriminator 1))))
+            (union_methods ())
             (union_impls
              (((impl_interface
                 (Value
@@ -1922,7 +1926,9 @@ let%expect_test "unions" =
           (struct_impls ()) (struct_id 100)))))
       (unions
        ((101
-         ((cases ((StructType 101) (StructType 100)))
+         ((cases
+           (((StructType 101) (Discriminator 0))
+            ((StructType 100) (Discriminator 1))))
           (union_methods
            ((id
              ((function_signature

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -21,7 +21,7 @@ let parse_program s = Parser.program Tact.Lexer.token (Lexing.from_string s)
 let build_program ?(errors = make_errors Show.show_error)
     ?(bindings = Lang.default_bindings) ?(structs = Lang.default_structs)
     ?(strip_defaults = true) p =
-  let c = new Lang.constructor bindings structs errors in
+  let c = new Lang.constructor bindings structs [] errors in
   let p' = c#visit_program () p in
   errors#to_result p'
   (* remove default bindings and methods *)


### PR DESCRIPTION
This PR implements many aspects of unions:

1. Making union type f9283d0c211741f3a98f94ccbf97e4c73a1b271d.
2. Checks for duplicate variants e5efe0482ff59a53188d2da298897de4ed0ed500.
3. Constructing variants 2b09845b82bc6e91e67c0b3bd84d810ddfea5249.
4. Codegen acb7f9ade3ab0b842c8954af068c68c5ebad6f96.

Pattern matching will be considered in another PR.