### PR TITLE
Add slice primivite + deserialization for std structs

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -166,7 +166,14 @@ let builtin_bindings =
         VoidType
         (SendRawMsg
            { msg = Reference ("msg", BuiltinType "Cell");
-             flags = Reference ("flags", IntegerType) } ) ) ]
+             flags = Reference ("flags", IntegerType) } ) );
+    ( "builtin_equal",
+      make_builtin_fn
+        [("x", IntegerType); ("y", IntegerType)]
+        BoolType
+        (Equality
+           {x = Reference ("x", IntegerType); y = Reference ("y", IntegerType)}
+        ) ) ]
 
 let default_bindings () =
   [ ("Integer", Value (Type IntegerType));

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -113,6 +113,7 @@ let tensor2 t1 t2 =
 let builtin_bindings =
   [ ("builtin_Builder", Value (Type (BuiltinType "Builder")));
     ("builtin_Cell", Value (Type (BuiltinType "Cell")));
+    ("builtin_Slice", Value (Type (BuiltinType "Slice")));
     ( "builtin_builder_new",
       Value
         (Function
@@ -135,6 +136,23 @@ let builtin_bindings =
              length = Reference ("bits", IntegerType);
              integer = Reference ("int", IntegerType);
              signed = true } ) );
+    ( "builtin_slice_begin_parse",
+      make_builtin_fn
+        [("c", BuiltinType "Cell")]
+        (BuiltinType "Slice")
+        (ParseCell {cell = Reference ("c", BuiltinType "Cell")}) );
+    ( "builtin_slice_end_parse",
+      make_builtin_fn
+        [("s", BuiltinType "Slice")]
+        VoidType
+        (SliceEndParse {slice = Reference ("s", BuiltinType "Slice")}) );
+    ( "builtin_slice_load_int",
+      make_builtin_fn
+        [("s", BuiltinType "Slice"); ("bits", IntegerType)]
+        (StructType (tensor2 (BuiltinType "Slice") IntegerType).struct_id)
+        (SliceLoadInt
+           { slice = Reference ("s", BuiltinType "Slice");
+             bits = Reference ("bits", IntegerType) } ) );
     ( "builtin_divmod",
       make_builtin_fn
         [("x", IntegerType); ("y", IntegerType)]

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -296,6 +296,8 @@ class constructor (program : T.program) =
             ( "load_int",
               [self#cg_expr slice; self#cg_expr bits],
               F.TensorType [F.SliceType; F.IntType] )
+      | Equality {x; y} ->
+          Operator (self#cg_expr x, F.EqualityOperator, self#cg_expr y)
 
     method cg_EmptyBuilder = F.FunctionCall ("begin_cell", [], F.BuilderType)
 

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -287,6 +287,15 @@ class constructor (program : T.program) =
             ( "send_raw_message",
               [self#cg_expr msg; self#cg_expr flags],
               F.InferType )
+      | ParseCell {cell} ->
+          F.FunctionCall ("begin_parse", [self#cg_expr cell], F.SliceType)
+      | SliceEndParse {slice} ->
+          F.FunctionCall ("end_parse", [self#cg_expr slice], F.InferType)
+      | SliceLoadInt {slice; bits} ->
+          F.FunctionCall
+            ( "load_int",
+              [self#cg_expr slice; self#cg_expr bits],
+              F.TensorType [F.SliceType; F.IntType] )
 
     method cg_EmptyBuilder = F.FunctionCall ("begin_cell", [], F.BuilderType)
 

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -317,8 +317,6 @@ class constructor (program : T.program) =
       | StructType s ->
           self#struct_to_ty (T.Program.get_struct program s)
       | UnionType u ->
-          T.print_sexp @@ sexp_of_int u ;
-          T.print_sexp @@ sexp_of_string "|" ;
           self#create_ty_from_union
             (List.Assoc.find_exn program.unions u ~equal:equal_int)
       | BuiltinType "Builder" ->

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -177,9 +177,7 @@ class constructor (program : T.program) =
       fun name -> function
         | Value (Function f) -> (
           try Some (F.Function (self#add_function f ~name:(Some name)))
-          with ex ->
-            if equal_string name "builtin_send_raw_msg" then raise ex else None
-          )
+          with ex -> if equal_string name "test" then raise ex else None )
         | _ ->
             None
 
@@ -319,12 +317,16 @@ class constructor (program : T.program) =
       | StructType s ->
           self#struct_to_ty (T.Program.get_struct program s)
       | UnionType u ->
+          T.print_sexp @@ sexp_of_int u ;
+          T.print_sexp @@ sexp_of_string "|" ;
           self#create_ty_from_union
             (List.Assoc.find_exn program.unions u ~equal:equal_int)
       | BuiltinType "Builder" ->
           F.BuilderType
       | BuiltinType "Cell" ->
           F.CellType
+      | BuiltinType "Slice" ->
+          F.SliceType
       | HoleType | VoidType ->
           F.InferType
       (* FIXME: actually, ExprType should not be here, this is bug. It is flows from

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -46,17 +46,49 @@ class ['s] struct_updater (program : program) (old : int) (new_s : int) =
         Program.update_struct program sid ~f:(fun st ->
             self#visit_struct_ env st )
 
+    method! visit_UnionType env u =
+      if not (List.exists visited_structs ~f:(fun s' -> equal_int s' u)) then (
+        visited_structs <- u :: visited_structs ;
+        let _ =
+          Program.update_union program u ~f:(fun st -> self#visit_union env st)
+        in
+        UnionType u )
+      else UnionType u
+
     method! visit_Struct env (s, fields) =
       let fields' = self#visit_list self#visit_binding env fields in
       if equal_int s old then Struct (new_s, fields') else Struct (s, fields')
   end
 
-class ['s] union_updater (old : int) (new_s : int) =
-  object
+class ['s] union_updater (program : program) (old : int) (new_s : int) =
+  object (self : 's)
     inherit ['s] map
 
-    method! visit_UnionType _ s =
-      if equal_int s old then UnionType new_s else UnionType s
+    val mutable visited_structs = []
+
+    method! visit_UnionType env s =
+      if equal_int s old then UnionType new_s else self#update_unions env s
+
+    method update_unions : 'env. 'env -> _ -> _ =
+      fun env u ->
+        if not (List.exists visited_structs ~f:(fun s' -> equal_int s' u)) then (
+          visited_structs <- u :: visited_structs ;
+          let _ =
+            Program.update_union program u ~f:(fun st ->
+                self#visit_union env st )
+          in
+          () ) ;
+        UnionType u
+
+    method! visit_StructType env s =
+      if not (List.exists visited_structs ~f:(fun s' -> equal_int s' s)) then (
+        visited_structs <- s :: visited_structs ;
+        let _ =
+          Program.update_struct program s ~f:(fun st ->
+              self#visit_struct_ env st )
+        in
+        () ) ;
+      StructType s
 
     method! visit_UnionVariant _ (expr, s) =
       if equal_int s old then UnionVariant (expr, new_s)
@@ -296,7 +328,8 @@ class interpreter
                     union_id = id } )
                 (fun u_base ->
                   let union_updater =
-                    new union_updater mk_union.mk_union_id u_base.union_id
+                    new union_updater
+                      program mk_union.mk_union_id u_base.union_id
                   in
                   let union_methods =
                     List.map mk_union.mk_union_methods ~f:(fun (name, fn) ->

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -21,7 +21,7 @@ class ['s] struct_updater (program : program) (old : int) (new_s : int) =
       if equal_int s old then StructType new_s
       else if not (List.exists visited_structs ~f:(fun s' -> equal_int s' s))
       then
-        let _ = self#update_struct_ids_if_need env s in
+        let _ = self#update_struct_ids_if_needed env s in
         StructType s
       else StructType s
 
@@ -40,7 +40,7 @@ class ['s] struct_updater (program : program) (old : int) (new_s : int) =
        is expected that after `Test` was constructed, `val x` field should have struct id `3`.
        So, to update such ids there is a function below.
     *)
-    method private update_struct_ids_if_need : 'env. 'env -> _ -> _ =
+    method private update_struct_ids_if_needed : 'env. 'env -> _ -> _ =
       fun env sid ->
         visited_structs <- sid :: visited_structs ;
         Program.update_struct program sid ~f:(fun st ->

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -442,6 +442,12 @@ module Program = struct
     p.structs <- update_list sid (Ok new_s) p.structs ;
     new_s
 
+  let update_union p sid ~f =
+    let s = get_union p sid in
+    let new_u = f s in
+    p.unions <- update_list sid (Ok new_u) p.unions ;
+    new_u
+
   let with_struct p s f =
     p.structs <- (s.struct_id, s) :: p.structs ;
     let new_s = f () in

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -435,6 +435,12 @@ module Program = struct
           match new_s with Ok new_s -> (id, new_s) :: xs | Error _ -> xs
         else (xid, old_s) :: update_list id new_s xs
 
+  let update_struct p sid ~f =
+    let s = get_struct p sid in
+    let new_s = f s in
+    p.structs <- update_list sid (Ok new_s) p.structs ;
+    new_s
+
   let with_struct p s f =
     p.structs <- (s.struct_id, s) :: p.structs ;
     let new_s = f () in

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -166,6 +166,7 @@ and branch = {branch_ty : type_; branch_var : string; branch_stmt : stmt}
 
 and primitive =
   | Divmod of {x : expr; y : expr}
+  | Equality of {x : expr; y : expr}
   | EmptyBuilder
   | StoreInt of {builder : expr; length : expr; integer : expr; signed : bool}
   | BuildCell of {builder : expr}

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -170,6 +170,9 @@ and primitive =
   | StoreInt of {builder : expr; length : expr; integer : expr; signed : bool}
   | BuildCell of {builder : expr}
   | SendRawMsg of {msg : expr; flags : expr}
+  | ParseCell of {cell : expr}
+  | SliceEndParse of {slice : expr}
+  | SliceLoadInt of {slice : expr; bits : expr}
 [@@deriving
   equal,
     compare,

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -2,6 +2,8 @@ struct Cell {
   val c: builtin_Cell
 }
 
+// Do not change place of builder struct - for internal reasons
+// it should be second struct in the file.
 struct Builder {
   val b: builtin_Builder
 
@@ -15,6 +17,26 @@ struct Builder {
   fn serialize_int(self: Self, int: Integer, bits: Integer) -> Self {
     let b = builtin_builder_store_int(self.b, int, bits);
     Self { b: b }
+  }
+}
+
+struct LoadResultBase(S: Type, X: Type) {
+  val slice: S
+  val value: X
+}
+
+struct Slice {
+  val s: builtin_Slice
+
+  fn parse(cell: Cell) -> Self {
+    Self { s: builtin_slice_begin_parse(cell.c) }
+  }
+
+  fn load_int(self: Self, bits: Integer) -> LoadResultBase(Self, Integer) {
+    let output = builtin_slice_load_int(self.s, bits);
+    let slice = Self { s: output.value1 };
+    let int = output.value2;
+    LoadResultBase(Self, Integer) { slice: slice, value: int }
   }
 }
 

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -23,6 +23,13 @@ struct Builder {
 struct LoadResultBase(S: Type, X: Type) {
   val slice: S
   val value: X
+
+  fn new(s: S, x: X) -> Self {
+    Self {
+      slice: s,
+      value: x,
+    }
+  }
 }
 
 struct Slice {
@@ -49,6 +56,15 @@ struct Int(bits: Integer) {
 
   fn serialize(self: Self, builder: Builder) -> Builder {
     builder.serialize_int(self.value, bits)
+  }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res = s.load_int(bits);
+    
+    LoadResultBase(Slice, Self) { 
+      slice: res.slice, 
+      value: Self { value: res.value }
+    }
   }
 
   impl From(Integer) {
@@ -88,6 +104,19 @@ struct AddrExtern {
     let b = b.serialize_int(self.bits, self.len.value);
     return b;
   }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_len = Int(9).deserialize(s);
+    let res_bits = res_len.slice.load_int(res_len.value);
+
+    LoadResultBase(Slice, Self) { 
+      slice: res_bits.slice, 
+      value: Self { 
+        len: res_len.value,
+        bits: res_bits.value,
+      }
+    }
+  }
 }
 
 union MsgAddressExt {
@@ -105,6 +134,18 @@ union MsgAddressExt {
       }
     }
   }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_discr = s.load_int(1);
+    if (builtin_equal(res_discr.value, 0)) {
+      return LoadResultBase(Slice, Self).new(res_discr.slice, AddrNone{});
+    } else if (builtin_equal(res_discr.value, 1)) {
+      let res_addr = AddrExtern.deserialize(res_discr.slice);
+      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+    } else {
+      /* TODO: throw an exception */
+    }
+  }
 }
 
 struct AddressStd {
@@ -114,6 +155,21 @@ struct AddressStd {
   fn serialize(self: Self, b: Builder) -> Builder {
     let b = b.serialize_int(0, 0); // AnyCast
     serializer(Self)(self, b)
+  }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_anycast = s.load_int(1);
+    if (builtin_equal(res_anycast.value, 0)) {
+      let res_workchain = Int(8).deserialize(res_anycast.slice);
+      let res_address = Int(256).deserialize(res_workchain.slice);
+      return LoadResultBase(Slice, Self)
+        .new(res_address.slice, Self {
+          workchain_id: res_workchain.value,
+          address: res_address.value,
+        });
+    } else {
+      /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+    }
   }
 }
 
@@ -128,6 +184,23 @@ struct AddressVar {
     let b = self.workchain_id.serialize(b);
     let b = b.serialize_int(self.address, self.len.value);
     return b;
+  }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_anycast = s.load_int(1);
+    if (builtin_equal(res_anycast.value, 0)) {
+      let res_len = Int(9).deserialize(res_anycast.slice);
+      let res_workchain = Int(8).deserialize(res_len.slice);
+      let res_address = res_workchain.slice.load_int(res_len);
+      return LoadResultBase(Slice, Self)
+        .new(res_address.slice, Self {
+          len: res_len.value,
+          workchain_id: res_workchain.value,
+          address: res_address.value,
+        });
+    } else {
+      /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+    }
   }
 }
 
@@ -145,6 +218,17 @@ union MsgAddressInt {
         let b = b.serialize_int(1, 1);
         return addr.serialize(b);
       }
+    }
+  }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_discr = s.load_int(1);
+    if (builtin_equal(res_discr.value, 0)) {
+      let res_addr = AddressStd.deserialize(res_discr.value);
+      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+    } else {
+      let res_addr = AddressVar.deserialize(res_discr.slice);
+      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
     }
   }
 }
@@ -165,6 +249,17 @@ union MsgAddress {
       }
     }
   }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_discr = s.load_int(1);
+    if (builtin_equal(res_discr.value, 0)) {
+      let res_addr = MsgAddressExt.deserialize(res_discr.value);
+      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+    } else {
+      let res_addr = MsgAddressInt.deserialize(res_discr.slice);
+      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+    }
+  }
 }
 
 struct ExtOutMsgInfo {
@@ -179,6 +274,40 @@ struct ExtOutMsgInfo {
     let b = self.created_lt.serialize(b);
     let b = self.created_at.serialize(b);
     return b;
+  }
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_src = MsgAddress.deserialize(s);
+    let res_dest = MsgAddressExt.deserialize(res_src.slice);
+    let res_created_lt = Int(64).deserialize(res_dest.slice);
+    let res_created_at = Int(64).deserialize(res_created_lt.slice);
+    return LoadResultBase(Slice, Self)
+      .new(res_created_at.slice, Self {
+        src: res_src.value,
+        dest: res_dest.value,
+        created_lt: res_created_lt.value,
+        created_at: res_created_at.value,
+      });
+  }
+}
+
+union CommonMsgInfo {
+  case ExtOutMsgInfo
+  // TODO: int_msg_info, ext_in_msg_info
+
+  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+    let res_discr1 = s.load_int(1);
+    if (builtin_equal(res_discr1.value, 0)) {
+      /* TODO: int_msg_info */
+    } else {
+      let res_discr2 = res_discr1.slice.load_int(1);
+      if (builtin_equal(res_discr2.value, 0)) {
+        /* TODO: ext_in_msg_info */
+      } else {
+        let res_info = ExtOutMsgInfo.deserialize(res_discr2.slice);
+        return LoadResultBase(Slice, Self).new(res_info.slice, res_info.value);
+      }
+    }
   }
 }
 

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -12,26 +12,26 @@ let%expect_test "Int(bits) constructor" =
     {|
     (Ok
      ((bindings
-       ((overflow (Value (Struct (21 ((value (Value (Integer 513))))))))
-        (i (Value (Struct (42 ((value (Value (Integer 100))))))))))
+       ((overflow (Value (Struct (24 ((value (Value (Integer 513))))))))
+        (i (Value (Struct (53 ((value (Value (Integer 100))))))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -42,35 +42,64 @@ let%expect_test "Int(bits) constructor" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
@@ -102,7 +131,7 @@ let%expect_test "Int(bits) serializer" =
                  (Expr
                   (FunctionCall
                    ((ResolvedReference (serialize <opaque>))
-                    ((Reference (i (StructType 36)))
+                    ((Reference (i (StructType 43)))
                      (Reference (b (StructType 3))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -141,7 +170,7 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (T_serializer <opaque>))
                     ((Value
                       (Struct
-                       (44
+                       (55
                         ((a
                           (FunctionCall
                            ((ResolvedReference (new <opaque>))
@@ -155,7 +184,7 @@ let%expect_test "demo struct serializer" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 44)) (b (StructType 3))))
+             ((function_params ((self (StructType 55)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -167,7 +196,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 36)) (builder (StructType 3))))
+                            ((self (StructType 43)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -178,11 +207,11 @@ let%expect_test "demo struct serializer" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 36))) value
+                                    ((Reference (self (StructType 43))) value
                                      IntegerType))
                                    (Value (Integer 32)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 44))) a (StructType 36)))
+                        ((Reference (self (StructType 55))) a (StructType 43)))
                        (Reference (b (StructType 3)))))))))
                  (Let
                   ((b
@@ -191,7 +220,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 42)) (builder (StructType 3))))
+                            ((self (StructType 53)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -202,37 +231,37 @@ let%expect_test "demo struct serializer" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 42))) value
+                                    ((Reference (self (StructType 53))) value
                                      IntegerType))
                                    (Value (Integer 16)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 44))) b (StructType 42)))
+                        ((Reference (self (StructType 55))) b (StructType 53)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (T (Value (Type (StructType 44))))))
+        (T (Value (Type (StructType 55))))))
       (structs
-       ((44
+       ((55
          ((struct_fields
-           ((a ((field_type (StructType 36))))
-            (b ((field_type (StructType 42))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 44)))
-        (42
+           ((a ((field_type (StructType 43))))
+            (b ((field_type (StructType 53))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 55)))
+        (53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -243,35 +272,64 @@ let%expect_test "demo struct serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 16))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 16))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -295,46 +353,46 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var (Value (Struct (43 ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (54 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params ((y (StructType 43))))
-              (function_returns (StructType 43))))
+             ((function_params ((y (StructType 54))))
+              (function_returns (StructType 54))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (y (StructType 43))))))))))))))
-        (Value (Value (Type (StructType 43))))))
+             (Fn ((Block ((Break (Expr (Reference (y (StructType 54))))))))))))))
+        (Value (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields ((a ((field_type IntegerType)))))
           (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns (StructType 43))))
