### PR TITLE
Preliminary attempt to handle tensor-like types for internal use

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -8,7 +8,14 @@
   ppx_sexp_conv
   sexplib)
  (preprocess
-  (pps ppx_show ppx_make ppx_compare visitors.ppx ppx_sexp_conv ppx_blob))
+  (pps
+   ppx_show
+   ppx_make
+   ppx_compare
+   visitors.ppx
+   ppx_sexp_conv
+   ppx_blob
+   ppx_hash))
  (preprocessor_deps
   (file std/std.tact))
  (name tact))

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -198,7 +198,11 @@ class interpreter
             program.type_counter <- program.type_counter + 1 ;
             let struct_ty = struct_id in
             let struct_ =
-              {struct_fields; struct_methods = []; struct_impls = []; struct_id}
+              { struct_fields;
+                struct_methods = [];
+                struct_impls = [];
+                struct_id;
+                tensor = false }
             in
             let struct_updater = new struct_updater mk_struct_id struct_id in
             let s =
@@ -232,7 +236,12 @@ class interpreter
                                     (self#interpret_expr
                                        (struct_updater#visit_expr () x) ) ) ) } )
                   in
-                  Ok {struct_fields; struct_methods; struct_impls; struct_id} )
+                  Ok
+                    { struct_fields;
+                      struct_methods;
+                      struct_impls;
+                      struct_id;
+                      tensor = false } )
             in
             let _ =
               match s with Ok t -> t | Error _ -> raise InternalCompilerError

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -533,7 +533,8 @@ functor
                     (name, {field_type = ExprType expr}) );
               struct_methods = [];
               struct_impls = [];
-              struct_id = program.type_counter }
+              struct_id = program.type_counter;
+              tensor = false }
           in
           program.type_counter <- program.type_counter + 1 ;
           let mk_struct =

--- a/lib/zint.ml
+++ b/lib/zint.ml
@@ -10,3 +10,5 @@ class ['s] map =
   end
 
 let equal = Z.equal
+
+let hash_fold_t h v = Ppx_hash_lib.Std.Hash.fold_string h @@ Z.to_string v

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -336,3 +336,32 @@ let%expect_test "from interface" =
                           (Value (Struct (39 ((a (Reference (x IntegerType)))))))))))))))))))))))
           (struct_id 39)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
+
+let%expect_test "tensor2" =
+  let source =
+    {|
+    fn test() {
+      let x = builtin_divmod(10, 2);
+    }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ()) (function_returns HoleType)))
+            (function_impl
+             (Fn
+              ((Block
+                ((Let
+                  ((x
+                    (FunctionCall
+                     ((ResolvedReference (builtin_divmod <opaque>))
+                      ((Value (Integer 10)) (Value (Integer 2)))))))))))))))))))
+      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)))
+      |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -49,8 +49,19 @@ let%expect_test "simple function generation" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -82,8 +93,19 @@ let%expect_test "passing struct to a function" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -111,8 +133,19 @@ let%expect_test "function calls" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -145,8 +178,19 @@ let%expect_test "Int(bits) serializer codegen" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -193,8 +237,19 @@ let%expect_test "demo struct serializer" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -255,8 +310,19 @@ let%expect_test "demo struct serializer 2" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -314,8 +380,19 @@ let%expect_test "true and false" =
   pp source ;
   [%expect
     {|
+      forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+        (Value1 value,  _) = tensor;
+        return value;
+      }
+      forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+        ( _, Value2 value) = tensor;
+        return value;
+      }
       _ builtin_send_raw_msg(cell msg, int flags) {
         return send_raw_message(msg, flags);
+      }
+      (int, int) builtin_divmod(int x, int y) {
+        return divmod(x, y);
       }
       builder builtin_builder_store_int(builder b, int int_, int bits) {
         return store_int(b, int_, bits);
@@ -352,8 +429,19 @@ let%expect_test "if/then/else" =
   pp source ;
   [%expect
     {|
+      forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+        (Value1 value,  _) = tensor;
+        return value;
+      }
+      forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+        ( _, Value2 value) = tensor;
+        return value;
+      }
       _ builtin_send_raw_msg(cell msg, int flags) {
         return send_raw_message(msg, flags);
+      }
+      (int, int) builtin_divmod(int x, int y) {
+        return divmod(x, y);
       }
       builder builtin_builder_store_int(builder b, int int_, int bits) {
         return store_int(b, int_, bits);
@@ -386,8 +474,19 @@ let%expect_test "serializer inner struct" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -431,8 +530,19 @@ let%expect_test "unions" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -478,8 +588,19 @@ let%expect_test "switch statement" =
   pp source ;
   [%expect
     {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -511,3 +632,47 @@ let%expect_test "switch statement" =
     }} else
     {
       }}} |}]
+
+let%expect_test "tensor2" =
+  let source =
+    {|
+    fn test() {
+      let x = builtin_divmod(10, 2);
+      return x.value1;
+    }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
+    _ builtin_send_raw_msg(cell msg, int flags) {
+      return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
+    }
+    builder builtin_builder_store_int(builder b, int int_, int bits) {
+      return store_int(b, int_, bits);
+    }
+    cell builtin_builder_build(builder b) {
+      return end_cell(b);
+    }
+    builder builtin_builder_new() {
+      return begin_cell();
+    }
+    _ send_raw_msg(cell msg, int flags) {
+      builtin_send_raw_msg(msg, flags);
+    }
+    int test() {
+      (int, int) x = builtin_divmod(10, 2);
+      return tensor2_value1(x);
+    }
+   |}]


### PR DESCRIPTION
The main reason behind this type, as confusing it may be for the end
user (it has to do with the stack machine abstraction that we're not
leaking to Tact), we still need it to access TVM primitives (either
through FunC or TVM directly.

Current implementation is rather rough and supports only tensors of
arity of two but that can be relatively easily improved in the future as
necessary.

I've implemented `Divmod` primitive as a simple example of tensor use
(it returns two values).

I've started populating builtin structs (Tensor2 parameterized by types)
in the keyspace of negative type identifiers. This is rather a hack (it
would have been better to add them to a program, but I ran out of steam;
can do it later). We've used this approach before.