+                (function_returns (StructType 54))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (43 ((a (Reference (x IntegerType))))))))))))))))))
+                     (Value (Struct (54 ((a (Reference (x IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns (StructType 43))))
+                     (function_returns (StructType 54))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
-                          (Value (Struct (43 ((a (Reference (x IntegerType)))))))))))))))))))))))
-          (struct_id 43)))))
+                          (Value (Struct (54 ((a (Reference (x IntegerType)))))))))))))))))))))))
+          (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "tensor2" =

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -372,8 +372,8 @@ let%expect_test "slice api" =
       fn test(cell: Cell) {
         let slice = Slice.parse(cell);
         let result = slice.load_int(10);
-        let slice2 = result.slice;
-        let int = result.value;
+        let slice2: Slice = result.slice;
+        let int: Integer = result.value;
       }
     |}
   in
@@ -403,10 +403,33 @@ let%expect_test "slice api" =
                       ((Reference (slice (StructType 7))) (Value (Integer 10))))))))
                  (Let
                   ((slice2
-                    (StructField
-                     ((Reference (result (StructType 6))) slice (StructType 5))))))
+                    (FunctionCall
+                     ((MkFunction
+                       ((function_signature
+                         ((function_params ((v (StructType 7))))
+                          (function_returns (StructType 7))))
+                        (function_impl
+                         (Fn
+                          ((Return
+                            (StructField
+                             ((Reference (result (StructType 6))) slice
+                              (StructType 7)))))))))
+                      ((StructField
+                        ((Reference (result (StructType 6))) slice
+                         (StructType 7)))))))))
                  (Let
                   ((int
-                    (StructField
-                     ((Reference (result (StructType 6))) value IntegerType))))))))))))))))
+                    (FunctionCall
+                     ((MkFunction
+                       ((function_signature
+                         ((function_params ((v IntegerType)))
+                          (function_returns IntegerType)))
+                        (function_impl
+                         (Fn
+                          ((Return
+                            (StructField
+                             ((Reference (result (StructType 6))) value
+                              IntegerType))))))))
+                      ((StructField
+                        ((Reference (result (StructType 6))) value IntegerType)))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -12,26 +12,26 @@ let%expect_test "Int(bits) constructor" =
     {|
     (Ok
      ((bindings
-       ((overflow (Value (Struct (17 ((value (Value (Integer 513))))))))
-        (i (Value (Struct (38 ((value (Value (Integer 100))))))))))
+       ((overflow (Value (Struct (21 ((value (Value (Integer 513))))))))
+        (i (Value (Struct (42 ((value (Value (Integer 100))))))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -42,35 +42,35 @@ let%expect_test "Int(bits) constructor" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
@@ -102,7 +102,7 @@ let%expect_test "Int(bits) serializer" =
                  (Expr
                   (FunctionCall
                    ((ResolvedReference (serialize <opaque>))
-                    ((Reference (i (StructType 32)))
+                    ((Reference (i (StructType 36)))
                      (Reference (b (StructType 3))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -141,7 +141,7 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (T_serializer <opaque>))
                     ((Value
                       (Struct
-                       (40
+                       (44
                         ((a
                           (FunctionCall
                            ((ResolvedReference (new <opaque>))
@@ -155,7 +155,7 @@ let%expect_test "demo struct serializer" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 40)) (b (StructType 3))))
+             ((function_params ((self (StructType 44)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -167,7 +167,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 32)) (builder (StructType 3))))
+                            ((self (StructType 36)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -178,11 +178,11 @@ let%expect_test "demo struct serializer" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 32))) value
+                                    ((Reference (self (StructType 36))) value
                                      IntegerType))
                                    (Value (Integer 32)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 40))) a (StructType 32)))
+                        ((Reference (self (StructType 44))) a (StructType 36)))
                        (Reference (b (StructType 3)))))))))
                  (Let
                   ((b
@@ -191,7 +191,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 38)) (builder (StructType 3))))
+                            ((self (StructType 42)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -202,37 +202,37 @@ let%expect_test "demo struct serializer" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 38))) value
+                                    ((Reference (self (StructType 42))) value
                                      IntegerType))
                                    (Value (Integer 16)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 40))) b (StructType 38)))
+                        ((Reference (self (StructType 44))) b (StructType 42)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (T (Value (Type (StructType 40))))))
+        (T (Value (Type (StructType 44))))))
       (structs
-       ((40
+       ((44
          ((struct_fields
-           ((a ((field_type (StructType 32))))
-            (b ((field_type (StructType 38))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 40)))
-        (38
+           ((a ((field_type (StructType 36))))
+            (b ((field_type (StructType 42))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 44)))
+        (42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -243,35 +243,35 @@ let%expect_test "demo struct serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 16))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -295,46 +295,46 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var (Value (Struct (39 ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (43 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params ((y (StructType 39))))
-              (function_returns (StructType 39))))
+             ((function_params ((y (StructType 43))))
+              (function_returns (StructType 43))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (y (StructType 39))))))))))))))
-        (Value (Value (Type (StructType 39))))))
+             (Fn ((Block ((Break (Expr (Reference (y (StructType 43))))))))))))))
+        (Value (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields ((a ((field_type IntegerType)))))
           (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns (StructType 39))))
+                (function_returns (StructType 43))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (39 ((a (Reference (x IntegerType))))))))))))))))))
+                     (Value (Struct (43 ((a (Reference (x IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns (StructType 39))))
+                     (function_returns (StructType 43))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
-                          (Value (Struct (39 ((a (Reference (x IntegerType)))))))))))))))))))))))
-          (struct_id 39)))))
+                          (Value (Struct (43 ((a (Reference (x IntegerType)))))))))))))))))))))))
+          (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "tensor2" =
@@ -365,3 +365,48 @@ let%expect_test "tensor2" =
                       ((Value (Integer 10)) (Value (Integer 2)))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)))
       |}]
+
+let%expect_test "slice api" =
+  let source =
+    {|
+      fn test(cell: Cell) {
+        let slice = Slice.parse(cell);
+        let result = slice.load_int(10);
+        let slice2 = result.slice;
+        let int = result.value;
+      }
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((cell (StructType 1))))
+              (function_returns HoleType)))
+            (function_impl
+             (Fn
+              ((Block
+                ((Let
+                  ((slice
+                    (FunctionCall
+                     ((ResolvedReference (parse <opaque>))
+                      ((Reference (cell (StructType 1)))))))))
+                 (Let
+                  ((result
+                    (FunctionCall
+                     ((ResolvedReference (load_int <opaque>))
+                      ((Reference (slice (StructType 7))) (Value (Integer 10))))))))
+                 (Let
+                  ((slice2
+                    (StructField
+                     ((Reference (result (StructType 6))) slice (StructType 5))))))
+                 (Let
+                  ((int
+                    (StructField
+                     ((Reference (result (StructType 6))) value IntegerType))))))))))))))))
+      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -57,6 +57,9 @@ let%expect_test "simple function generation" =
       ( _, Value2 value) = tensor;
       return value;
     }
+    int builtin_equal(int x, int y) {
+      return x == y;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
     }
@@ -101,6 +104,9 @@ let%expect_test "passing struct to a function" =
       ( _, Value2 value) = tensor;
       return value;
     }
+    int builtin_equal(int x, int y) {
+      return x == y;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
     }
@@ -140,6 +146,9 @@ let%expect_test "function calls" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
@@ -185,6 +194,9 @@ let%expect_test "Int(bits) serializer codegen" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
@@ -244,6 +256,9 @@ let%expect_test "demo struct serializer" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
@@ -318,6 +333,9 @@ let%expect_test "demo struct serializer 2" =
       ( _, Value2 value) = tensor;
       return value;
     }
+    int builtin_equal(int x, int y) {
+      return x == y;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
     }
@@ -388,6 +406,9 @@ let%expect_test "true and false" =
         ( _, Value2 value) = tensor;
         return value;
       }
+      int builtin_equal(int x, int y) {
+        return x == y;
+      }
       _ builtin_send_raw_msg(cell msg, int flags) {
         return send_raw_message(msg, flags);
       }
@@ -437,6 +458,9 @@ let%expect_test "if/then/else" =
         ( _, Value2 value) = tensor;
         return value;
       }
+      int builtin_equal(int x, int y) {
+        return x == y;
+      }
       _ builtin_send_raw_msg(cell msg, int flags) {
         return send_raw_message(msg, flags);
       }
@@ -481,6 +505,9 @@ let%expect_test "serializer inner struct" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
@@ -537,6 +564,9 @@ let%expect_test "unions" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
@@ -596,6 +626,9 @@ let%expect_test "switch statement" =
       ( _, Value2 value) = tensor;
       return value;
     }
+    int builtin_equal(int x, int y) {
+      return x == y;
+    }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);
     }
@@ -652,6 +685,9 @@ let%expect_test "tensor2" =
     forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
       ( _, Value2 value) = tensor;
       return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
     }
     _ builtin_send_raw_msg(cell msg, int flags) {
       return send_raw_message(msg, flags);

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -66,6 +66,15 @@ let%expect_test "simple function generation" =
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
     }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
     }
@@ -113,6 +122,15 @@ let%expect_test "passing struct to a function" =
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
     }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
     }
@@ -155,6 +173,15 @@ let%expect_test "function calls" =
     }
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -203,6 +230,15 @@ let%expect_test "Int(bits) serializer codegen" =
     }
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -265,6 +301,15 @@ let%expect_test "demo struct serializer" =
     }
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -342,6 +387,15 @@ let%expect_test "demo struct serializer 2" =
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
     }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
     }
@@ -415,6 +469,15 @@ let%expect_test "true and false" =
       (int, int) builtin_divmod(int x, int y) {
         return divmod(x, y);
       }
+      (slice, int) builtin_slice_load_int(slice s, int bits) {
+        return load_int(s, bits);
+      }
+      _ builtin_slice_end_parse(slice s) {
+        return end_parse(s);
+      }
+      slice builtin_slice_begin_parse(cell c) {
+        return begin_parse(c);
+      }
       builder builtin_builder_store_int(builder b, int int_, int bits) {
         return store_int(b, int_, bits);
       }
@@ -467,6 +530,15 @@ let%expect_test "if/then/else" =
       (int, int) builtin_divmod(int x, int y) {
         return divmod(x, y);
       }
+      (slice, int) builtin_slice_load_int(slice s, int bits) {
+        return load_int(s, bits);
+      }
+      _ builtin_slice_end_parse(slice s) {
+        return end_parse(s);
+      }
+      slice builtin_slice_begin_parse(cell c) {
+        return begin_parse(c);
+      }
       builder builtin_builder_store_int(builder b, int int_, int bits) {
         return store_int(b, int_, bits);
       }
@@ -514,6 +586,15 @@ let%expect_test "serializer inner struct" =
     }
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -573,6 +654,15 @@ let%expect_test "unions" =
     }
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
     }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
@@ -635,6 +725,15 @@ let%expect_test "switch statement" =
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
     }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
     }
@@ -695,6 +794,15 @@ let%expect_test "tensor2" =
     (int, int) builtin_divmod(int x, int y) {
       return divmod(x, y);
     }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
     builder builtin_builder_store_int(builder b, int int_, int bits) {
       return store_int(b, int_, bits);
     }
@@ -712,3 +820,191 @@ let%expect_test "tensor2" =
       return tensor2_value1(x);
     }
    |}]
+
+let%expect_test "deserialization api" =
+  let source =
+    {|
+     fn test(c: Cell) {
+       let s = Slice.parse(c);
+       let msg = CommonMsgInfo.deserialize(s);
+     }
+     |}
+  in
+  pp source ;
+  [%expect
+    {|
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value,  _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      ( _, Value2 value) = tensor;
+      return value;
+    }
+    int builtin_equal(int x, int y) {
+      return x == y;
+    }
+    _ builtin_send_raw_msg(cell msg, int flags) {
+      return send_raw_message(msg, flags);
+    }
+    (int, int) builtin_divmod(int x, int y) {
+      return divmod(x, y);
+    }
+    (slice, int) builtin_slice_load_int(slice s, int bits) {
+      return load_int(s, bits);
+    }
+    _ builtin_slice_end_parse(slice s) {
+      return end_parse(s);
+    }
+    slice builtin_slice_begin_parse(cell c) {
+      return begin_parse(c);
+    }
+    builder builtin_builder_store_int(builder b, int int_, int bits) {
+      return store_int(b, int_, bits);
+    }
+    cell builtin_builder_build(builder b) {
+      return end_cell(b);
+    }
+    builder builtin_builder_new() {
+      return begin_cell();
+    }
+    _ send_raw_msg(cell msg, int flags) {
+      builtin_send_raw_msg(msg, flags);
+    }
+    slice f0(cell cell_) {
+      builtin_slice_begin_parse(cell_);
+    }
+    [slice, int] f2(slice self, int bits) {
+      (slice, int) output = builtin_slice_load_int(self, bits);
+      slice slice_ = tensor2_value1(output);
+      int int_ = tensor2_value2(output);
+      [slice_, int_];
+    }
+    [slice, int] f7(slice s) {
+      [slice, int] res = f2(s, 9);
+      [first(res), second(res)];
+    }
+    [slice, int] f8(slice s) {
+      [slice, int] res = f2(s, 8);
+      [first(res), second(res)];
+    }
+    [slice, [int, int, int]] f9(slice s, [int, int, int] x) {
+      [s, x];
+    }
+    [slice, [int, int, int]] f6(slice s) {
+      [slice, int] res_anycast = f2(s, 1);
+      if (builtin_equal(second(res_anycast), 0)) {
+      [slice, int] res_len = f7(first(res_anycast));
+    [slice, int] res_workchain =
+    f8(first(res_len));
+    [slice, int] res_address =
+    f2(first(res_workchain), res_len);
+    return
+    f9(first(res_address), [second(res_len), second(res_workchain), second(res_address)]);
+    } else
+    {
+      }}
+    [slice, tuple] f10(slice s, tuple x) {
+      [s, x];
+    }
+    [slice, int] f12(slice s) {
+      [slice, int] res = f2(s, 256);
+      [first(res), second(res)];
+    }
+    [slice, [int, int]] f13(slice s, [int, int] x) {
+      [s, x];
+    }
+    [slice, [int, int]] f11(slice s) {
+      [slice, int] res_anycast = f2(s, 1);
+      if (builtin_equal(second(res_anycast), 0)) {
+      [slice, int] res_workchain = f8(first(res_anycast));
+    [slice, int] res_address =
+    f12(first(res_workchain));
+    return
+    f13(first(res_address), [second(res_workchain), second(res_address)]);
+    } else
+    {
+      }}
+    [slice, tuple] f5(slice s) {
+      [slice, int] res_discr = f2(s, 1);
+      if (builtin_equal(second(res_discr), 0)) {
+      [slice, [int, int]] res_addr = f11(second(res_discr));
+    return
+    f10(first(res_addr), second(res_addr));
+    } else
+    {
+      [slice, [int, int, int]] res_addr = f6(first(res_discr));
+    return
+    f10(first(res_addr), second(res_addr));
+    }}
+    [slice, tuple] f14(slice s, tuple x) {
+      [s, x];
+    }
+    [slice, [int, int]] f16(slice s) {
+      [slice, int] res_len = f7(s);
+      [slice, int] res_bits = f2(first(res_len), second(res_len));
+      [first(res_bits), [second(res_len), second(res_bits)]];
+    }
+    [slice, tuple] f17(slice s, tuple x) {
+      [s, x];
+    }
+    [slice, tuple] f15(slice s) {
+      [slice, int] res_discr = f2(s, 1);
+      if (builtin_equal(second(res_discr), 0)) {
+      return f17(first(res_discr), []);
+    } else if (builtin_equal(second(res_discr), 1))
+    {
+      [slice, [int, int]] res_addr = f16(first(res_discr));
+    return
+    f17(first(res_addr), second(res_addr));
+    } else
+    {
+      }}
+    [slice, tuple] f4(slice s) {
+      [slice, int] res_discr = f2(s, 1);
+      if (builtin_equal(second(res_discr), 0)) {
+      [slice, tuple] res_addr = f15(second(res_discr));
+    return
+    f14(first(res_addr), second(res_addr));
+    } else
+    {
+      [slice, tuple] res_addr = f5(first(res_discr));
+    return
+    f14(first(res_addr), second(res_addr));
+    }}
+    [slice, int] f18(slice s) {
+      [slice, int] res = f2(s, 64);
+      [first(res), second(res)];
+    }
+    [slice, [tuple, tuple, int, int]] f19(slice s, [tuple, tuple, int, int] x) {
+      [s, x];
+    }
+    [slice, [tuple, tuple, int, int]] f3(slice s) {
+      [slice, tuple] res_src = f4(s);
+      [slice, tuple] res_dest = f15(first(res_src));
+      [slice, int] res_created_lt = f18(first(res_dest));
+      [slice, int] res_created_at = f18(first(res_created_lt));
+      return
+        f19(first(res_created_at), [second(res_src), second(res_dest), second(res_created_lt), second(res_created_at)]);
+    }
+    [slice, tuple] f20(slice s, tuple x) {
+      [s, x];
+    }
+    [slice, tuple] f1(slice s) {
+      [slice, int] res_discr1 = f2(s, 1);
+      if (builtin_equal(second(res_discr1), 0)) {
+      } else
+    {
+      [slice, int] res_discr2 = f2(first(res_discr1), 1);
+    if (builtin_equal(second(res_discr2), 0))
+    {
+      } else
+    {
+      [slice, [tuple, tuple, int, int]] res_info = f3(first(res_discr2));
+    return
+    f20(first(res_info), second(res_info));
+    }}}
+    _ test(cell c) {
+      slice s = f0(c);
+      [slice, tuple] msg = f1(s);
+    } |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -34,25 +34,25 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 42))))))
+     ((bindings ((T (Value (Type (StructType 53))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -63,35 +63,64 @@ let%expect_test "scope resolution" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
@@ -102,25 +131,25 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 42))))))
+     ((bindings ((T (Value (Type (StructType 53))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -131,35 +160,64 @@ let%expect_test "binding resolution" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -184,25 +242,25 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 42)))) (A (Value (Type (StructType 42))))))
+       ((B (Value (Type (StructType 53)))) (A (Value (Type (StructType 53))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -213,35 +271,64 @@ let%expect_test "scope resolution after let binding" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
@@ -252,28 +339,28 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 44))))))
+     ((bindings ((T (Value (Type (StructType 55))))))
       (structs
-       ((44
-         ((struct_fields ((t ((field_type (StructType 42))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 44)))
-        (42
+       ((55
+         ((struct_fields ((t ((field_type (StructType 53))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 55)))
+        (53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -284,35 +371,64 @@ let%expect_test "basic struct definition" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
@@ -343,33 +459,33 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a (Value (Struct (42 ((value (Value (Integer 1))))))))
+       ((a (Value (Struct (53 ((value (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 42))))
-              (function_returns (StructType 42))))
+             ((function_params ((i (StructType 53))))
+              (function_returns (StructType 53))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 42))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 53))))))))))))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -380,35 +496,64 @@ let%expect_test "Tact function evaluation" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -453,29 +598,29 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings ((MyType (Value (Type (StructType 44))))))
+       ((bindings ((MyType (Value (Type (StructType 55))))))
         (structs
-         ((44
+         ((55
            ((struct_fields
-             ((a ((field_type (StructType 42)))) (b ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 44)))
-          (42
+             ((a ((field_type (StructType 53)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 55)))
+          (53
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                       (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 42)) (builder (StructType 3))))
+                   ((self (StructType 53)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -486,35 +631,64 @@ let%expect_test "struct definition" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 42))) value IntegerType))
+                           ((Reference (self (StructType 53))) value IntegerType))
                           (Value (Integer 257))))))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 7))))
+                  (function_returns (StructType 9))))
+                (function_impl
+                 (Fn
+                  ((Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((ResolvedReference (load_int <opaque>))
+                          ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                     (Break
+                      (Expr
+                       (Value
+                        (Struct
+                         (9
+                          ((slice
+                            (StructField
+                             ((Reference (res (StructType 6))) slice
+                              (StructType 7))))
+                           (value
+                            (Value
+                             (Struct
+                              (53
+                               ((value
+                                 (StructField
+                                  ((Reference (res (StructType 6))) value
+                                   IntegerType)))))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                       (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 42))))
+                       (function_returns (StructType 53))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 42)))))
+                             (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 53)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -533,32 +707,32 @@ let%expect_test "duplicate type field" =
      (((DuplicateField
         (a
          ((mk_struct_fields
-           ((a (Value (Type (StructType 42)))) (a (Value (Type BoolType)))))
+           ((a (Value (Type (StructType 53)))) (a (Value (Type BoolType)))))
           (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
-       ((bindings ((MyType (Value (Type (StructType 44))))))
+       ((bindings ((MyType (Value (Type (StructType 55))))))
         (structs
-         ((44
+         ((55
            ((struct_fields
-             ((a ((field_type (StructType 42)))) (a ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 44)))
-          (42
+             ((a ((field_type (StructType 53)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 55)))
+          (53
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 42)) (builder (StructType 3))))
+                   ((self (StructType 53)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -569,36 +743,65 @@ let%expect_test "duplicate type field" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 42))) value IntegerType))
+                           ((Reference (self (StructType 53))) value IntegerType))
                           (Value (Integer 257))))))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 7))))
+                  (function_returns (StructType 9))))
+                (function_impl
+                 (Fn
+                  ((Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((ResolvedReference (load_int <opaque>))
+                          ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                     (Break
+                      (Expr
+                       (Value
+                        (Struct
+                         (9
+                          ((slice
+                            (StructField
+                             ((Reference (res (StructType 6))) slice
+                              (StructType 7))))
+                           (value
+                            (Value
+                             (Struct
+                              (53
+                               ((value
+                                 (StructField
+                                  ((Reference (res (StructType 6))) value
+                                   IntegerType)))))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 42))))
+                       (function_returns (StructType 53))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 42)))))
+                             (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 53)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -613,7 +816,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 44))))
+       ((TA (Value (Type (StructType 55))))
         (T
          (Value
           (Function
@@ -624,28 +827,28 @@ let%expect_test "parametric struct instantiation" =
               ((Expr
                 (MkStructDef
                  ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                  (mk_methods ()) (mk_impls ()) (mk_struct_id 42)))))))))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 53)))))))))))))
       (structs
-       ((44
-         ((struct_fields ((a ((field_type (StructType 43))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 44)))
-        (43
+       ((55
+         ((struct_fields ((a ((field_type (StructType 54))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 55)))
+        (54
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 43))))
+                (function_returns (StructType 54))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (43 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (54 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 43)) (builder (StructType 3))))
+                 ((self (StructType 54)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -656,35 +859,64 @@ let%expect_test "parametric struct instantiation" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 43))) value IntegerType))
+                         ((Reference (self (StructType 54))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (54
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 43))))
+                (function_returns (StructType 54))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (43 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (54 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 43))))
+                     (function_returns (StructType 54))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (43 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 43)))))
+                           (Struct (54 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -721,36 +953,36 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b (Value (Struct (42 ((value (Value (Integer 1))))))))
+       ((b (Value (Struct (53 ((value (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 42))))
-              (function_returns (StructType 42))))
+             ((function_params ((i (StructType 53))))
+              (function_returns (StructType 53))))
             (function_impl
              (Fn
               ((Block
-                ((Let ((a (Reference (i (StructType 42))))))
-                 (Break (Expr (Reference (a (StructType 42))))))))))))))))
+                ((Let ((a (Reference (i (StructType 53))))))
+                 (Break (Expr (Reference (a (StructType 53))))))))))))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -761,35 +993,64 @@ let%expect_test "scoping that `let` introduces in code" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
@@ -814,7 +1075,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 42))))
+             ((function_params ((x (StructType 53))))
               (function_returns HoleType)))
             (function_impl
              (Fn
@@ -823,40 +1084,40 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (x (StructType 42)))
-                       (Reference (x (StructType 42)))))))))
+                      ((Reference (x (StructType 53)))
+                       (Reference (x (StructType 53)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (a (StructType 42)))
-                       (Reference (a (StructType 42))))))))))))))))))
+                      ((Reference (a (StructType 53)))
+                       (Reference (a (StructType 53))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 42)) (i_ (StructType 42))))
-              (function_returns (StructType 42))))
+             ((function_params ((i (StructType 53)) (i_ (StructType 53))))
+              (function_returns (StructType 53))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 42))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 53))))))))))))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -867,35 +1128,64 @@ let%expect_test "reference in function bodies" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -941,19 +1231,19 @@ let%expect_test "struct method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (Struct (43 ()))))
-        (Foo (Value (Type (StructType 43))))))
+       ((res (Value (Integer 1))) (foo (Value (Struct (54 ()))))
+        (Foo (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 43)) (i IntegerType)))
+               ((function_params ((self (StructType 54)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 43)))))
+          (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -971,9 +1261,9 @@ let%expect_test "struct type method access" =
   [%expect
     {|
     (Ok
-     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 43))))))
+     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields ())
           (struct_methods
            ((bar
@@ -982,7 +1272,7 @@ let%expect_test "struct type method access" =
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 43)))))
+          (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -999,18 +1289,18 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 43))))))
+     ((bindings ((Foo (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 43))))
-                (function_returns (StructType 43))))
+               ((function_params ((self (StructType 54))))
+                (function_returns (StructType 54))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (self (StructType 43))))))))))))))
-          (struct_impls ()) (struct_id 43)))))
+               (Fn ((Block ((Break (Expr (Reference (self (StructType 54))))))))))))))
+          (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -1034,44 +1324,44 @@ let%expect_test "union method access" =
     {|
       (Ok
        ((bindings
-         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 43))))
+         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 54))))
           (make_foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 43))))
-                (function_returns (UnionType 43))))
+               ((function_params ((foo (UnionType 54))))
+                (function_returns (UnionType 54))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 43))))))))))))))
-          (Foo (Value (Type (UnionType 43))))))
+               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 54))))))))))))))
+          (Foo (Value (Type (UnionType 54))))))
         (structs ())
         (unions
-         ((43
+         ((54
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (UnionType 43)) (i IntegerType)))
+                 ((function_params ((self (UnionType 54)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl
                  (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 44))))
+             (((impl_interface (Value (Type (InterfaceType 55))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 43))))
+                       (function_returns (UnionType 54))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 43)))))))))))))))
-            (union_id 43)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 54)))))))))))))))
+            (union_id 54)))))
         (interfaces
-         ((44
+         ((55
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1103,14 +1393,14 @@ let%expect_test "union type method access" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 43))))
-                (function_returns (UnionType 43))))
+               ((function_params ((foo (UnionType 54))))
+                (function_returns (UnionType 54))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 43))))))))))))))
-          (Foo (Value (Type (UnionType 43))))))
+               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 54))))))))))))))
+          (Foo (Value (Type (UnionType 54))))))
         (structs ())
         (unions
-         ((43
+         ((54
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
@@ -1120,22 +1410,22 @@ let%expect_test "union type method access" =
                 (function_impl
                  (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 44))))
+             (((impl_interface (Value (Type (InterfaceType 55))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 43))))
+                       (function_returns (UnionType 54))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 43)))))))))))))))
-            (union_id 43)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 54)))))))))))))))
+            (union_id 54)))))
         (interfaces
-         ((44
+         ((55
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1159,13 +1449,13 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value (Struct (43 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 43))))))
+         (Value (Struct (54 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_methods ()) (struct_impls ()) (struct_id 43)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -1176,22 +1466,22 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 35) (StructType 36)))
+     (((TypeError ((StructType 42) (StructType 43)))
        ((bindings
          ((foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((i (StructType 36))))
-                (function_returns (StructType 35))))
+               ((function_params ((i (StructType 43))))
+                (function_returns (StructType 42))))
               (function_impl
-               (Fn ((Block ((Return (Reference (i (StructType 36)))))))))))))))
+               (Fn ((Block ((Return (Reference (i (StructType 43)))))))))))))))
         (structs ())
         (interfaces
-         ((42
+         ((53
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 36))))
+               ((function_params ((from (StructType 43))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1284,27 +1574,27 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 42) (StructType 43)))
+     (((TypeError ((StructType 53) (StructType 54)))
        ((bindings ())
         (structs
-         ((43
+         ((54
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 43))))
+                  (function_returns (StructType 54))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (43 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (54 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 43)) (builder (StructType 3))))
+                   ((self (StructType 54)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1315,54 +1605,83 @@ let%expect_test "type check error" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 43))) value IntegerType))
+                           ((Reference (self (StructType 54))) value IntegerType))
                           (Value (Integer 10))))))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 7))))
+                  (function_returns (StructType 9))))
+                (function_impl
+                 (Fn
+                  ((Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((ResolvedReference (load_int <opaque>))
+                          ((Reference (s (StructType 7))) (Value (Integer 10))))))))
+                     (Break
+                      (Expr
+                       (Value
+                        (Struct
+                         (9
+                          ((slice
+                            (StructField
+                             ((Reference (res (StructType 6))) slice
+                              (StructType 7))))
+                           (value
+                            (Value
+                             (Struct
+                              (54
+                               ((value
+                                 (StructField
+                                  ((Reference (res (StructType 6))) value
+                                   IntegerType)))))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 43))))
+                  (function_returns (StructType 54))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (43 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (54 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 43))))
+                       (function_returns (StructType 54))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (43 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 43)))
-          (42
+                             (Struct (54 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 54)))
+          (53
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 42)) (builder (StructType 3))))
+                   ((self (StructType 53)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1373,41 +1692,70 @@ let%expect_test "type check error" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 42))) value IntegerType))
+                           ((Reference (self (StructType 53))) value IntegerType))
                           (Value (Integer 99))))))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 7))))
+                  (function_returns (StructType 9))))
+                (function_impl
+                 (Fn
+                  ((Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((ResolvedReference (load_int <opaque>))
+                          ((Reference (s (StructType 7))) (Value (Integer 99))))))))
+                     (Break
+                      (Expr
+                       (Value
+                        (Struct
+                         (9
+                          ((slice
+                            (StructField
+                             ((Reference (res (StructType 6))) slice
+                              (StructType 7))))
+                           (value
+                            (Value
+                             (Struct
+                              (53
+                               ((value
+                                 (StructField
+                                  ((Reference (res (StructType 6))) value
+                                   IntegerType)))))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 42))))
+                       (function_returns (StructType 53))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 42)))))
+                             (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 53)))))
         (interfaces
-         ((44
+         ((55
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 43))))
+               ((function_params ((from (StructType 54))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1427,9 +1775,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 43))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 54))))))
       (structs
-       ((43
+       ((54
          ((struct_fields ())
           (struct_methods
            ((op
@@ -1450,7 +1798,7 @@ let%expect_test "implement interface op" =
                    (function_impl
                     (Fn
                      ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))
-          (struct_id 43)))))
+          (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -1472,30 +1820,30 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (44 ())))) (Empty (Value (Type (StructType 44))))
-        (Make (Value (Type (InterfaceType 42))))))
+       ((empty (Value (Struct (55 ())))) (Empty (Value (Type (StructType 55))))
+        (Make (Value (Type (InterfaceType 53))))))
       (structs
-       ((44
+       ((55
          ((struct_fields ())
           (struct_methods
            ((new
              ((function_signature
-               ((function_params ()) (function_returns (StructType 44))))
+               ((function_params ()) (function_returns (StructType 55))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Value (Struct (44 ()))))))))))))))
+               (Fn ((Block ((Break (Expr (Value (Struct (55 ()))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 42))))
+           (((impl_interface (Value (Type (InterfaceType 53))))
              (impl_methods
               ((new
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 44))))
+                    ((function_params ()) (function_returns (StructType 55))))
                    (function_impl
-                    (Fn ((Block ((Break (Expr (Value (Struct (44 ())))))))))))))))))))
-          (struct_id 44)))))
+                    (Fn ((Block ((Break (Expr (Value (Struct (55 ())))))))))))))))))))
+          (struct_id 55)))))
       (interfaces
-       ((42
+       ((53
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
@@ -1517,7 +1865,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 45)) (b (StructType 3))))
+             ((function_params ((self (StructType 56)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -1529,7 +1877,7 @@ let%expect_test "serializer inner struct" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 36)) (builder (StructType 3))))
+                            ((self (StructType 43)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -1540,24 +1888,24 @@ let%expect_test "serializer inner struct" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 36))) value
+                                    ((Reference (self (StructType 43))) value
                                      IntegerType))
                                    (Value (Integer 32)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 45))) y (StructType 36)))
+                        ((Reference (self (StructType 56))) y (StructType 43)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (Outer (Value (Type (StructType 45))))
-        (Inner (Value (Type (StructType 43))))))
+        (Outer (Value (Type (StructType 56))))
+        (Inner (Value (Type (StructType 54))))))
       (structs
-       ((45
+       ((56
          ((struct_fields
-           ((y ((field_type (StructType 36))))
-            (z ((field_type (StructType 43))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 45)))
-        (43
-         ((struct_fields ((x ((field_type (StructType 36))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 43)))))
+           ((y ((field_type (StructType 43))))
+            (z ((field_type (StructType 54))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 56)))
+        (54
+         ((struct_fields ((x ((field_type (StructType 43))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -1714,25 +2062,25 @@ let%expect_test "union variants constructing" =
     (Ok
      ((bindings
        ((b
-         (Value (UnionVariant ((Struct (36 ((value (Value (Integer 1)))))) 43))))
-        (a (Value (UnionVariant ((Integer 10) 43))))
+         (Value (UnionVariant ((Struct (43 ((value (Value (Integer 1)))))) 54))))
+        (a (Value (UnionVariant ((Integer 10) 54))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 43))))
-              (function_returns (UnionType 43))))
+             ((function_params ((value (UnionType 54))))
+              (function_returns (UnionType 54))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (value (UnionType 43))))))))))))))
-        (Uni (Value (Type (UnionType 43))))))
+             (Fn ((Block ((Break (Expr (Reference (value (UnionType 54))))))))))))))
+        (Uni (Value (Type (UnionType 54))))))
       (structs ())
       (unions
-       ((43
+       ((54
          ((cases
-           (((StructType 36) (Discriminator 0)) (IntegerType (Discriminator 1))))
+           (((StructType 43) (Discriminator 0)) (IntegerType (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
@@ -1740,35 +2088,35 @@ let%expect_test "union variants constructing" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type IntegerType))))))
-                     (function_returns (UnionType 43))))
+                     (function_returns (UnionType 54))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference (v (ExprType (Value (Type IntegerType)))))
-                         43)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 44))))
+                         54)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 55))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 36)))))))
-                     (function_returns (UnionType 43))))
+                      ((v (ExprType (Value (Type (StructType 43)))))))
+                     (function_returns (UnionType 54))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 36))))))
-                         43)))))))))))))))
-          (union_id 43)))))
+                          (v (ExprType (Value (Type (StructType 43))))))
+                         54)))))))))))))))
+          (union_id 54)))))
       (interfaces
-       ((44
+       ((55
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 36))))
+             ((function_params ((from (StructType 43))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -1791,7 +2139,7 @@ let%expect_test "unions duplicate variant" =
     (Error
      (((DuplicateVariant IntegerType)
        ((bindings
-         ((b (Value (Type (UnionType 45)))) (a (Value (Type (UnionType 43))))
+         ((b (Value (Type (UnionType 56)))) (a (Value (Type (UnionType 54))))
           (Test
            (Value
             (Function
@@ -1820,14 +2168,14 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 42))))
+                               (function_returns (UnionType 53))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Value
                                     (Type (ExprType (Reference (v IntegerType)))))
-                                   42)))))))))))))
+                                   53)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -1843,7 +2191,7 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v (Dependent T (TypeN 0)))))
-                               (function_returns (UnionType 42))))
+                               (function_returns (UnionType 53))))
                              (function_impl
                               (Fn
                                ((Return
@@ -1853,8 +2201,8 @@ let%expect_test "unions duplicate variant" =
                                      (ExprType
                                       (Reference
                                        (v (ExprType (Reference (T (TypeN 0)))))))))
-                                   42)))))))))))))))
-                    (mk_union_id 42)))))))
+                                   53)))))))))))))))
+                    (mk_union_id 53)))))))
               (function_impl
                (Fn
                 ((Block
@@ -1881,12 +2229,12 @@ let%expect_test "unions duplicate variant" =
                               (Function
                                ((function_signature
                                  ((function_params ((v IntegerType)))
-                                  (function_returns (UnionType 42))))
+                                  (function_returns (UnionType 53))))
                                 (function_impl
                                  (Fn
                                   ((Return
                                     (MakeUnionVariant
-                                     ((Reference (v IntegerType)) 42)))))))))))))
+                                     ((Reference (v IntegerType)) 53)))))))))))))
                          ((impl_interface
                            (FunctionCall
                             ((Value
@@ -1903,33 +2251,33 @@ let%expect_test "unions duplicate variant" =
                                ((function_signature
                                  ((function_params
                                    ((v (ExprType (Reference (T (TypeN 0)))))))
-                                  (function_returns (UnionType 42))))
+                                  (function_returns (UnionType 53))))
                                 (function_impl
                                  (Fn
                                   ((Return
                                     (MakeUnionVariant
                                      ((Reference
                                        (v (ExprType (Reference (T (TypeN 0))))))
-                                      42)))))))))))))))
-                       (mk_union_id 42))))))))))))))))
+                                      53)))))))))))))))
+                       (mk_union_id 53))))))))))))))))
         (structs ())
         (unions
-         ((45
+         ((56
            ((cases ((IntegerType (Discriminator 0)))) (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 45))))
+                       (function_returns (UnionType 56))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 45)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 9))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 56)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
@@ -1937,33 +2285,33 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 45))))
+                       (function_returns (UnionType 56))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           45)))))))))))))))
-            (union_id 45)))
-          (43
+                           56)))))))))))))))
+            (union_id 56)))
+          (54
            ((cases
              (((BuiltinType Builder) (Discriminator 0))
               (IntegerType (Discriminator 1))))
             (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 43))))
+                       (function_returns (UnionType 54))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 43)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 44))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 54)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 55))))
                (impl_methods
                 ((from
                   (Value
@@ -1971,16 +2319,16 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 43))))
+                       (function_returns (UnionType 54))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           43)))))))))))))))
-            (union_id 43)))))
+                           54)))))))))))))))
+            (union_id 54)))))
         (interfaces
-         ((44
+         ((55
            ((interface_methods
              ((from
                ((function_params ((from (BuiltinType Builder))))
@@ -2003,25 +2351,25 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings ((Test (Value (Type (UnionType 44))))))
+     ((bindings ((Test (Value (Type (UnionType 55))))))
       (structs
-       ((42
+       ((53
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 42)) (builder (StructType 3))))
+                 ((self (StructType 53)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -2032,49 +2380,94 @@ let%expect_test "unions" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 42))) value IntegerType))
+                         ((Reference (self (StructType 53))) value IntegerType))
                         (Value (Integer 257))))))))))))))
+            (deserialize
+             ((function_signature
+               ((function_params ((s (StructType 7))))
+                (function_returns (StructType 9))))
+              (function_impl
+               (Fn
+                ((Block
+                  ((Let
+                    ((res
+                      (FunctionCall
+                       ((ResolvedReference (load_int <opaque>))
+                        ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                   (Break
+                    (Expr
+                     (Value
+                      (Struct
+                       (9
+                        ((slice
+                          (StructField
+                           ((Reference (res (StructType 6))) slice
+                            (StructType 7))))
+                         (value
+                          (Value
+                           (Struct
+                            (53
+                             ((value
+                               (StructField
+                                ((Reference (res (StructType 6))) value
+                                 IntegerType)))))))))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 42))))
+                (function_returns (StructType 53))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 9))))
+           (((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 42))))
+                     (function_returns (StructType 53))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 42)))))
+                           (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 53)))))
       (unions
-       ((44
+       ((55
          ((cases
-           (((StructType 35) (Discriminator 0))
-            ((StructType 42) (Discriminator 1))))
+           (((StructType 42) (Discriminator 0))
+            ((StructType 53) (Discriminator 1))))
           (union_methods
            ((id
              ((function_signature
-               ((function_params ((self (UnionType 44))))
-                (function_returns (UnionType 44))))
+               ((function_params ((self (UnionType 55))))
+                (function_returns (UnionType 55))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (self (UnionType 44))))))))))))))
+               (Fn ((Block ((Break (Expr (Reference (self (UnionType 55))))))))))))))
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 45))))
+           (((impl_interface (Value (Type (InterfaceType 56))))
+             (impl_methods
+              ((from
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((v (ExprType (Value (Type (StructType 53)))))))
+                     (function_returns (UnionType 55))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (MakeUnionVariant
+                        ((Reference
+                          (v (ExprType (Value (Type (StructType 53))))))
+                         55)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 57))))
              (impl_methods
               ((from
                 (Value
@@ -2082,41 +2475,25 @@ let%expect_test "unions" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type (StructType 42)))))))
-                     (function_returns (UnionType 44))))
+                     (function_returns (UnionType 55))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
                           (v (ExprType (Value (Type (StructType 42))))))
-                         44)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 46))))
-             (impl_methods
-              ((from
-                (Value
-                 (Function
-                  ((function_signature
-                    ((function_params
-                      ((v (ExprType (Value (Type (StructType 35)))))))
-                     (function_returns (UnionType 44))))
-                   (function_impl
-                    (Fn
-                     ((Return
-                       (MakeUnionVariant
-                        ((Reference
-                          (v (ExprType (Value (Type (StructType 35))))))
-                         44)))))))))))))))
-          (union_id 44)))))
+                         55)))))))))))))))
+          (union_id 55)))))
       (interfaces
-       ((46
-         ((interface_methods
-           ((from
-             ((function_params ((from (StructType 35))))
-              (function_returns SelfType)))))))
-        (45
+       ((57
          ((interface_methods
            ((from
              ((function_params ((from (StructType 42))))
+              (function_returns SelfType)))))))
+        (56
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 53))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2141,9 +2518,9 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct (45 ())))) (foo_empty (Value (Struct (46 ()))))
-        (Empty (Value (Type (StructType 45)))) (x (Value (Integer 10)))
-        (foo (Value (Struct (43 ()))))
+       ((y (Value (Struct (56 ())))) (foo_empty (Value (Struct (57 ()))))
+        (Empty (Value (Type (StructType 56)))) (x (Value (Integer 10)))
+        (foo (Value (Struct (54 ()))))
         (Foo
          (Value
           (Function
@@ -2161,7 +2538,7 @@ let%expect_test "methods monomorphization" =
                         (MkFunction
                          ((function_signature
                            ((function_params
-                             ((self (StructType 42))
+                             ((self (StructType 53))
                               (x (ExprType (Reference (X (TypeN 0)))))))
                             (function_returns
                              (ExprType (Reference (X (TypeN 0)))))))
@@ -2172,31 +2549,31 @@ let%expect_test "methods monomorphization" =
                                 (Expr
                                  (Reference
                                   (x (ExprType (Reference (X (TypeN 0))))))))))))))))))
-                     (mk_impls ()) (mk_struct_id 42))))))))))))))))
+                     (mk_impls ()) (mk_struct_id 53))))))))))))))))
       (structs
-       ((46
+       ((57
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 46)) (x (StructType 45))))
-                (function_returns (StructType 45))))
+               ((function_params ((self (StructType 57)) (x (StructType 56))))
+                (function_returns (StructType 56))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (x (StructType 45))))))))))))))
-          (struct_impls ()) (struct_id 46)))
-        (45
+               (Fn ((Block ((Break (Expr (Reference (x (StructType 56))))))))))))))
+          (struct_impls ()) (struct_id 57)))
+        (56
          ((struct_fields ()) (struct_methods ()) (struct_impls ())
-          (struct_id 45)))
-        (43
+          (struct_id 56)))
+        (54
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 43)) (x IntegerType)))
+               ((function_params ((self (StructType 54)) (x IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (x IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 43)))))
+          (struct_impls ()) (struct_id 54)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -2226,71 +2603,71 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 43))))
+             ((function_params ((i (UnionType 54))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               ((Block
                 ((Break
                   (Switch
-                   ((switch_condition (Reference (i (UnionType 43))))
+                   ((switch_condition (Reference (i (UnionType 54))))
                     (branches
-                     (((branch_ty (StructType 36)) (branch_var vax)
+                     (((branch_ty (StructType 43)) (branch_var vax)
                        (branch_stmt (Block ((Return (Value (Integer 32)))))))
-                      ((branch_ty (StructType 35)) (branch_var vax)
+                      ((branch_ty (StructType 42)) (branch_var vax)
                        (branch_stmt (Block ((Return (Value (Integer 64)))))))))))))))))))))
-        (Ints (Value (Type (UnionType 43))))))
+        (Ints (Value (Type (UnionType 54))))))
       (structs ())
       (unions
-       ((43
+       ((54
          ((cases
-           (((StructType 35) (Discriminator 0))
-            ((StructType 36) (Discriminator 1))))
+           (((StructType 42) (Discriminator 0))
+            ((StructType 43) (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 44))))
+           (((impl_interface (Value (Type (InterfaceType 55))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 36)))))))
-                     (function_returns (UnionType 43))))
+                      ((v (ExprType (Value (Type (StructType 43)))))))
+                     (function_returns (UnionType 54))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 36))))))
-                         43)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 45))))
+                          (v (ExprType (Value (Type (StructType 43))))))
+                         54)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 56))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 35)))))))
-                     (function_returns (UnionType 43))))
+                      ((v (ExprType (Value (Type (StructType 42)))))))
+                     (function_returns (UnionType 54))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 35))))))
-                         43)))))))))))))))
-          (union_id 43)))))
+                          (v (ExprType (Value (Type (StructType 42))))))
+                         54)))))))))))))))
+          (union_id 54)))))
       (interfaces
-       ((45
+       ((56
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 35))))
+             ((function_params ((from (StructType 42))))
               (function_returns SelfType)))))))
-        (44
+        (55
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 36))))
+             ((function_params ((from (StructType 43))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2375,26 +2752,26 @@ let%expect_test "let binding with type" =
     {|
       (Ok
        ((bindings
-         ((a (Value (Struct (36 ((value (Value (Integer 2))))))))
-          (a (Value (Struct (42 ((value (Value (Integer 1))))))))))
+         ((a (Value (Struct (43 ((value (Value (Integer 2))))))))
+          (a (Value (Struct (53 ((value (Value (Integer 1))))))))))
         (structs
-         ((42
+         ((53
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
+                       (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 42)) (builder (StructType 3))))
+                   ((self (StructType 53)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2405,35 +2782,64 @@ let%expect_test "let binding with type" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 42))) value IntegerType))
+                           ((Reference (self (StructType 53))) value IntegerType))
                           (Value (Integer 257))))))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 7))))
+                  (function_returns (StructType 9))))
+                (function_impl
+                 (Fn
+                  ((Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((ResolvedReference (load_int <opaque>))
+                          ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                     (Break
+                      (Expr
+                       (Value
+                        (Struct
+                         (9
+                          ((slice
+                            (StructField
+                             ((Reference (res (StructType 6))) slice
+                              (StructType 7))))
+                           (value
+                            (Value
+                             (Struct
+                              (53
+                               ((value
+                                 (StructField
+                                  ((Reference (res (StructType 6))) value
+                                   IntegerType)))))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 42))))
+                  (function_returns (StructType 53))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
+                       (Value (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 9))))
+             (((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 42))))
+                       (function_returns (StructType 53))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 42)))))
+                             (Struct (53 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 53)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)))
       |}]
 
@@ -2479,7 +2885,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 44))))
+             ((function_params ((t (StructType 55))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -2489,19 +2895,19 @@ let%expect_test "interface constraints" =
                    ((Value
                      (Function
                       ((function_signature
-                        ((function_params ((self (StructType 44))))
+                        ((function_params ((self (StructType 55))))
                          (function_returns IntegerType)))
                        (function_impl
                         (Fn ((Block ((Break (Expr (Value (Integer 1))))))))))))
-                    ((Reference (t (StructType 44))))))))))))))))
+                    ((Reference (t (StructType 55))))))))))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 42))))
+             ((function_params ((T (InterfaceType 53))))
               (function_returns
                (FunctionType
-                ((function_params ((t (Dependent T (InterfaceType 42)))))
+                ((function_params ((t (Dependent T (InterfaceType 53)))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -2511,47 +2917,47 @@ let%expect_test "interface constraints" =
                    (MkFunction
                     ((function_signature
                       ((function_params
-                        ((t (ExprType (Reference (T (InterfaceType 42)))))))
+                        ((t (ExprType (Reference (T (InterfaceType 53)))))))
                        (function_returns IntegerType)))
                      (function_impl
                       (Fn
                        ((Block
                          ((Return
                            (IntfMethodCall
-                            ((intf_instance (Reference (T (InterfaceType 42))))
-                             (intf_def 42)
+                            ((intf_instance (Reference (T (InterfaceType 53))))
+                             (intf_def 53)
                              (intf_method
                               (beep
                                ((function_params ((self SelfType)))
                                 (function_returns IntegerType))))
                              (intf_args
                               ((Reference
-                                (t (ExprType (Reference (T (InterfaceType 42)))))))))))))))))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 44))))
-        (Beep (Value (Type (InterfaceType 42))))))
+                                (t (ExprType (Reference (T (InterfaceType 53)))))))))))))))))))))))))))))
+        (BeeperImpl1 (Value (Type (StructType 55))))
+        (Beep (Value (Type (InterfaceType 53))))))
       (structs
-       ((44
+       ((55
          ((struct_fields ())
           (struct_methods
            ((beep
              ((function_signature
-               ((function_params ((self (StructType 44))))
+               ((function_params ((self (StructType 55))))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Block ((Break (Expr (Value (Integer 1)))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 42))))
+           (((impl_interface (Value (Type (InterfaceType 53))))
              (impl_methods
               ((beep
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ((self (StructType 44))))
+                    ((function_params ((self (StructType 55))))
                      (function_returns IntegerType)))
                    (function_impl
                     (Fn ((Block ((Break (Expr (Value (Integer 1))))))))))))))))))
-          (struct_id 44)))))
+          (struct_id 55)))))
       (interfaces
-       ((42
+       ((53
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -34,25 +34,25 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 38))))))
+     ((bindings ((T (Value (Type (StructType 42))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -63,35 +63,35 @@ let%expect_test "scope resolution" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
@@ -102,25 +102,25 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 38))))))
+     ((bindings ((T (Value (Type (StructType 42))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -131,35 +131,35 @@ let%expect_test "binding resolution" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -184,25 +184,25 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 38)))) (A (Value (Type (StructType 38))))))
+       ((B (Value (Type (StructType 42)))) (A (Value (Type (StructType 42))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -213,35 +213,35 @@ let%expect_test "scope resolution after let binding" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
@@ -252,28 +252,28 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 40))))))
+     ((bindings ((T (Value (Type (StructType 44))))))
       (structs
-       ((40
-         ((struct_fields ((t ((field_type (StructType 38))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 40)))
-        (38
+       ((44
+         ((struct_fields ((t ((field_type (StructType 42))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 44)))
+        (42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -284,35 +284,35 @@ let%expect_test "basic struct definition" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
@@ -343,33 +343,33 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a (Value (Struct (38 ((value (Value (Integer 1))))))))
+       ((a (Value (Struct (42 ((value (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 38))))
-              (function_returns (StructType 38))))
+             ((function_params ((i (StructType 42))))
+              (function_returns (StructType 42))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 38))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 42))))))))))))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -380,35 +380,35 @@ let%expect_test "Tact function evaluation" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -453,29 +453,29 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings ((MyType (Value (Type (StructType 40))))))
+       ((bindings ((MyType (Value (Type (StructType 44))))))
         (structs
-         ((40
+         ((44
            ((struct_fields
-             ((a ((field_type (StructType 38)))) (b ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 40)))
-          (38
+             ((a ((field_type (StructType 42)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 44)))
+          (42
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 38)) (builder (StructType 3))))
+                   ((self (StructType 42)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -486,35 +486,35 @@ let%expect_test "struct definition" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 38))) value IntegerType))
+                           ((Reference (self (StructType 42))) value IntegerType))
                           (Value (Integer 257))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 38))))
+                       (function_returns (StructType 42))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 38)))))
+                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 42)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -533,32 +533,32 @@ let%expect_test "duplicate type field" =
      (((DuplicateField
         (a
          ((mk_struct_fields
-           ((a (Value (Type (StructType 38)))) (a (Value (Type BoolType)))))
+           ((a (Value (Type (StructType 42)))) (a (Value (Type BoolType)))))
           (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
-       ((bindings ((MyType (Value (Type (StructType 40))))))
+       ((bindings ((MyType (Value (Type (StructType 44))))))
         (structs
-         ((40
+         ((44
            ((struct_fields
-             ((a ((field_type (StructType 38)))) (a ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 40)))
-          (38
+             ((a ((field_type (StructType 42)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 44)))
+          (42
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 38)) (builder (StructType 3))))
+                   ((self (StructType 42)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -569,36 +569,36 @@ let%expect_test "duplicate type field" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 38))) value IntegerType))
+                           ((Reference (self (StructType 42))) value IntegerType))
                           (Value (Integer 257))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 38))))
+                       (function_returns (StructType 42))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 38)))))
+                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 42)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -613,7 +613,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 40))))
+       ((TA (Value (Type (StructType 44))))
         (T
          (Value
           (Function
@@ -624,28 +624,28 @@ let%expect_test "parametric struct instantiation" =
               ((Expr
                 (MkStructDef
                  ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                  (mk_methods ()) (mk_impls ()) (mk_struct_id 38)))))))))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 42)))))))))))))
       (structs
-       ((40
-         ((struct_fields ((a ((field_type (StructType 39))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 40)))
-        (39
+       ((44
+         ((struct_fields ((a ((field_type (StructType 43))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 44)))
+        (43
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 39))))
+                (function_returns (StructType 43))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (39 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (43 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 39)) (builder (StructType 3))))
+                 ((self (StructType 43)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -656,35 +656,35 @@ let%expect_test "parametric struct instantiation" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 39))) value IntegerType))
+                         ((Reference (self (StructType 43))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 39))))
+                (function_returns (StructType 43))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (39 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (43 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 39))))
+                     (function_returns (StructType 43))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (39 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 39)))))
+                           (Struct (43 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -721,36 +721,36 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b (Value (Struct (38 ((value (Value (Integer 1))))))))
+       ((b (Value (Struct (42 ((value (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 38))))
-              (function_returns (StructType 38))))
+             ((function_params ((i (StructType 42))))
+              (function_returns (StructType 42))))
             (function_impl
              (Fn
               ((Block
-                ((Let ((a (Reference (i (StructType 38))))))
-                 (Break (Expr (Reference (a (StructType 38))))))))))))))))
+                ((Let ((a (Reference (i (StructType 42))))))
+                 (Break (Expr (Reference (a (StructType 42))))))))))))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -761,35 +761,35 @@ let%expect_test "scoping that `let` introduces in code" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
@@ -814,7 +814,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 38))))
+             ((function_params ((x (StructType 42))))
               (function_returns HoleType)))
             (function_impl
              (Fn
@@ -823,40 +823,40 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (x (StructType 38)))
-                       (Reference (x (StructType 38)))))))))
+                      ((Reference (x (StructType 42)))
+                       (Reference (x (StructType 42)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (a (StructType 38)))
-                       (Reference (a (StructType 38))))))))))))))))))
+                      ((Reference (a (StructType 42)))
+                       (Reference (a (StructType 42))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 38)) (i_ (StructType 38))))
-              (function_returns (StructType 38))))
+             ((function_params ((i (StructType 42)) (i_ (StructType 42))))
+              (function_returns (StructType 42))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (i (StructType 38))))))))))))))))
+             (Fn ((Block ((Break (Expr (Reference (i (StructType 42))))))))))))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -867,35 +867,35 @@ let%expect_test "reference in function bodies" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -941,19 +941,19 @@ let%expect_test "struct method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (Struct (39 ()))))
-        (Foo (Value (Type (StructType 39))))))
+       ((res (Value (Integer 1))) (foo (Value (Struct (43 ()))))
+        (Foo (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 39)) (i IntegerType)))
+               ((function_params ((self (StructType 43)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 39)))))
+          (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -971,9 +971,9 @@ let%expect_test "struct type method access" =
   [%expect
     {|
     (Ok
-     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 39))))))
+     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields ())
           (struct_methods
            ((bar
@@ -982,7 +982,7 @@ let%expect_test "struct type method access" =
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 39)))))
+          (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -999,18 +999,18 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 39))))))
+     ((bindings ((Foo (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 39))))
-                (function_returns (StructType 39))))
+               ((function_params ((self (StructType 43))))
+                (function_returns (StructType 43))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (self (StructType 39))))))))))))))
-          (struct_impls ()) (struct_id 39)))))
+               (Fn ((Block ((Break (Expr (Reference (self (StructType 43))))))))))))))
+          (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -1034,44 +1034,44 @@ let%expect_test "union method access" =
     {|
       (Ok
        ((bindings
-         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 39))))
+         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 43))))
           (make_foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 39))))
-                (function_returns (UnionType 39))))
+               ((function_params ((foo (UnionType 43))))
+                (function_returns (UnionType 43))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 39))))))))))))))
-          (Foo (Value (Type (UnionType 39))))))
+               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 43))))))))))))))
+          (Foo (Value (Type (UnionType 43))))))
         (structs ())
         (unions
-         ((39
+         ((43
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (UnionType 39)) (i IntegerType)))
+                 ((function_params ((self (UnionType 43)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl
                  (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 40))))
+             (((impl_interface (Value (Type (InterfaceType 44))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 39))))
+                       (function_returns (UnionType 43))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 39)))))))))))))))
-            (union_id 39)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 43)))))))))))))))
+            (union_id 43)))))
         (interfaces
-         ((40
+         ((44
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1103,14 +1103,14 @@ let%expect_test "union type method access" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 39))))
-                (function_returns (UnionType 39))))
+               ((function_params ((foo (UnionType 43))))
+                (function_returns (UnionType 43))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 39))))))))))))))
-          (Foo (Value (Type (UnionType 39))))))
+               (Fn ((Block ((Break (Expr (Reference (foo (UnionType 43))))))))))))))
+          (Foo (Value (Type (UnionType 43))))))
         (structs ())
         (unions
-         ((39
+         ((43
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
@@ -1120,22 +1120,22 @@ let%expect_test "union type method access" =
                 (function_impl
                  (Fn ((Block ((Break (Expr (Reference (i IntegerType)))))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 40))))
+             (((impl_interface (Value (Type (InterfaceType 44))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 39))))
+                       (function_returns (UnionType 43))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 39)))))))))))))))
-            (union_id 39)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 43)))))))))))))))
+            (union_id 43)))))
         (interfaces
-         ((40
+         ((44
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1159,13 +1159,13 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value (Struct (39 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 39))))))
+         (Value (Struct (43 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_methods ()) (struct_impls ()) (struct_id 39)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -1176,22 +1176,22 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 31) (StructType 32)))
+     (((TypeError ((StructType 35) (StructType 36)))
        ((bindings
          ((foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((i (StructType 32))))
-                (function_returns (StructType 31))))
+               ((function_params ((i (StructType 36))))
+                (function_returns (StructType 35))))
               (function_impl
-               (Fn ((Block ((Return (Reference (i (StructType 32)))))))))))))))
+               (Fn ((Block ((Return (Reference (i (StructType 36)))))))))))))))
         (structs ())
         (interfaces
-         ((38
+         ((42
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 32))))
+               ((function_params ((from (StructType 36))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1284,27 +1284,27 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 38) (StructType 39)))
+     (((TypeError ((StructType 42) (StructType 43)))
        ((bindings ())
         (structs
-         ((39
+         ((43
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 39))))
+                  (function_returns (StructType 43))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (39 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (43 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 39)) (builder (StructType 3))))
+                   ((self (StructType 43)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1315,54 +1315,54 @@ let%expect_test "type check error" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 39))) value IntegerType))
+                           ((Reference (self (StructType 43))) value IntegerType))
                           (Value (Integer 10))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 39))))
+                  (function_returns (StructType 43))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (39 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (43 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 39))))
+                       (function_returns (StructType 43))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (39 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 39)))
-          (38
+                             (Struct (43 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 43)))
+          (42
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 38)) (builder (StructType 3))))
+                   ((self (StructType 42)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1373,41 +1373,41 @@ let%expect_test "type check error" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 38))) value IntegerType))
+                           ((Reference (self (StructType 42))) value IntegerType))
                           (Value (Integer 99))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
                        (Value
-                        (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                        (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 38))))
+                       (function_returns (StructType 42))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 38)))))
+                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 42)))))
         (interfaces
-         ((40
+         ((44
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 39))))
+               ((function_params ((from (StructType 43))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1427,9 +1427,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 39))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 43))))))
       (structs
-       ((39
+       ((43
          ((struct_fields ())
           (struct_methods
            ((op
@@ -1450,7 +1450,7 @@ let%expect_test "implement interface op" =
                    (function_impl
                     (Fn
                      ((Block ((Break (Expr (Reference (left IntegerType))))))))))))))))))
-          (struct_id 39)))))
+          (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -1472,30 +1472,30 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (40 ())))) (Empty (Value (Type (StructType 40))))
-        (Make (Value (Type (InterfaceType 38))))))
+       ((empty (Value (Struct (44 ())))) (Empty (Value (Type (StructType 44))))
+        (Make (Value (Type (InterfaceType 42))))))
       (structs
-       ((40
+       ((44
          ((struct_fields ())
           (struct_methods
            ((new
              ((function_signature
-               ((function_params ()) (function_returns (StructType 40))))
+               ((function_params ()) (function_returns (StructType 44))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Value (Struct (40 ()))))))))))))))
+               (Fn ((Block ((Break (Expr (Value (Struct (44 ()))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 38))))
+           (((impl_interface (Value (Type (InterfaceType 42))))
              (impl_methods
               ((new
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 40))))
+                    ((function_params ()) (function_returns (StructType 44))))
                    (function_impl
-                    (Fn ((Block ((Break (Expr (Value (Struct (40 ())))))))))))))))))))
-          (struct_id 40)))))
+                    (Fn ((Block ((Break (Expr (Value (Struct (44 ())))))))))))))))))))
+          (struct_id 44)))))
       (interfaces
-       ((38
+       ((42
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
@@ -1517,7 +1517,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 41)) (b (StructType 3))))
+             ((function_params ((self (StructType 45)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -1529,7 +1529,7 @@ let%expect_test "serializer inner struct" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 32)) (builder (StructType 3))))
+                            ((self (StructType 36)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -1540,24 +1540,24 @@ let%expect_test "serializer inner struct" =
                                  ((ResolvedReference (serialize_int <opaque>))
                                   ((Reference (builder (StructType 3)))
                                    (StructField
-                                    ((Reference (self (StructType 32))) value
+                                    ((Reference (self (StructType 36))) value
                                      IntegerType))
                                    (Value (Integer 32)))))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 41))) y (StructType 32)))
+                        ((Reference (self (StructType 45))) y (StructType 36)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (Outer (Value (Type (StructType 41))))
-        (Inner (Value (Type (StructType 39))))))
+        (Outer (Value (Type (StructType 45))))
+        (Inner (Value (Type (StructType 43))))))
       (structs
-       ((41
+       ((45
          ((struct_fields
-           ((y ((field_type (StructType 32))))
-            (z ((field_type (StructType 39))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 41)))
-        (39
-         ((struct_fields ((x ((field_type (StructType 32))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 39)))))
+           ((y ((field_type (StructType 36))))
+            (z ((field_type (StructType 43))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 45)))
+        (43
+         ((struct_fields ((x ((field_type (StructType 36))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -1714,25 +1714,25 @@ let%expect_test "union variants constructing" =
     (Ok
      ((bindings
        ((b
-         (Value (UnionVariant ((Struct (32 ((value (Value (Integer 1)))))) 39))))
-        (a (Value (UnionVariant ((Integer 10) 39))))
+         (Value (UnionVariant ((Struct (36 ((value (Value (Integer 1)))))) 43))))
+        (a (Value (UnionVariant ((Integer 10) 43))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 39))))
-              (function_returns (UnionType 39))))
+             ((function_params ((value (UnionType 43))))
+              (function_returns (UnionType 43))))
             (function_impl
-             (Fn ((Block ((Break (Expr (Reference (value (UnionType 39))))))))))))))
-        (Uni (Value (Type (UnionType 39))))))
+             (Fn ((Block ((Break (Expr (Reference (value (UnionType 43))))))))))))))
+        (Uni (Value (Type (UnionType 43))))))
       (structs ())
       (unions
-       ((39
+       ((43
          ((cases
-           (((StructType 32) (Discriminator 0)) (IntegerType (Discriminator 1))))
+           (((StructType 36) (Discriminator 0)) (IntegerType (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
@@ -1740,35 +1740,35 @@ let%expect_test "union variants constructing" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type IntegerType))))))
-                     (function_returns (UnionType 39))))
+                     (function_returns (UnionType 43))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference (v (ExprType (Value (Type IntegerType)))))
-                         39)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 40))))
+                         43)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 44))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 32)))))))
-                     (function_returns (UnionType 39))))
+                      ((v (ExprType (Value (Type (StructType 36)))))))
+                     (function_returns (UnionType 43))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 32))))))
-                         39)))))))))))))))
-          (union_id 39)))))
+                          (v (ExprType (Value (Type (StructType 36))))))
+                         43)))))))))))))))
+          (union_id 43)))))
       (interfaces
-       ((40
+       ((44
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 32))))
+             ((function_params ((from (StructType 36))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -1791,7 +1791,7 @@ let%expect_test "unions duplicate variant" =
     (Error
      (((DuplicateVariant IntegerType)
        ((bindings
-         ((b (Value (Type (UnionType 41)))) (a (Value (Type (UnionType 39))))
+         ((b (Value (Type (UnionType 45)))) (a (Value (Type (UnionType 43))))
           (Test
            (Value
             (Function
@@ -1820,14 +1820,14 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 38))))
+                               (function_returns (UnionType 42))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Value
                                     (Type (ExprType (Reference (v IntegerType)))))
-                                   38)))))))))))))
+                                   42)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -1843,7 +1843,7 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v (Dependent T (TypeN 0)))))
-                               (function_returns (UnionType 38))))
+                               (function_returns (UnionType 42))))
                              (function_impl
                               (Fn
                                ((Return
@@ -1853,8 +1853,8 @@ let%expect_test "unions duplicate variant" =
                                      (ExprType
                                       (Reference
                                        (v (ExprType (Reference (T (TypeN 0)))))))))
-                                   38)))))))))))))))
-                    (mk_union_id 38)))))))
+                                   42)))))))))))))))
+                    (mk_union_id 42)))))))
               (function_impl
                (Fn
                 ((Block
@@ -1881,12 +1881,12 @@ let%expect_test "unions duplicate variant" =
                               (Function
                                ((function_signature
                                  ((function_params ((v IntegerType)))
-                                  (function_returns (UnionType 38))))
+                                  (function_returns (UnionType 42))))
                                 (function_impl
                                  (Fn
                                   ((Return
                                     (MakeUnionVariant
-                                     ((Reference (v IntegerType)) 38)))))))))))))
+                                     ((Reference (v IntegerType)) 42)))))))))))))
                          ((impl_interface
                            (FunctionCall
                             ((Value
@@ -1903,33 +1903,33 @@ let%expect_test "unions duplicate variant" =
                                ((function_signature
                                  ((function_params
                                    ((v (ExprType (Reference (T (TypeN 0)))))))
-                                  (function_returns (UnionType 38))))
+                                  (function_returns (UnionType 42))))
                                 (function_impl
                                  (Fn
                                   ((Return
                                     (MakeUnionVariant
                                      ((Reference
                                        (v (ExprType (Reference (T (TypeN 0))))))
-                                      38)))))))))))))))
-                       (mk_union_id 38))))))))))))))))
+                                      42)))))))))))))))
+                       (mk_union_id 42))))))))))))))))
         (structs ())
         (unions
-         ((41
+         ((45
            ((cases ((IntegerType (Discriminator 0)))) (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 41))))
+                       (function_returns (UnionType 45))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 41)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 5))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 45)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
@@ -1937,33 +1937,33 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 41))))
+                       (function_returns (UnionType 45))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           41)))))))))))))))
-            (union_id 41)))
-          (39
+                           45)))))))))))))))
+            (union_id 45)))
+          (43
            ((cases
              (((BuiltinType Builder) (Discriminator 0))
               (IntegerType (Discriminator 1))))
             (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 39))))
+                       (function_returns (UnionType 43))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 39)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 40))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 43)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 44))))
                (impl_methods
                 ((from
                   (Value
@@ -1971,16 +1971,16 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 39))))
+                       (function_returns (UnionType 43))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           39)))))))))))))))
-            (union_id 39)))))
+                           43)))))))))))))))
+            (union_id 43)))))
         (interfaces
-         ((40
+         ((44
            ((interface_methods
              ((from
                ((function_params ((from (BuiltinType Builder))))
@@ -2003,25 +2003,25 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings ((Test (Value (Type (UnionType 40))))))
+     ((bindings ((Test (Value (Type (UnionType 44))))))
       (structs
-       ((38
+       ((42
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 38)) (builder (StructType 3))))
+                 ((self (StructType 42)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -2032,91 +2032,91 @@ let%expect_test "unions" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 38))) value IntegerType))
+                         ((Reference (self (StructType 42))) value IntegerType))
                         (Value (Integer 257))))))))))))))
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 38))))
+                (function_returns (StructType 42))))
               (function_impl
                (Fn
                 ((Block
                   ((Break
                     (Expr
-                     (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                     (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 5))))
+           (((impl_interface (Value (Type (InterfaceType 9))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 38))))
+                     (function_returns (StructType 42))))
                    (function_impl
                     (Fn
                      ((Block
                        ((Break
                          (Expr
                           (Value
-                           (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-          (struct_id 38)))))
+                           (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+          (struct_id 42)))))
       (unions
-       ((40
+       ((44
          ((cases
-           (((StructType 31) (Discriminator 0))
-            ((StructType 38) (Discriminator 1))))
+           (((StructType 35) (Discriminator 0))
+            ((StructType 42) (Discriminator 1))))
           (union_methods
            ((id
              ((function_signature
-               ((function_params ((self (UnionType 40))))
-                (function_returns (UnionType 40))))
+               ((function_params ((self (UnionType 44))))
+                (function_returns (UnionType 44))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (self (UnionType 40))))))))))))))
+               (Fn ((Block ((Break (Expr (Reference (self (UnionType 44))))))))))))))
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 41))))
+           (((impl_interface (Value (Type (InterfaceType 45))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 38)))))))
-                     (function_returns (UnionType 40))))
+                      ((v (ExprType (Value (Type (StructType 42)))))))
+                     (function_returns (UnionType 44))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 38))))))
-                         40)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 42))))
+                          (v (ExprType (Value (Type (StructType 42))))))
+                         44)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 46))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 31)))))))
-                     (function_returns (UnionType 40))))
+                      ((v (ExprType (Value (Type (StructType 35)))))))
+                     (function_returns (UnionType 44))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 31))))))
-                         40)))))))))))))))
-          (union_id 40)))))
+                          (v (ExprType (Value (Type (StructType 35))))))
+                         44)))))))))))))))
+          (union_id 44)))))
       (interfaces
-       ((42
+       ((46
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 31))))
+             ((function_params ((from (StructType 35))))
               (function_returns SelfType)))))))
-        (41
+        (45
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 38))))
+             ((function_params ((from (StructType 42))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2141,9 +2141,9 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct (41 ())))) (foo_empty (Value (Struct (42 ()))))
-        (Empty (Value (Type (StructType 41)))) (x (Value (Integer 10)))
-        (foo (Value (Struct (39 ()))))
+       ((y (Value (Struct (45 ())))) (foo_empty (Value (Struct (46 ()))))
+        (Empty (Value (Type (StructType 45)))) (x (Value (Integer 10)))
+        (foo (Value (Struct (43 ()))))
         (Foo
          (Value
           (Function
@@ -2161,7 +2161,7 @@ let%expect_test "methods monomorphization" =
                         (MkFunction
                          ((function_signature
                            ((function_params
-                             ((self (StructType 38))
+                             ((self (StructType 42))
                               (x (ExprType (Reference (X (TypeN 0)))))))
                             (function_returns
                              (ExprType (Reference (X (TypeN 0)))))))
@@ -2172,31 +2172,31 @@ let%expect_test "methods monomorphization" =
                                 (Expr
                                  (Reference
                                   (x (ExprType (Reference (X (TypeN 0))))))))))))))))))
-                     (mk_impls ()) (mk_struct_id 38))))))))))))))))
+                     (mk_impls ()) (mk_struct_id 42))))))))))))))))
       (structs
-       ((42
+       ((46
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 42)) (x (StructType 41))))
-                (function_returns (StructType 41))))
+               ((function_params ((self (StructType 46)) (x (StructType 45))))
+                (function_returns (StructType 45))))
               (function_impl
-               (Fn ((Block ((Break (Expr (Reference (x (StructType 41))))))))))))))
-          (struct_impls ()) (struct_id 42)))
-        (41
+               (Fn ((Block ((Break (Expr (Reference (x (StructType 45))))))))))))))
+          (struct_impls ()) (struct_id 46)))
+        (45
          ((struct_fields ()) (struct_methods ()) (struct_impls ())
-          (struct_id 41)))
-        (39
+          (struct_id 45)))
+        (43
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 39)) (x IntegerType)))
+               ((function_params ((self (StructType 43)) (x IntegerType)))
                 (function_returns IntegerType)))
               (function_impl
                (Fn ((Block ((Break (Expr (Reference (x IntegerType)))))))))))))
-          (struct_impls ()) (struct_id 39)))))
+          (struct_impls ()) (struct_id 43)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -2226,71 +2226,71 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 39))))
+             ((function_params ((i (UnionType 43))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               ((Block
                 ((Break
                   (Switch
-                   ((switch_condition (Reference (i (UnionType 39))))
+                   ((switch_condition (Reference (i (UnionType 43))))
                     (branches
-                     (((branch_ty (StructType 32)) (branch_var vax)
+                     (((branch_ty (StructType 36)) (branch_var vax)
                        (branch_stmt (Block ((Return (Value (Integer 32)))))))
-                      ((branch_ty (StructType 31)) (branch_var vax)
+                      ((branch_ty (StructType 35)) (branch_var vax)
                        (branch_stmt (Block ((Return (Value (Integer 64)))))))))))))))))))))
-        (Ints (Value (Type (UnionType 39))))))
+        (Ints (Value (Type (UnionType 43))))))
       (structs ())
       (unions
-       ((39
+       ((43
          ((cases
-           (((StructType 31) (Discriminator 0))
-            ((StructType 32) (Discriminator 1))))
+           (((StructType 35) (Discriminator 0))
+            ((StructType 36) (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 40))))
+           (((impl_interface (Value (Type (InterfaceType 44))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 32)))))))
-                     (function_returns (UnionType 39))))
+                      ((v (ExprType (Value (Type (StructType 36)))))))
+                     (function_returns (UnionType 43))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 32))))))
-                         39)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 41))))
+                          (v (ExprType (Value (Type (StructType 36))))))
+                         43)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 45))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 31)))))))
-                     (function_returns (UnionType 39))))
+                      ((v (ExprType (Value (Type (StructType 35)))))))
+                     (function_returns (UnionType 43))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 31))))))
-                         39)))))))))))))))
-          (union_id 39)))))
+                          (v (ExprType (Value (Type (StructType 35))))))
+                         43)))))))))))))))
+          (union_id 43)))))
       (interfaces
-       ((41
+       ((45
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 31))))
+             ((function_params ((from (StructType 35))))
               (function_returns SelfType)))))))
-        (40
+        (44
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 32))))
+             ((function_params ((from (StructType 36))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2375,26 +2375,26 @@ let%expect_test "let binding with type" =
     {|
       (Ok
        ((bindings
-         ((a (Value (Struct (32 ((value (Value (Integer 2))))))))
-          (a (Value (Struct (38 ((value (Value (Integer 1))))))))))
+         ((a (Value (Struct (36 ((value (Value (Integer 2))))))))
+          (a (Value (Struct (42 ((value (Value (Integer 1))))))))))
         (structs
-         ((38
+         ((42
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))
+                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 38)) (builder (StructType 3))))
+                   ((self (StructType 42)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2405,35 +2405,35 @@ let%expect_test "let binding with type" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 38))) value IntegerType))
+                           ((Reference (self (StructType 42))) value IntegerType))
                           (Value (Integer 257))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 38))))
+                  (function_returns (StructType 42))))
                 (function_impl
                  (Fn
                   ((Block
                     ((Break
                       (Expr
-                       (Value (Struct (38 ((value (Reference (i IntegerType))))))))))))))))))
+                       (Value (Struct (42 ((value (Reference (i IntegerType))))))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 5))))
+             (((impl_interface (Value (Type (InterfaceType 9))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 38))))
+                       (function_returns (StructType 42))))
                      (function_impl
                       (Fn
                        ((Block
                          ((Break
                            (Expr
                             (Value
-                             (Struct (38 ((value (Reference (i IntegerType)))))))))))))))))))))))
-            (struct_id 38)))))
+                             (Struct (42 ((value (Reference (i IntegerType)))))))))))))))))))))))
+            (struct_id 42)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)))
       |}]
 
@@ -2479,7 +2479,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 40))))
+             ((function_params ((t (StructType 44))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -2489,19 +2489,19 @@ let%expect_test "interface constraints" =
                    ((Value
                      (Function
                       ((function_signature
-                        ((function_params ((self (StructType 40))))
+                        ((function_params ((self (StructType 44))))
                          (function_returns IntegerType)))
                        (function_impl
                         (Fn ((Block ((Break (Expr (Value (Integer 1))))))))))))
-                    ((Reference (t (StructType 40))))))))))))))))
+                    ((Reference (t (StructType 44))))))))))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 38))))
+             ((function_params ((T (InterfaceType 42))))
               (function_returns
                (FunctionType
-                ((function_params ((t (Dependent T (InterfaceType 38)))))
+                ((function_params ((t (Dependent T (InterfaceType 42)))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -2511,47 +2511,47 @@ let%expect_test "interface constraints" =
                    (MkFunction
                     ((function_signature
                       ((function_params
-                        ((t (ExprType (Reference (T (InterfaceType 38)))))))
+                        ((t (ExprType (Reference (T (InterfaceType 42)))))))
                        (function_returns IntegerType)))
                      (function_impl
                       (Fn
                        ((Block
                          ((Return
                            (IntfMethodCall
-                            ((intf_instance (Reference (T (InterfaceType 38))))
-                             (intf_def 38)
+                            ((intf_instance (Reference (T (InterfaceType 42))))
+                             (intf_def 42)
                              (intf_method
                               (beep
                                ((function_params ((self SelfType)))
                                 (function_returns IntegerType))))
                              (intf_args
                               ((Reference
-                                (t (ExprType (Reference (T (InterfaceType 38)))))))))))))))))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 40))))
-        (Beep (Value (Type (InterfaceType 38))))))
+                                (t (ExprType (Reference (T (InterfaceType 42)))))))))))))))))))))))))))))
+        (BeeperImpl1 (Value (Type (StructType 44))))
+        (Beep (Value (Type (InterfaceType 42))))))
       (structs
-       ((40
+       ((44
          ((struct_fields ())
           (struct_methods
            ((beep
              ((function_signature
-               ((function_params ((self (StructType 40))))
+               ((function_params ((self (StructType 44))))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Block ((Break (Expr (Value (Integer 1)))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 38))))
+           (((impl_interface (Value (Type (InterfaceType 42))))
              (impl_methods
               ((beep
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ((self (StructType 40))))
+                    ((function_params ((self (StructType 44))))
                      (function_returns IntegerType)))
                    (function_impl
                     (Fn ((Block ((Break (Expr (Value (Integer 1))))))))))))))))))
-          (struct_id 40)))))
+          (struct_id 44)))))
       (interfaces
-       ((38
+       ((42
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -87,8 +87,8 @@ and print_sexp e =
   pp_sexp
     (Result.sexp_of_t Lang.sexp_of_program (List.sexp_of_t sexp_of_error) e)
 
-let pp ?(prev_program = Lang.default_program ()) s =
-  parse_program s |> build_program ~prev_program |> print_sexp
+let pp ?(prev_program = Lang.default_program ()) ?(strip_defaults = true) s =
+  parse_program s |> build_program ~prev_program ~strip_defaults |> print_sexp
 
 exception Exn of error list
 


### PR DESCRIPTION
This PR adds `builtin_Slice` builtin, `Slice` std struct and `deserialize` method for most of the types required for the deserialization of messages.