### PR TITLE
Add (De)Serialize interfaces

### DIFF
--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -366,6 +366,9 @@ class constructor (program : T.program) =
           in
           self#lang_type_to_type @@ T.expr_to_type
           @@ Value (inter#interpret_expr ex)
+      (* TODO: this is a bug that SelfType flows into codegen stage *)
+      | SelfType ->
+          F.InferType
       | _ ->
           raise Invalid
 

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -495,8 +495,16 @@ let enum_member ==
 let union_definition(name) ==
   UNION;
   n = name;
-  (members, bindings) = delimited(LBRACE, pair(list(preceded(CASE, located(union_member))), list(sugared_function_definition(option(code_block)))), RBRACE);  
-  { (n, Union (make_union_definition ~union_members: members ~union_bindings: bindings ())) }
+  LBRACE;
+  (members, bindings) =
+    pair(
+      list(preceded(CASE, located(union_member))), 
+      list(sugared_function_definition(option(code_block)))
+    );
+  impls = list(impl);
+  RBRACE;
+  { (n, Union (make_union_definition ~union_members: members ~union_bindings: bindings ()
+                    ~union_impls: impls)) }
 
 let union_member :=
  (* can be a struct definition *)

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -14,12 +14,12 @@ program: UNION VAL
 ##
 ## Ends in an error in state: 1.
 ##
-## expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
-## non_semicolon_stmt -> UNION . IDENT LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## stmt_expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ SEMICOLON RBRACE EOF ]
+## expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
+## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
+## non_semicolon_stmt -> UNION . IDENT LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## stmt_expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION
@@ -31,9 +31,9 @@ program: UNION LBRACE VAL
 ##
 ## Ends in an error in state: 2.
 ##
-## expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
-## stmt_expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ SEMICOLON RBRACE EOF ]
+## expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
+## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
+## stmt_expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION LBRACE
@@ -45,7 +45,7 @@ program: UNION LBRACE CASE VAL
 ##
 ## Ends in an error in state: 3.
 ##
-## list(preceded(CASE,located(union_member))) -> CASE . union_member list(preceded(CASE,located(union_member))) [ RBRACE FN ]
+## list(preceded(CASE,located(union_member))) -> CASE . union_member list(preceded(CASE,located(union_member))) [ RBRACE IMPL FN ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE
@@ -57,7 +57,7 @@ program: UNION LBRACE CASE UNION VAL
 ##
 ## Ends in an error in state: 4.
 ##
-## union_member -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
+## union_member -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION
@@ -69,7 +69,7 @@ program: UNION LBRACE CASE UNION LBRACE VAL
 ##
 ## Ends in an error in state: 5.
 ##
-## union_member -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
+## union_member -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION LBRACE
@@ -162,8 +162,8 @@ program: RETURN UNION VAL
 ##
 ## Ends in an error in state: 12.
 ##
-## expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
+## expr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION
@@ -175,8 +175,8 @@ program: RETURN UNION LBRACE VAL
 ##
 ## Ends in an error in state: 13.
 ##
-## expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
+## expr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION LBRACE
@@ -184,45 +184,45 @@ program: RETURN UNION LBRACE VAL
 
 Invalid syntax
 
-program: RETURN UNION LBRACE FN IDENT LPAREN RPAREN IMPL
+program: UNION LBRACE IMPL VAL
 ##
-## Ends in an error in state: 15.
+## Ends in an error in state: 16.
 ##
-## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
+## list(impl) -> IMPL . fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## IMPL
 ##
 
 Invalid syntax
 
-program: RETURN UNION LBRACE RBRACE UNION
+program: LET IDENT COLON UNION VAL
 ##
-## Ends in an error in state: 16.
+## Ends in an error in state: 17.
 ##
-## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
+## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE
+## UNION
+##
+
+Invalid syntax
+
+program: LET IDENT COLON UNION LBRACE VAL
+##
+## Ends in an error in state: 18.
+##
+## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## UNION LBRACE
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 17.
+## Ends in an error in state: 23.
 ##
 ## list(sugared_function_definition(option(code_block))) -> function_definition(located_ident_with_params,option(code_block)) . list(sugared_function_definition(option(code_block))) [ RBRACE IMPL ]
 ##
@@ -234,7 +234,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 19.
+## Ends in an error in state: 25.
 ##
 ## list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) . list(sugared_function_definition(option(code_block))) [ RBRACE IMPL ]
 ##
@@ -244,9 +244,106 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LBRACE RBRACE VAL
 
 Invalid syntax
 
+program: LET IDENT COLON TILDE VAL
+##
+## Ends in an error in state: 27.
+##
+## fexpr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## TILDE
+##
+
+Invalid syntax
+
+program: LET IDENT COLON STRUCT VAL
+##
+## Ends in an error in state: 29.
+##
+## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## STRUCT
+##
+
+Invalid syntax
+
+program: STRUCT LPAREN VAL
+##
+## Ends in an error in state: 30.
+##
+## option(params) -> LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN [ LBRACE ]
+## option(params) -> LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN
+##
+
+Invalid syntax
+
+program: LET IDENT COLON STRUCT LPAREN RPAREN VAL
+##
+## Ends in an error in state: 36.
+##
+## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## STRUCT option(params)
+##
+
+Invalid syntax
+
+program: LET IDENT COLON STRUCT LBRACE UNION
+##
+## Ends in an error in state: 37.
+##
+## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## STRUCT option(params) LBRACE
+##
+
+Invalid syntax
+
+program: STRUCT LBRACE VAL VAL
+##
+## Ends in an error in state: 38.
+##
+## list(struct_field) -> VAL . IDENT COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
+##
+## The known suffix of the stack is as follows:
+## VAL
+##
+
+Invalid syntax
+
+program: STRUCT LBRACE VAL IDENT VAL
+##
+## Ends in an error in state: 39.
+##
+## list(struct_field) -> VAL IDENT . COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
+##
+## The known suffix of the stack is as follows:
+## VAL IDENT
+##
+
+Invalid syntax
+
+program: STRUCT LBRACE VAL IDENT COLON VAL
+##
+## Ends in an error in state: 40.
+##
+## list(struct_field) -> VAL IDENT COLON . expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
+##
+## The known suffix of the stack is as follows:
+## VAL IDENT COLON
+##
+
+Invalid syntax
+
 program: RETURN TILDE VAL
 ##
-## Ends in an error in state: 21.
+## Ends in an error in state: 41.
 ##
 ## expr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> TILDE . IDENT [ LPAREN ]
@@ -259,7 +356,7 @@ Invalid syntax
 
 program: RETURN TILDE IDENT UNION
 ##
-## Ends in an error in state: 22.
+## Ends in an error in state: 42.
 ##
 ## expr -> TILDE IDENT . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> TILDE IDENT . [ LPAREN ]
@@ -272,7 +369,7 @@ Invalid syntax
 
 program: RETURN STRUCT VAL
 ##
-## Ends in an error in state: 23.
+## Ends in an error in state: 43.
 ##
 ## expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -283,22 +380,9 @@ program: RETURN STRUCT VAL
 
 Invalid syntax
 
-program: STRUCT LPAREN VAL
-##
-## Ends in an error in state: 24.
-##
-## option(params) -> LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN [ LBRACE ]
-## option(params) -> LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
-##
-
-Invalid syntax
-
 program: RETURN STRUCT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 30.
+## Ends in an error in state: 44.
 ##
 ## expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -311,7 +395,7 @@ Invalid syntax
 
 program: RETURN STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 31.
+## Ends in an error in state: 45.
 ##
 ## expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -322,45 +406,22 @@ program: RETURN STRUCT LBRACE UNION
 
 Invalid syntax
 
-program: STRUCT LBRACE VAL VAL
+program: RETURN STRUCT LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 32.
+## Ends in an error in state: 49.
 ##
-## list(struct_field) -> VAL . IDENT COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE VAL IDENT VAL
-##
-## Ends in an error in state: 33.
-##
-## list(struct_field) -> VAL IDENT . COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
+## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## VAL IDENT
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE VAL IDENT COLON VAL
-##
-## Ends in an error in state: 34.
-##
-## list(struct_field) -> VAL IDENT COLON . expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL IDENT COLON
+## STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
 ##
 
 Invalid syntax
 
 program: RETURN STRING UNION
 ##
-## Ends in an error in state: 35.
+## Ends in an error in state: 50.
 ##
 ## expr -> STRING . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> STRING . [ LPAREN ]
@@ -373,7 +434,7 @@ Invalid syntax
 
 program: LPAREN VAL
 ##
-## Ends in an error in state: 36.
+## Ends in an error in state: 51.
 ##
 ## fexpr -> LPAREN . struct_constructor RPAREN [ LPAREN ]
 ## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ LPAREN ]
@@ -381,7 +442,7 @@ program: LPAREN VAL
 ## type_expr -> LPAREN . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ## type_expr -> LPAREN . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ## type_expr -> LPAREN . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ## type_expr -> LPAREN . IDENT RPAREN [ LBRACE IDENT EQUALS ]
 ## type_expr -> LPAREN . function_call RPAREN [ LBRACE IDENT EQUALS ]
 ## type_expr -> LPAREN . INT RPAREN [ LBRACE IDENT EQUALS ]
@@ -397,10 +458,10 @@ Invalid syntax
 
 program: LPAREN UNION VAL
 ##
-## Ends in an error in state: 37.
+## Ends in an error in state: 52.
 ##
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
-## type_expr -> LPAREN UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
+## type_expr -> LPAREN UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN UNION
@@ -410,10 +471,10 @@ Invalid syntax
 
 program: LPAREN UNION LBRACE VAL
 ##
-## Ends in an error in state: 38.
+## Ends in an error in state: 53.
 ##
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
-## type_expr -> LPAREN UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
+## type_expr -> LPAREN UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN UNION LBRACE
@@ -421,45 +482,22 @@ program: LPAREN UNION LBRACE VAL
 
 Invalid syntax
 
-program: LPAREN UNION LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 40.
-##
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
-## type_expr -> LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
 program: LPAREN UNION LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 41.
+## Ends in an error in state: 57.
 ##
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
-## type_expr -> LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
+## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
+## type_expr -> LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE
+## LPAREN UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
 ##
 
 Invalid syntax
 
 program: LPAREN TILDE VAL
 ##
-## Ends in an error in state: 43.
+## Ends in an error in state: 59.
 ##
 ## fexpr -> TILDE . IDENT [ LPAREN ]
 ## type_expr -> LPAREN TILDE . IDENT RPAREN [ LBRACE IDENT EQUALS ]
@@ -472,7 +510,7 @@ Invalid syntax
 
 program: LPAREN TILDE IDENT VAL
 ##
-## Ends in an error in state: 44.
+## Ends in an error in state: 60.
 ##
 ## fexpr -> TILDE IDENT . [ LPAREN ]
 ## type_expr -> LPAREN TILDE IDENT . RPAREN [ LBRACE IDENT EQUALS ]
@@ -485,7 +523,7 @@ Invalid syntax
 
 program: LPAREN STRUCT VAL
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 62.
 ##
 ## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -498,7 +536,7 @@ Invalid syntax
 
 program: LPAREN STRUCT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 63.
 ##
 ## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -511,7 +549,7 @@ Invalid syntax
 
 program: LPAREN STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 64.
 ##
 ## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
 ## type_expr -> LPAREN STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -522,152 +560,61 @@ program: LPAREN STRUCT LBRACE UNION
 
 Invalid syntax
 
-program: STRUCT LBRACE IMPL VAL
-##
-## Ends in an error in state: 51.
-##
-## list(impl) -> IMPL . fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL
-##
-
-Invalid syntax
-
-program: LET IDENT COLON UNION VAL
-##
-## Ends in an error in state: 52.
-##
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## UNION
-##
-
-Invalid syntax
-
-program: LET IDENT COLON UNION LBRACE VAL
-##
-## Ends in an error in state: 53.
-##
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE
-##
-
-Invalid syntax
-
-program: LET IDENT COLON UNION LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 55.
-##
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
-program: LET IDENT COLON TILDE VAL
-##
-## Ends in an error in state: 57.
-##
-## fexpr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## TILDE
-##
-
-Invalid syntax
-
-program: LET IDENT COLON STRUCT VAL
-##
-## Ends in an error in state: 59.
-##
-## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT
-##
-
-Invalid syntax
-
-program: LET IDENT COLON STRUCT LPAREN RPAREN VAL
-##
-## Ends in an error in state: 60.
-##
-## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params)
-##
-
-Invalid syntax
-
-program: LET IDENT COLON STRUCT LBRACE UNION
-##
-## Ends in an error in state: 61.
-##
-## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE IMPL LPAREN VAL
-##
-## Ends in an error in state: 67.
-##
-## fexpr -> LPAREN . struct_constructor RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
-##
-
-Invalid syntax
-
-program: LET IDENT COLON INTERFACE VAL
+program: LPAREN STRUCT LBRACE RBRACE VAL
 ##
 ## Ends in an error in state: 68.
 ##
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
+## type_expr -> LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## INTERFACE
+## LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
 ##
 
 Invalid syntax
 
-program: LET IDENT COLON INTERFACE LBRACE VAL
+program: LPAREN STRING VAL
 ##
-## Ends in an error in state: 69.
+## Ends in an error in state: 70.
 ##
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> STRING . [ LPAREN ]
+## type_expr -> LPAREN STRING . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## INTERFACE LBRACE
+## LPAREN STRING
+##
+
+Invalid syntax
+
+program: LPAREN INTERFACE VAL
+##
+## Ends in an error in state: 72.
+##
+## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
+## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN INTERFACE
+##
+
+Invalid syntax
+
+program: LPAREN INTERFACE LBRACE VAL
+##
+## Ends in an error in state: 73.
+##
+## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
+## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN INTERFACE LBRACE
 ##
 
 Invalid syntax
 
 program: INTERFACE LBRACE FN VAL
 ##
-## Ends in an error in state: 70.
+## Ends in an error in state: 74.
 ##
 ## function_definition(located(ident),nothing) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ## function_definition(located(ident),nothing) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
@@ -680,7 +627,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE FN IDENT VAL
 ##
-## Ends in an error in state: 71.
+## Ends in an error in state: 75.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ## function_definition(located(ident),nothing) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
@@ -693,7 +640,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE FN IDENT LPAREN VAL
 ##
-## Ends in an error in state: 72.
+## Ends in an error in state: 76.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
@@ -706,7 +653,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 78.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ##
@@ -718,7 +665,7 @@ Invalid syntax
 
 program: FN LPAREN RPAREN RARROW VAL
 ##
-## Ends in an error in state: 75.
+## Ends in an error in state: 79.
 ##
 ## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ VAL SEMICOLON RPAREN RBRACE LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -728,9 +675,128 @@ program: FN LPAREN RPAREN RARROW VAL
 
 Invalid syntax
 
+program: UNION LBRACE IMPL LPAREN VAL
+##
+## Ends in an error in state: 81.
+##
+## fexpr -> LPAREN . struct_constructor RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN
+##
+
+Invalid syntax
+
+program: LET IDENT COLON INTERFACE VAL
+##
+## Ends in an error in state: 82.
+##
+## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## INTERFACE
+##
+
+Invalid syntax
+
+program: LET IDENT COLON INTERFACE LBRACE VAL
+##
+## Ends in an error in state: 83.
+##
+## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## INTERFACE LBRACE
+##
+
+Invalid syntax
+
+program: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 86.
+##
+## list(located(function_signature_binding)) -> function_definition(located(ident),nothing) . list(located(function_signature_binding)) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located(ident),nothing)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 405, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+
+Invalid syntax
+
+program: LET IDENT COLON IDENT VAL
+##
+## Ends in an error in state: 89.
+##
+## fexpr -> IDENT . [ LPAREN ]
+## type_expr -> IDENT . [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+Invalid syntax
+
+program: LPAREN FN VAL
+##
+## Ends in an error in state: 90.
+##
+## function_definition(nothing,nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## FN
+##
+
+Invalid syntax
+
+program: LPAREN FN LPAREN VAL
+##
+## Ends in an error in state: 91.
+##
+## function_definition(nothing,nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## FN LPAREN
+##
+
+Invalid syntax
+
+program: LPAREN FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+##
+## Ends in an error in state: 93.
+##
+## function_definition(nothing,nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+program: LPAREN FN LPAREN RPAREN VAL
+##
+## Ends in an error in state: 96.
+##
+## function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
 program: LET IDENT COLON ENUM VAL
 ##
-## Ends in an error in state: 78.
+## Ends in an error in state: 98.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
@@ -743,7 +809,7 @@ Invalid syntax
 
 program: LET IDENT COLON ENUM LBRACE VAL
 ##
-## Ends in an error in state: 79.
+## Ends in an error in state: 99.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
@@ -756,7 +822,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT VAL
 ##
-## Ends in an error in state: 80.
+## Ends in an error in state: 100.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN ]
@@ -775,7 +841,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT EQUALS VAL
 ##
-## Ends in an error in state: 81.
+## Ends in an error in state: 101.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -790,7 +856,7 @@ Invalid syntax
 
 program: RETURN INTERFACE VAL
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 102.
 ##
 ## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -803,7 +869,7 @@ Invalid syntax
 
 program: RETURN INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 103.
 ##
 ## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -816,7 +882,7 @@ Invalid syntax
 
 program: RETURN INTERFACE LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 105.
 ##
 ## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
@@ -827,28 +893,9 @@ program: RETURN INTERFACE LBRACE RBRACE UNION
 
 Invalid syntax
 
-program: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 86.
-##
-## list(located(function_signature_binding)) -> function_definition(located(ident),nothing) . list(located(function_signature_binding)) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## function_definition(located(ident),nothing)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 383, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-
-Invalid syntax
-
 program: RETURN INT UNION
 ##
-## Ends in an error in state: 88.
+## Ends in an error in state: 106.
 ##
 ## expr -> INT . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> INT . [ LPAREN ]
@@ -861,7 +908,7 @@ Invalid syntax
 
 program: RETURN IDENT UNION
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 107.
 ##
 ## expr -> IDENT . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> IDENT . [ LPAREN ]
@@ -875,7 +922,7 @@ Invalid syntax
 
 program: RETURN FN VAL
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 108.
 ##
 ## function_definition(nothing,option(code_block)) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## function_definition(nothing,option(code_block)) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -888,7 +935,7 @@ Invalid syntax
 
 program: RETURN FN LPAREN VAL
 ##
-## Ends in an error in state: 91.
+## Ends in an error in state: 109.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -901,7 +948,7 @@ Invalid syntax
 
 program: RETURN FN LPAREN IDENT COLON BOOL COMMA RPAREN UNION
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 111.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -913,7 +960,7 @@ Invalid syntax
 
 program: LBRACE VAL
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 113.
 ##
 ## code_block -> LBRACE . block_stmt RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
 ## code_block -> LBRACE . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
@@ -926,7 +973,7 @@ Invalid syntax
 
 program: TILDE VAL
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 114.
 ##
 ## expr -> TILDE . IDENT [ DOT ]
 ## fexpr -> TILDE . IDENT [ LPAREN ]
@@ -940,7 +987,7 @@ Invalid syntax
 
 program: TILDE IDENT VAL
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 115.
 ##
 ## expr -> TILDE IDENT . [ DOT ]
 ## fexpr -> TILDE IDENT . [ LPAREN ]
@@ -954,7 +1001,7 @@ Invalid syntax
 
 program: SWITCH VAL
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 116.
 ##
 ## switch -> SWITCH . LPAREN expr RPAREN LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -966,7 +1013,7 @@ Invalid syntax
 
 program: SWITCH LPAREN VAL
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 117.
 ##
 ## switch -> SWITCH LPAREN . expr RPAREN LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -978,7 +1025,7 @@ Invalid syntax
 
 program: RETURN ENUM VAL
 ##
-## Ends in an error in state: 100.
+## Ends in an error in state: 118.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -993,7 +1040,7 @@ Invalid syntax
 
 program: RETURN ENUM LBRACE VAL
 ##
-## Ends in an error in state: 101.
+## Ends in an error in state: 119.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1008,7 +1055,7 @@ Invalid syntax
 
 program: RETURN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 122.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -1020,18 +1067,18 @@ program: RETURN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: RETURN ENUM LBRACE IDENT COMMA RBRACE UNION
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 123.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -1044,7 +1091,7 @@ Invalid syntax
 
 program: RETURN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 107.
+## Ends in an error in state: 125.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -1056,18 +1103,18 @@ program: RETURN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: RETURN ENUM LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 126.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -1080,7 +1127,7 @@ Invalid syntax
 
 program: RETURN BOOL UNION
 ##
-## Ends in an error in state: 109.
+## Ends in an error in state: 127.
 ##
 ## expr -> BOOL . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> BOOL . [ LPAREN ]
@@ -1093,7 +1140,7 @@ Invalid syntax
 
 program: LPAREN BOOL RPAREN IDENT
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 128.
 ##
 ## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1106,7 +1153,7 @@ Invalid syntax
 
 program: IDENT LBRACE VAL
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 129.
 ##
 ## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1119,7 +1166,7 @@ Invalid syntax
 
 program: IDENT LBRACE IDENT VAL
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 130.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1134,7 +1181,7 @@ Invalid syntax
 
 program: IDENT LBRACE IDENT COLON VAL
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 131.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1149,7 +1196,7 @@ Invalid syntax
 
 program: RETURN BOOL LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 134.
 ##
 ## expr -> function_call . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -1163,7 +1210,7 @@ Invalid syntax
 
 program: LET IDENT COLON BOOL VAL
 ##
-## Ends in an error in state: 117.
+## Ends in an error in state: 135.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA ]
@@ -1176,7 +1223,7 @@ Invalid syntax
 
 program: BOOL LPAREN VAL
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 136.
 ##
 ## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA ]
 ## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA ]
@@ -1189,7 +1236,7 @@ Invalid syntax
 
 program: BOOL LPAREN BOOL VAL
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 142.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT COMMA ]
@@ -1206,14 +1253,14 @@ program: BOOL LPAREN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: RETURN BOOL DOT VAL
 ##
-## Ends in an error in state: 125.
+## Ends in an error in state: 143.
 ##
 ## expr -> expr DOT . IDENT [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1227,7 +1274,7 @@ Invalid syntax
 
 program: RETURN BOOL DOT IDENT UNION
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 144.
 ##
 ## expr -> expr DOT IDENT . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1241,7 +1288,7 @@ Invalid syntax
 
 program: RETURN BOOL DOT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 145.
 ##
 ## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
@@ -1254,7 +1301,7 @@ Invalid syntax
 
 program: BOOL LPAREN BOOL COMMA VAL
 ##
-## Ends in an error in state: 132.
+## Ends in an error in state: 150.
 ##
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN ]
@@ -1268,7 +1315,7 @@ Invalid syntax
 
 program: IDENT LBRACE IDENT COLON BOOL VAL
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 153.
 ##
 ## expr -> expr . DOT IDENT [ RBRACE DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE DOT COMMA ]
@@ -1285,14 +1332,14 @@ program: IDENT LBRACE IDENT COLON BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: IDENT LBRACE IDENT COLON BOOL COMMA VAL
 ##
-## Ends in an error in state: 136.
+## Ends in an error in state: 154.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1306,7 +1353,7 @@ Invalid syntax
 
 program: SWITCH LPAREN BOOL VAL
 ##
-## Ends in an error in state: 144.
+## Ends in an error in state: 162.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
@@ -1320,14 +1367,14 @@ program: SWITCH LPAREN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN VAL
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 163.
 ##
 ## switch -> SWITCH LPAREN expr RPAREN . LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1339,7 +1386,7 @@ Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 146.
+## Ends in an error in state: 164.
 ##
 ## switch -> SWITCH LPAREN expr RPAREN LBRACE . list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1351,7 +1398,7 @@ Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 165.
 ##
 ## switch_branch -> CASE . type_expr IDENT REARROW code_block [ RBRACE CASE ]
 ##
@@ -1361,22 +1408,9 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
 
 Invalid syntax
 
-program: LET IDENT COLON IDENT VAL
-##
-## Ends in an error in state: 148.
-##
-## fexpr -> IDENT . [ LPAREN ]
-## type_expr -> IDENT . [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-Invalid syntax
-
 program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT LBRACE
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 167.
 ##
 ## switch_branch -> CASE type_expr . IDENT REARROW code_block [ RBRACE CASE ]
 ##
@@ -1387,14 +1421,14 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT LBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 148, spurious reduction of production type_expr -> IDENT
+## In state 89, spurious reduction of production type_expr -> IDENT
 ##
 
 Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT VAL
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 168.
 ##
 ## switch_branch -> CASE type_expr IDENT . REARROW code_block [ RBRACE CASE ]
 ##
@@ -1406,7 +1440,7 @@ Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW VAL
 ##
-## Ends in an error in state: 152.
+## Ends in an error in state: 169.
 ##
 ## switch_branch -> CASE type_expr IDENT REARROW . code_block [ RBRACE CASE ]
 ##
@@ -1418,7 +1452,7 @@ Invalid syntax
 
 program: LET IDENT COLON BOOL LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 171.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> function_call . [ LBRACE IDENT EQUALS ]
@@ -1431,7 +1465,7 @@ Invalid syntax
 
 program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 155.
+## Ends in an error in state: 172.
 ##
 ## list(switch_branch) -> switch_branch . list(switch_branch) [ RBRACE ]
 ##
@@ -1443,7 +1477,7 @@ Invalid syntax
 
 program: STRUCT VAL
 ##
-## Ends in an error in state: 159.
+## Ends in an error in state: 176.
 ##
 ## expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1460,7 +1494,7 @@ Invalid syntax
 
 program: STRUCT IDENT VAL
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 177.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> STRUCT IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -1474,7 +1508,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 161.
+## Ends in an error in state: 178.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -1487,7 +1521,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 163.
+## Ends in an error in state: 180.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1499,7 +1533,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 181.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1511,7 +1545,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 187.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1523,7 +1557,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 188.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1535,7 +1569,7 @@ Invalid syntax
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 176.
+## Ends in an error in state: 193.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1547,7 +1581,7 @@ Invalid syntax
 
 program: STRUCT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 198.
 ##
 ## expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1561,7 +1595,7 @@ Invalid syntax
 
 program: STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 182.
+## Ends in an error in state: 199.
 ##
 ## expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1575,7 +1609,7 @@ Invalid syntax
 
 program: STRUCT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 186.
+## Ends in an error in state: 203.
 ##
 ## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ DOT ]
 ## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
@@ -1589,7 +1623,7 @@ Invalid syntax
 
 program: STRING VAL
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 204.
 ##
 ## expr -> STRING . [ DOT ]
 ## fexpr -> STRING . [ LPAREN ]
@@ -1603,7 +1637,7 @@ Invalid syntax
 
 program: RETURN VAL
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 205.
 ##
 ## semicolon_stmt -> RETURN . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1615,7 +1649,7 @@ Invalid syntax
 
 program: RETURN BOOL VAL
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 206.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1629,14 +1663,14 @@ program: RETURN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: LET VAL
 ##
-## Ends in an error in state: 191.
+## Ends in an error in state: 208.
 ##
 ## semicolon_stmt -> LET . IDENT option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1652,7 +1686,7 @@ Invalid syntax
 
 program: LET LBRACE VAL
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 209.
 ##
 ## semicolon_stmt -> LET LBRACE . nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET LBRACE . loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1665,7 +1699,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT VAL
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 210.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . AS IDENT COMMA [ RBRACE DOUBLEDOT ]
@@ -1684,7 +1718,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 211.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1698,7 +1732,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS VAL
 ##
-## Ends in an error in state: 197.
+## Ends in an error in state: 214.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1713,7 +1747,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS IDENT VAL
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 215.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1728,7 +1762,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS IDENT COMMA VAL
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 216.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1742,7 +1776,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA DOUBLEDOT VAL
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 222.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1754,7 +1788,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 223.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1766,7 +1800,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 224.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1778,7 +1812,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 225.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1792,14 +1826,14 @@ program: LET LBRACE IDENT COMMA RBRACE EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: LET LBRACE DOUBLEDOT VAL
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 227.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1811,7 +1845,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 228.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1823,7 +1857,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 229.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1835,7 +1869,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 230.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1849,14 +1883,14 @@ program: LET LBRACE RBRACE EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: LET IDENT VAL
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 231.
 ##
 ## semicolon_stmt -> LET IDENT . option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1870,7 +1904,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN VAL
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 232.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1883,7 +1917,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 234.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1895,7 +1929,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 235.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1907,7 +1941,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 236.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1921,14 +1955,14 @@ program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: LET IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 221.
+## Ends in an error in state: 238.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1940,7 +1974,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 239.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1952,7 +1986,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 240.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1966,14 +2000,14 @@ program: LET IDENT LPAREN RPAREN EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: LET IDENT COLON VAL
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 241.
 ##
 ## option(__anonymous_0) -> COLON . type_expr [ EQUALS ]
 ##
@@ -1985,7 +2019,7 @@ Invalid syntax
 
 program: LET IDENT COLON IDENT LBRACE
 ##
-## Ends in an error in state: 226.
+## Ends in an error in state: 243.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1996,15 +2030,15 @@ program: LET IDENT COLON IDENT LBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 148, spurious reduction of production type_expr -> IDENT
-## In state 225, spurious reduction of production option(__anonymous_0) -> COLON type_expr
+## In state 89, spurious reduction of production type_expr -> IDENT
+## In state 242, spurious reduction of production option(__anonymous_0) -> COLON type_expr
 ##
 
 Invalid syntax
 
 program: LET IDENT EQUALS VAL
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 244.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2016,7 +2050,7 @@ Invalid syntax
 
 program: LET IDENT EQUALS BOOL VAL
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 245.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2030,14 +2064,14 @@ program: LET IDENT EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: INTERFACE VAL
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 246.
 ##
 ## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -2054,7 +2088,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 247.
 ##
 ## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -2068,7 +2102,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 249.
 ##
 ## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ DOT ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
@@ -2082,7 +2116,7 @@ Invalid syntax
 
 program: INTERFACE IDENT VAL
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 250.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2096,7 +2130,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 251.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2109,7 +2143,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 253.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2121,7 +2155,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 254.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2133,7 +2167,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 258.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2145,7 +2179,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 242.
+## Ends in an error in state: 259.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2157,7 +2191,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LBRACE VAL
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 262.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2169,7 +2203,7 @@ Invalid syntax
 
 program: INT VAL
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 265.
 ##
 ## expr -> INT . [ DOT ]
 ## fexpr -> INT . [ LPAREN ]
@@ -2183,7 +2217,7 @@ Invalid syntax
 
 program: IF VAL
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 266.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2195,7 +2229,7 @@ Invalid syntax
 
 program: IF LPAREN VAL
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 267.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2207,7 +2241,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL VAL
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 268.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
@@ -2221,14 +2255,14 @@ program: IF LPAREN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: IF LPAREN BOOL RPAREN VAL
 ##
-## Ends in an error in state: 252.
+## Ends in an error in state: 269.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2240,7 +2274,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 270.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2252,7 +2286,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL RPAREN LBRACE RBRACE ELSE VAL
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 271.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## else_ -> ELSE . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2265,7 +2299,7 @@ Invalid syntax
 
 program: IDENT VAL
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 276.
 ##
 ## expr -> IDENT . [ DOT ]
 ## fexpr -> IDENT . [ LPAREN ]
@@ -2280,7 +2314,7 @@ Invalid syntax
 
 program: FN VAL
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 277.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2301,7 +2335,7 @@ Invalid syntax
 
 program: FN LPAREN VAL
 ##
-## Ends in an error in state: 261.
+## Ends in an error in state: 278.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
@@ -2316,7 +2350,7 @@ Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 263.
+## Ends in an error in state: 280.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -2327,9 +2361,9 @@ program: FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 
 Invalid syntax
 
-program: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 264.
+## Ends in an error in state: 281.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -2341,14 +2375,14 @@ program: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 283.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -2361,7 +2395,7 @@ Invalid syntax
 
 program: FN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 285.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -2372,9 +2406,9 @@ program: FN LPAREN RPAREN VAL
 
 Invalid syntax
 
-program: FN LPAREN RPAREN RARROW BOOL VAL
+program: FN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 286.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -2386,14 +2420,14 @@ program: FN LPAREN RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN LPAREN RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 288.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -2406,7 +2440,7 @@ Invalid syntax
 
 program: FN IDENT VAL
 ##
-## Ends in an error in state: 272.
+## Ends in an error in state: 289.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2423,7 +2457,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN VAL
 ##
-## Ends in an error in state: 273.
+## Ends in an error in state: 290.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2440,7 +2474,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 292.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2454,7 +2488,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 293.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2467,7 +2501,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 295.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2477,9 +2511,9 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL C
 
 Invalid syntax
 
-program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 296.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2490,14 +2524,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL C
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 282.
+## Ends in an error in state: 299.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2507,9 +2541,9 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN VAL
 
 Invalid syntax
 
-program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 300.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2520,14 +2554,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW BOOL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 302.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2538,14 +2572,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 305.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2559,7 +2593,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 306.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2572,7 +2606,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 291.
+## Ends in an error in state: 308.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2582,9 +2616,9 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 
 Invalid syntax
 
-program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 309.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2595,14 +2629,14 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 312.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2612,9 +2646,9 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 
 Invalid syntax
 
-program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 313.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2625,14 +2659,14 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-program: FN IDENT LPAREN RPAREN RARROW BOOL VAL
+program: FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 315.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2643,14 +2677,14 @@ program: FN IDENT LPAREN RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM VAL
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 317.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2673,7 +2707,7 @@ Invalid syntax
 
 program: ENUM LBRACE VAL
 ##
-## Ends in an error in state: 301.
+## Ends in an error in state: 318.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2690,7 +2724,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 303.
+## Ends in an error in state: 320.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ DOT ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -2703,18 +2737,18 @@ program: ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 321.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2728,7 +2762,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 323.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ DOT ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -2741,18 +2775,18 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 307.
+## Ends in an error in state: 324.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2766,7 +2800,7 @@ Invalid syntax
 
 program: ENUM IDENT VAL
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 325.
 ##
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2783,7 +2817,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN VAL
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 326.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2798,7 +2832,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 311.
+## Ends in an error in state: 328.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2811,7 +2845,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 329.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2824,7 +2858,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 314.
+## Ends in an error in state: 331.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2835,18 +2869,18 @@ program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE IDENT COMMA FN I
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 334.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2857,18 +2891,18 @@ program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE FN IDENT LPAREN 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 337.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2881,7 +2915,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 338.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2894,7 +2928,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 340.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2905,18 +2939,18 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 343.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2927,18 +2961,18 @@ program: ENUM IDENT LPAREN RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM IDENT LBRACE VAL
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 345.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2951,7 +2985,7 @@ Invalid syntax
 
 program: ENUM IDENT LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 347.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2962,18 +2996,18 @@ program: ENUM IDENT LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 333.
+## Ends in an error in state: 350.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2984,18 +3018,18 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: BOOL VAL
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 352.
 ##
 ## expr -> BOOL . [ DOT ]
 ## fexpr -> BOOL . [ LPAREN ]
@@ -3009,7 +3043,7 @@ Invalid syntax
 
 program: IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 354.
 ##
 ## expr -> struct_constructor . [ DOT ]
 ## stmt_expr -> struct_constructor . [ SEMICOLON RBRACE EOF ]
@@ -3022,7 +3056,7 @@ Invalid syntax
 
 program: BOOL SEMICOLON VAL
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 358.
 ##
 ## block_stmt -> semicolon_stmt SEMICOLON . block_stmt [ RBRACE EOF ]
 ## block_stmt -> semicolon_stmt SEMICOLON . [ RBRACE EOF ]
@@ -3035,7 +3069,7 @@ Invalid syntax
 
 program: LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 359.
 ##
 ## block_stmt -> non_semicolon_stmt . block_stmt [ RBRACE EOF ]
 ## stmt -> non_semicolon_stmt . [ RBRACE EOF ]
@@ -3048,7 +3082,7 @@ Invalid syntax
 
 program: BOOL LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 364.
 ##
 ## expr -> function_call . [ DOT ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -3063,7 +3097,7 @@ Invalid syntax
 
 program: BOOL DOT VAL
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 366.
 ##
 ## expr -> expr DOT . IDENT [ DOT ]
 ## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3080,7 +3114,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT VAL
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 367.
 ##
 ## expr -> expr DOT IDENT . [ DOT ]
 ## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3097,7 +3131,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 368.
 ##
 ## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
 ## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
@@ -3112,7 +3146,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 370.
 ##
 ## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3125,7 +3159,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 372.
 ##
 ## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3138,7 +3172,7 @@ Invalid syntax
 
 program: LBRACE BOOL EOF
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 376.
 ##
 ## code_block -> LBRACE block_stmt . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
 ##
@@ -3149,17 +3183,17 @@ program: LBRACE BOOL EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production stmt_expr -> BOOL
-## In state 338, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 340, spurious reduction of production stmt -> semicolon_stmt
-## In state 339, spurious reduction of production block_stmt -> stmt
+## In state 352, spurious reduction of production stmt_expr -> BOOL
+## In state 355, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 357, spurious reduction of production stmt -> semicolon_stmt
+## In state 356, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax
 
 program: RETURN FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 380.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3171,7 +3205,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT EQUALS BOOL VAL
 ##
-## Ends in an error in state: 365.
+## Ends in an error in state: 382.
 ##
 ## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN DOT COMMA ]
@@ -3188,14 +3222,14 @@ program: ENUM LBRACE IDENT EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE IDENT EQUALS BOOL COMMA VAL
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 383.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -3209,7 +3243,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 386.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -3223,7 +3257,7 @@ Invalid syntax
 
 program: LET IDENT COLON ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 373.
+## Ends in an error in state: 390.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3234,18 +3268,18 @@ program: LET IDENT COLON ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: LET IDENT COLON ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 393.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3256,18 +3290,49 @@ program: LET IDENT COLON ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
-program: FN LPAREN RPAREN RARROW BOOL UNION
+program: LPAREN IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 395.
+##
+## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN struct_constructor
+##
+
+Invalid syntax
+
+program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 397.
+##
+## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN function_definition(nothing,nothing)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 97, spurious reduction of production function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+
+Invalid syntax
+
+program: FN LPAREN RPAREN RARROW IDENT UNION
+##
+## Ends in an error in state: 401.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
@@ -3281,7 +3346,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 404.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ##
@@ -3291,202 +3356,9 @@ program: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 
 Invalid syntax
 
-program: LPAREN FN VAL
-##
-## Ends in an error in state: 386.
-##
-## function_definition(nothing,nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-## function_definition(nothing,nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-##
-## The known suffix of the stack is as follows:
-## FN
-##
-
-Invalid syntax
-
-program: LPAREN FN LPAREN VAL
-##
-## Ends in an error in state: 387.
-##
-## function_definition(nothing,nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-## function_definition(nothing,nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN
-##
-
-Invalid syntax
-
-program: LPAREN FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 389.
-##
-## function_definition(nothing,nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-program: LPAREN FN LPAREN RPAREN VAL
-##
-## Ends in an error in state: 392.
-##
-## function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-program: LPAREN IDENT LBRACE RBRACE VAL
-##
-## Ends in an error in state: 394.
-##
-## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN struct_constructor
-##
-
-Invalid syntax
-
-program: LPAREN FN LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 396.
-##
-## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN function_definition(nothing,nothing)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 393, spurious reduction of production function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE IMPL BOOL VAL
-##
-## Ends in an error in state: 398.
-##
-## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ LPAREN LBRACE ]
-## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ LPAREN LBRACE ]
-## list(impl) -> IMPL fexpr . LBRACE list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE IMPL BOOL LBRACE VAL
-##
-## Ends in an error in state: 399.
-##
-## list(impl) -> IMPL fexpr LBRACE . list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE IMPL BOOL LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 400.
-##
-## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) . RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
-program: STRUCT LBRACE IMPL BOOL LBRACE RBRACE VAL
-##
-## Ends in an error in state: 401.
-##
-## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE . list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE
-##
-
-Invalid syntax
-
-program: LPAREN STRUCT LBRACE RBRACE VAL
-##
-## Ends in an error in state: 404.
-##
-## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
-## type_expr -> LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
-##
-
-Invalid syntax
-
-program: LPAREN STRING VAL
-##
-## Ends in an error in state: 406.
-##
-## fexpr -> STRING . [ LPAREN ]
-## type_expr -> LPAREN STRING . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRING
-##
-
-Invalid syntax
-
-program: LPAREN INTERFACE VAL
-##
-## Ends in an error in state: 408.
-##
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
-## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INTERFACE
-##
-
-Invalid syntax
-
-program: LPAREN INTERFACE LBRACE VAL
-##
-## Ends in an error in state: 409.
-##
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
-## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INTERFACE LBRACE
-##
-
-Invalid syntax
-
 program: LPAREN INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 407.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3499,7 +3371,7 @@ Invalid syntax
 
 program: LPAREN INT VAL
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 409.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3512,7 +3384,7 @@ Invalid syntax
 
 program: LPAREN IDENT VAL
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 411.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
 ## type_expr -> LPAREN IDENT . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3526,7 +3398,7 @@ Invalid syntax
 
 program: LPAREN ENUM VAL
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 413.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -3541,7 +3413,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE VAL
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 414.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -3556,7 +3428,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 416.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -3568,18 +3440,18 @@ program: LPAREN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 417.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3592,7 +3464,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 424.
+## Ends in an error in state: 420.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -3604,18 +3476,18 @@ program: LPAREN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: LPAREN ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 421.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3628,7 +3500,7 @@ Invalid syntax
 
 program: LPAREN BOOL VAL
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 423.
 ##
 ## fexpr -> BOOL . [ LPAREN ]
 ## type_expr -> LPAREN BOOL . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3641,7 +3513,7 @@ Invalid syntax
 
 program: LPAREN BOOL LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 425.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3655,7 +3527,7 @@ Invalid syntax
 
 program: STRUCT LBRACE VAL IDENT COLON BOOL RPAREN
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 427.
 ##
 ## expr -> expr . DOT IDENT [ VAL SEMICOLON RBRACE IMPL FN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT ]
@@ -3669,14 +3541,14 @@ program: STRUCT LBRACE VAL IDENT COLON BOOL RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: STRUCT LBRACE VAL IDENT COLON BOOL SEMICOLON UNION
 ##
-## Ends in an error in state: 433.
+## Ends in an error in state: 429.
 ##
 ## list(struct_field) -> VAL IDENT COLON expr option(SEMICOLON) . list(struct_field) [ RBRACE IMPL FN ]
 ##
@@ -3686,22 +3558,82 @@ program: STRUCT LBRACE VAL IDENT COLON BOOL SEMICOLON UNION
 
 Invalid syntax
 
-program: RETURN STRUCT LBRACE RBRACE UNION
+program: UNION LBRACE IMPL IDENT VAL
+##
+## Ends in an error in state: 435.
+##
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ LPAREN LBRACE ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ LPAREN LBRACE ]
+## list(impl) -> IMPL fexpr . LBRACE list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IMPL fexpr
+##
+
+Invalid syntax
+
+program: UNION LBRACE IMPL IDENT LBRACE VAL
+##
+## Ends in an error in state: 436.
+##
+## list(impl) -> IMPL fexpr LBRACE . list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IMPL fexpr LBRACE
+##
+
+Invalid syntax
+
+program: UNION LBRACE IMPL IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
+##
+## Ends in an error in state: 437.
+##
+## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) . RBRACE list(impl) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IMPL fexpr LBRACE list(sugared_function_definition(option(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+##
+
+Invalid syntax
+
+program: UNION LBRACE IMPL IDENT LBRACE RBRACE VAL
 ##
 ## Ends in an error in state: 438.
 ##
-## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
-## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
+## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE . list(impl) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
+## IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE
+##
+
+Invalid syntax
+
+program: RETURN UNION LBRACE RBRACE UNION
+##
+## Ends in an error in state: 441.
+##
+## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
+## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
+##
+## The known suffix of the stack is as follows:
+## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
 ##
 
 Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL VAL
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 442.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT COMMA ]
@@ -3718,14 +3650,14 @@ program: FN LPAREN IDENT COLON BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 109, spurious reduction of production expr -> BOOL
+## In state 127, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA VAL
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 443.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -3739,7 +3671,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 447.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3753,7 +3685,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 445.
+## Ends in an error in state: 448.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3766,7 +3698,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 450.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3776,9 +3708,9 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT 
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 451.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3789,14 +3721,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 454.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3806,9 +3738,9 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 455.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3819,14 +3751,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 457.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3837,14 +3769,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL V
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 460.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3858,7 +3790,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 461.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3871,7 +3803,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 463.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3881,9 +3813,9 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 464.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3894,14 +3826,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 467.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3911,9 +3843,9 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 468.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3924,14 +3856,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW BOOL VAL
+program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 470.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3942,38 +3874,16 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 379, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-program: UNION LBRACE CASE UNION LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 469.
-##
-## union_member -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE FN CASE ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: UNION LBRACE CASE STRUCT VAL
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 475.
 ##
-## union_member -> STRUCT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE FN CASE ]
+## union_member -> STRUCT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## STRUCT
@@ -3983,9 +3893,9 @@ Invalid syntax
 
 program: UNION LBRACE CASE STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 472.
+## Ends in an error in state: 476.
 ##
-## union_member -> STRUCT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE FN CASE ]
+## union_member -> STRUCT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## STRUCT LBRACE
@@ -3995,9 +3905,9 @@ Invalid syntax
 
 program: UNION LBRACE CASE INTERFACE VAL
 ##
-## Ends in an error in state: 477.
+## Ends in an error in state: 481.
 ##
-## union_member -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ RBRACE FN CASE ]
+## union_member -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## INTERFACE
@@ -4007,9 +3917,9 @@ Invalid syntax
 
 program: UNION LBRACE CASE INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 478.
+## Ends in an error in state: 482.
 ##
-## union_member -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ RBRACE FN CASE ]
+## union_member -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## INTERFACE LBRACE
@@ -4019,11 +3929,11 @@ Invalid syntax
 
 program: UNION LBRACE CASE IDENT VAL
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 485.
 ##
-## union_member -> IDENT . [ RBRACE FN CASE ]
-## union_member -> IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN CASE ]
-## union_member -> IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN CASE ]
+## union_member -> IDENT . [ RBRACE IMPL FN CASE ]
+## union_member -> IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN CASE ]
+## union_member -> IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENT
@@ -4033,10 +3943,10 @@ Invalid syntax
 
 program: UNION LBRACE CASE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 486.
 ##
-## union_member -> IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN CASE ]
-## union_member -> IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN CASE ]
+## union_member -> IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN CASE ]
+## union_member -> IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## IDENT LPAREN
@@ -4046,10 +3956,10 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM VAL
 ##
-## Ends in an error in state: 487.
+## Ends in an error in state: 491.
 ##
-## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
-## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
+## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
+## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM
@@ -4059,10 +3969,10 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE VAL
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 492.
 ##
-## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
-## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE FN CASE ]
+## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
+## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM LBRACE
@@ -4072,9 +3982,9 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 494.
 ##
-## union_member -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE FN CASE ]
+## union_member -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block)))
@@ -4083,20 +3993,20 @@ program: UNION LBRACE CASE ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 497.
 ##
-## union_member -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE FN CASE ]
+## union_member -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE IMPL FN CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block)))
@@ -4105,20 +4015,20 @@ program: UNION LBRACE CASE ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
+## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 470, spurious reduction of production option(code_block) ->
+## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
+## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
 
 Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 499.
 ##
-## list(preceded(CASE,located(union_member))) -> CASE union_member . list(preceded(CASE,located(union_member))) [ RBRACE FN ]
+## list(preceded(CASE,located(union_member))) -> CASE union_member . list(preceded(CASE,located(union_member))) [ RBRACE IMPL FN ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE union_member
@@ -4126,51 +4036,27 @@ program: UNION LBRACE CASE ENUM LBRACE RBRACE VAL
 
 Invalid syntax
 
-program: UNION LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 498.
-##
-## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ DOT ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
-## stmt_expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
 program: UNION LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 504.
 ##
-## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
-## stmt_expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE . [ SEMICOLON RBRACE EOF ]
+## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ DOT ]
+## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
+## stmt_expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ SEMICOLON RBRACE EOF ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE
+## UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE
 ##
 
 Invalid syntax
 
 program: UNION IDENT VAL
 ##
-## Ends in an error in state: 500.
+## Ends in an error in state: 505.
 ##
-## non_semicolon_stmt -> UNION IDENT . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT
@@ -4180,10 +4066,10 @@ Invalid syntax
 
 program: UNION IDENT LPAREN VAL
 ##
-## Ends in an error in state: 501.
+## Ends in an error in state: 506.
 ##
-## non_semicolon_stmt -> UNION IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LPAREN
@@ -4193,9 +4079,9 @@ Invalid syntax
 
 program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 508.
 ##
-## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
@@ -4205,9 +4091,9 @@ Invalid syntax
 
 program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 509.
 ##
-## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE
@@ -4215,33 +4101,11 @@ program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 
 Invalid syntax
 
-program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 506.
-##
-## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
 program: UNION IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 509.
+## Ends in an error in state: 515.
 ##
-## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
@@ -4251,9 +4115,9 @@ Invalid syntax
 
 program: UNION IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 516.
 ##
-## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE
@@ -4261,33 +4125,11 @@ program: UNION IDENT LPAREN RPAREN LBRACE VAL
 
 Invalid syntax
 
-program: UNION IDENT LPAREN RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 512.
-##
-## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
 program: UNION IDENT LBRACE VAL
 ##
-## Ends in an error in state: 514.
+## Ends in an error in state: 521.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## non_semicolon_stmt -> UNION IDENT LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## UNION IDENT LBRACE
@@ -4295,31 +4137,9 @@ program: UNION IDENT LBRACE VAL
 
 Invalid syntax
 
-program: UNION IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 516.
-##
-## non_semicolon_stmt -> UNION IDENT LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 457, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 467, spurious reduction of production option(code_block) ->
-## In state 468, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
-## In state 19, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
-## In state 20, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
-##
-
-Invalid syntax
-
 program: BOOL RBRACE
 ##
-## Ends in an error in state: 520.
+## Ends in an error in state: 528.
 ##
 ## program -> block_stmt . EOF [ # ]
 ##
@@ -4330,10 +4150,10 @@ program: BOOL RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 335, spurious reduction of production stmt_expr -> BOOL
-## In state 338, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 340, spurious reduction of production stmt -> semicolon_stmt
-## In state 339, spurious reduction of production block_stmt -> stmt
+## In state 352, spurious reduction of production stmt_expr -> BOOL
+## In state 355, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 357, spurious reduction of production stmt -> semicolon_stmt
+## In state 356, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -369,6 +369,46 @@ union CommonMsgInfoRelaxed {
   }
 }
 
+struct MessageRelaxed(X: Serialize) {
+  val info: CommonMsgInfoRelaxed
+  val body: X
+
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      let b = self.info.serialize(b);
+      let b = b.serialize_int(0, 1); // init
+      let b = b.serialize_int(0, 1); // body discriminant
+      let b = self.body.serialize(b);
+      return b;
+    }
+  }
+}
+
+struct Message(X: Deserialize) {
+  val info: CommonMsgInfo
+  val body: X
+
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_info = CommonMsgInfo.deserialize(s);
+      let res_init = res_info.slice.load_int(1);
+
+      if (builtin_equal(res_init.value, 0)) {
+        let res_body_discr = res_init.slice.load_int(1);
+        if (builtin_equal(res_body_discr.value, 0)) {
+          let body = X.deserialize(res_body_discr.slice);
+          let mes = Self { info: res_info.value, body: body.value };
+          return LoadResultBase(Slice, Self).new(body.slice, mes);
+        } else {
+          /* TODO: cells */
+        }
+      } else {
+        /* TODO: can be init state != 0? */
+      }
+    }
+  }
+}
+
 fn send_raw_msg(msg: Cell, flags: SendRawMsgFlags) -> VoidType {
   builtin_send_raw_msg(msg.c, flags.value);
 }

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -47,6 +47,14 @@ struct Slice {
   }
 }
 
+interface Serialize {
+  fn serialize(self: Self, builder: Builder) -> Builder
+}
+
+interface Deserialize {
+  fn deserialize(slice: Slice) -> LoadResultBase(Slice, Self)
+}
+
 struct Int(bits: Integer) {
   val value: Integer
 
@@ -54,16 +62,20 @@ struct Int(bits: Integer) {
     Self { value: i }
   }
 
-  fn serialize(self: Self, builder: Builder) -> Builder {
-    builder.serialize_int(self.value, bits)
+  impl Serialize {
+    fn serialize(self: Self, builder: Builder) -> Builder {
+      builder.serialize_int(self.value, bits)
+    } 
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res = s.load_int(bits);
-    
-    LoadResultBase(Slice, Self) { 
-      slice: res.slice, 
-      value: Self { value: res.value }
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res = s.load_int(bits);
+      
+      LoadResultBase(Slice, Self) { 
+        slice: res.slice, 
+        value: Self { value: res.value }
+      }
     }
   }
 
@@ -99,23 +111,27 @@ struct AddrExtern {
   val len: Int(9)
   val bits: Integer
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    let b = self.len.serialize(b);
-    let b = b.serialize_int(self.bits, self.len.value);
-    return b;
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      let b = self.len.serialize(b);
+      let b = b.serialize_int(self.bits, self.len.value);
+      return b;
+    }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_len = Int(9).deserialize(s);
-    let res_bits = res_len.slice.load_int(res_len.value);
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_len = Int(9).deserialize(s);
+      let res_bits = res_len.slice.load_int(res_len.value);
 
-    LoadResultBase(Slice, Self) { 
-      slice: res_bits.slice, 
-      value: Self { 
-        len: res_len.value,
-        bits: res_bits.value,
+      LoadResultBase(Slice, Self) { 
+        slice: res_bits.slice, 
+        value: Self { 
+          len: res_len.value,
+          bits: res_bits.value,
+        }
       }
-    }
+    } 
   }
 }
 
@@ -123,27 +139,31 @@ union MsgAddressExt {
   case AddrNone
   case AddrExtern
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    switch(self) {
-      case AddrNone a => {
-        return b.serialize_int(0, 1);
-      }
-      case AddrExtern addr => {
-        let b = b.serialize_int(1, 1);
-        return addr.serialize(b);
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      switch(self) {
+        case AddrNone a => {
+          return b.serialize_int(0, 1);
+        }
+        case AddrExtern addr => {
+          let b = b.serialize_int(1, 1);
+          return addr.serialize(b);
+        }
       }
     }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_discr = s.load_int(1);
-    if (builtin_equal(res_discr.value, 0)) {
-      return LoadResultBase(Slice, Self).new(res_discr.slice, AddrNone{});
-    } else if (builtin_equal(res_discr.value, 1)) {
-      let res_addr = AddrExtern.deserialize(res_discr.slice);
-      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
-    } else {
-      /* TODO: throw an exception */
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_discr = s.load_int(1);
+      if (builtin_equal(res_discr.value, 0)) {
+        return LoadResultBase(Slice, Self).new(res_discr.slice, AddrNone{});
+      } else if (builtin_equal(res_discr.value, 1)) {
+        let res_addr = AddrExtern.deserialize(res_discr.slice);
+        return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+      } else {
+        /* TODO: throw an exception */
+      }
     }
   }
 }
@@ -152,23 +172,27 @@ struct AddressStd {
   val workchain_id: Int(8)
   val address: Int(256)
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    let b = b.serialize_int(0, 0); // AnyCast
-    serializer(Self)(self, b)
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      let b = b.serialize_int(0, 0); // AnyCast
+      serializer(Self)(self, b)
+    }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_anycast = s.load_int(1);
-    if (builtin_equal(res_anycast.value, 0)) {
-      let res_workchain = Int(8).deserialize(res_anycast.slice);
-      let res_address = Int(256).deserialize(res_workchain.slice);
-      return LoadResultBase(Slice, Self)
-        .new(res_address.slice, Self {
-          workchain_id: res_workchain.value,
-          address: res_address.value,
-        });
-    } else {
-      /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_anycast = s.load_int(1);
+      if (builtin_equal(res_anycast.value, 0)) {
+        let res_workchain = Int(8).deserialize(res_anycast.slice);
+        let res_address = Int(256).deserialize(res_workchain.slice);
+        return LoadResultBase(Slice, Self)
+          .new(res_address.slice, Self {
+            workchain_id: res_workchain.value,
+            address: res_address.value,
+          });
+      } else {
+        /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+      }
     }
   }
 }
@@ -178,28 +202,32 @@ struct AddressVar {
   val workchain_id: Int(8)
   val address: Integer
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    let b = b.serialize_int(0, 0); // AnyCast
-    let b = self.len.serialize(b);
-    let b = self.workchain_id.serialize(b);
-    let b = b.serialize_int(self.address, self.len.value);
-    return b;
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      let b = b.serialize_int(0, 0); // AnyCast
+      let b = self.len.serialize(b);
+      let b = self.workchain_id.serialize(b);
+      let b = b.serialize_int(self.address, self.len.value);
+      return b;
+    }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_anycast = s.load_int(1);
-    if (builtin_equal(res_anycast.value, 0)) {
-      let res_len = Int(9).deserialize(res_anycast.slice);
-      let res_workchain = Int(8).deserialize(res_len.slice);
-      let res_address = res_workchain.slice.load_int(res_len);
-      return LoadResultBase(Slice, Self)
-        .new(res_address.slice, Self {
-          len: res_len.value,
-          workchain_id: res_workchain.value,
-          address: res_address.value,
-        });
-    } else {
-      /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_anycast = s.load_int(1);
+      if (builtin_equal(res_anycast.value, 0)) {
+        let res_len = Int(9).deserialize(res_anycast.slice);
+        let res_workchain = Int(8).deserialize(res_len.slice);
+        let res_address = res_workchain.slice.load_int(res_len);
+        return LoadResultBase(Slice, Self)
+          .new(res_address.slice, Self {
+            len: res_len.value,
+            workchain_id: res_workchain.value,
+            address: res_address.value,
+          });
+      } else {
+        /* TODO: Anycast is unsupported by TON for now, what we should do here? */
+      }
     }
   }
 }
@@ -208,27 +236,31 @@ union MsgAddressInt {
   case AddressStd
   case AddressVar
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    switch(self) {
-      case AddressStd addr => {
-        let b = b.serialize_int(0, 1);
-        return addr.serialize(b);
-      }
-      case AddressVar addr => {
-        let b = b.serialize_int(1, 1);
-        return addr.serialize(b);
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      switch(self) {
+        case AddressStd addr => {
+          let b = b.serialize_int(0, 1);
+          return addr.serialize(b);
+        }
+        case AddressVar addr => {
+          let b = b.serialize_int(1, 1);
+          return addr.serialize(b);
+        }
       }
     }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_discr = s.load_int(1);
-    if (builtin_equal(res_discr.value, 0)) {
-      let res_addr = AddressStd.deserialize(res_discr.value);
-      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
-    } else {
-      let res_addr = AddressVar.deserialize(res_discr.slice);
-      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_discr = s.load_int(1);
+      if (builtin_equal(res_discr.value, 0)) {
+        let res_addr = AddressStd.deserialize(res_discr.value);
+        return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+      } else {
+        let res_addr = AddressVar.deserialize(res_discr.slice);
+        return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+      }
     }
   }
 }
@@ -237,27 +269,31 @@ union MsgAddress {
   case MsgAddressExt
   case MsgAddressInt
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    switch(self) {
-      case MsgAddressExt addr_ext => {
-        let b = b.serialize_int(0, 1);
-        return addr_ext.serialize(b);
-      }
-      case MsgAddressInt addr_int => {
-        let b = b.serialize_int(1, 1);
-        return addr_int.serialize(b);
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      switch(self) {
+        case MsgAddressExt addr_ext => {
+          let b = b.serialize_int(0, 1);
+          return addr_ext.serialize(b);
+        }
+        case MsgAddressInt addr_int => {
+          let b = b.serialize_int(1, 1);
+          return addr_int.serialize(b);
+        }
       }
     }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_discr = s.load_int(1);
-    if (builtin_equal(res_discr.value, 0)) {
-      let res_addr = MsgAddressExt.deserialize(res_discr.value);
-      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
-    } else {
-      let res_addr = MsgAddressInt.deserialize(res_discr.slice);
-      return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_discr = s.load_int(1);
+      if (builtin_equal(res_discr.value, 0)) {
+        let res_addr = MsgAddressExt.deserialize(res_discr.value);
+        return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+      } else {
+        let res_addr = MsgAddressInt.deserialize(res_discr.slice);
+        return LoadResultBase(Slice, Self).new(res_addr.slice, res_addr.value);
+      }
     }
   }
 }
@@ -268,26 +304,30 @@ struct ExtOutMsgInfo {
   val created_lt: Int(64) // TODO: uint
   val created_at: Int(32) // TODO: uint
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    let b = self.src.serialize(b);
-    let b = self.dest.serialize(b);
-    let b = self.created_lt.serialize(b);
-    let b = self.created_at.serialize(b);
-    return b;
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      let b = self.src.serialize(b);
+      let b = self.dest.serialize(b);
+      let b = self.created_lt.serialize(b);
+      let b = self.created_at.serialize(b);
+      return b;
+    }
   }
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_src = MsgAddress.deserialize(s);
-    let res_dest = MsgAddressExt.deserialize(res_src.slice);
-    let res_created_lt = Int(64).deserialize(res_dest.slice);
-    let res_created_at = Int(64).deserialize(res_created_lt.slice);
-    return LoadResultBase(Slice, Self)
-      .new(res_created_at.slice, Self {
-        src: res_src.value,
-        dest: res_dest.value,
-        created_lt: res_created_lt.value,
-        created_at: res_created_at.value,
-      });
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_src = MsgAddress.deserialize(s);
+      let res_dest = MsgAddressExt.deserialize(res_src.slice);
+      let res_created_lt = Int(64).deserialize(res_dest.slice);
+      let res_created_at = Int(64).deserialize(res_created_lt.slice);
+      return LoadResultBase(Slice, Self)
+        .new(res_created_at.slice, Self {
+          src: res_src.value,
+          dest: res_dest.value,
+          created_lt: res_created_lt.value,
+          created_at: res_created_at.value,
+        });
+    }
   }
 }
 
@@ -295,17 +335,19 @@ union CommonMsgInfo {
   case ExtOutMsgInfo
   // TODO: int_msg_info, ext_in_msg_info
 
-  fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
-    let res_discr1 = s.load_int(1);
-    if (builtin_equal(res_discr1.value, 0)) {
-      /* TODO: int_msg_info */
-    } else {
-      let res_discr2 = res_discr1.slice.load_int(1);
-      if (builtin_equal(res_discr2.value, 0)) {
-        /* TODO: ext_in_msg_info */
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+      let res_discr1 = s.load_int(1);
+      if (builtin_equal(res_discr1.value, 0)) {
+        /* TODO: int_msg_info */
       } else {
-        let res_info = ExtOutMsgInfo.deserialize(res_discr2.slice);
-        return LoadResultBase(Slice, Self).new(res_info.slice, res_info.value);
+        let res_discr2 = res_discr1.slice.load_int(1);
+        if (builtin_equal(res_discr2.value, 0)) {
+          /* TODO: ext_in_msg_info */
+        } else {
+          let res_info = ExtOutMsgInfo.deserialize(res_discr2.slice);
+          return LoadResultBase(Slice, Self).new(res_info.slice, res_info.value);
+        }
       }
     }
   }
@@ -315,11 +357,13 @@ union CommonMsgInfoRelaxed {
   case ExtOutMsgInfo
   // TODO: int_msg_info
 
-  fn serialize(self: Self, b: Builder) -> Builder {
-    switch(self) {
-      case ExtOutMsgInfo info => {
-        let b = b.serialize_int(3, 2); // 0b11
-        return info.serialize(b);
+  impl Serialize {
+    fn serialize(self: Self, b: Builder) -> Builder {
+      switch(self) {
+        case ExtOutMsgInfo info => {
+          let b = b.serialize_int(3, 2); // 0b11
+          return info.serialize(b);
+        }
       }
     }
   }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -50,7 +50,8 @@ functor
     (* TODO: union impls *)
     and union_definition =
       { union_members : expr located list; [@sexpa.list]
-        union_bindings : binding located list [@sexp.list] }
+        union_bindings : binding located list; [@sexp.list]
+        union_impls : impl list [@sexp.list] }
 
     and expr =
       | Struct of struct_definition

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -12,24 +12,24 @@ let%expect_test "Int(bits) constructor" =
     {|
     (Ok
      ((bindings
-       ((overflow (Value (Struct (24 ((value (Value (Integer 513))))))))
-        (i (Value (Struct (53 ((value (Value (Integer 100))))))))))
+       ((overflow (Value (Struct (27 ((value (Value (Integer 513))))))))
+        (i (Value (Struct (56 ((value (Value (Integer 100))))))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -38,12 +38,12 @@ let%expect_test "Int(bits) constructor" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -55,14 +55,14 @@ let%expect_test "Int(bits) constructor" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -70,26 +70,77 @@ let%expect_test "Int(bits) constructor" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
@@ -121,7 +172,7 @@ let%expect_test "Int(bits) serializer" =
                  (Expr
                   (FunctionCall
                    ((ResolvedReference (serialize <opaque>))
-                    ((Reference (i (StructType 43)))
+                    ((Reference (i (StructType 46)))
                      (Reference (b (StructType 3))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -160,7 +211,7 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (T_serializer <opaque>))
                     ((Value
                       (Struct
-                       (55
+                       (58
                         ((a
                           (FunctionCall
                            ((ResolvedReference (new <opaque>))
@@ -174,7 +225,7 @@ let%expect_test "demo struct serializer" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 55)) (b (StructType 3))))
+             ((function_params ((self (StructType 58)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -186,7 +237,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 43)) (builder (StructType 3))))
+                            ((self (StructType 46)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -195,11 +246,11 @@ let%expect_test "demo struct serializer" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 43))) value
+                                 ((Reference (self (StructType 46))) value
                                   IntegerType))
                                 (Value (Integer 32))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 55))) a (StructType 43)))
+                        ((Reference (self (StructType 58))) a (StructType 46)))
                        (Reference (b (StructType 3)))))))))
                  (Let
                   ((b
@@ -208,7 +259,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 53)) (builder (StructType 3))))
+                            ((self (StructType 56)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -217,35 +268,35 @@ let%expect_test "demo struct serializer" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 53))) value
+                                 ((Reference (self (StructType 56))) value
                                   IntegerType))
                                 (Value (Integer 16))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 55))) b (StructType 53)))
+                        ((Reference (self (StructType 58))) b (StructType 56)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (T (Value (Type (StructType 55))))))
+        (T (Value (Type (StructType 58))))))
       (structs
-       ((55
+       ((58
          ((struct_fields
-           ((a ((field_type (StructType 43))))
-            (b ((field_type (StructType 53))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 55)))
-        (53
+           ((a ((field_type (StructType 46))))
+            (b ((field_type (StructType 56))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 58)))
+        (56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -254,12 +305,12 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 16)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -271,14 +322,14 @@ let%expect_test "demo struct serializer" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -286,26 +337,77 @@ let%expect_test "demo struct serializer" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 16))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 16))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -329,40 +431,40 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var (Value (Struct (54 ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (57 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params ((y (StructType 54))))
-              (function_returns (StructType 54))))
-            (function_impl (Fn ((Return (Reference (y (StructType 54)))))))))))
-        (Value (Value (Type (StructType 54))))))
+             ((function_params ((y (StructType 57))))
+              (function_returns (StructType 57))))
+            (function_impl (Fn ((Return (Reference (y (StructType 57)))))))))))
+        (Value (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields ((a ((field_type IntegerType)))))
           (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns (StructType 54))))
+                (function_returns (StructType 57))))
               (function_impl
                (Fn
-                ((Return (Value (Struct (54 ((a (Reference (x IntegerType)))))))))))))))
+                ((Return (Value (Struct (57 ((a (Reference (x IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns (StructType 54))))
+                     (function_returns (StructType 57))))
                    (function_impl
                     (Fn
                      ((Return
-                       (Value (Struct (54 ((a (Reference (x IntegerType))))))))))))))))))))
-          (struct_id 54)))))
+                       (Value (Struct (57 ((a (Reference (x IntegerType))))))))))))))))))))
+          (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "tensor2" =

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -13,23 +13,23 @@ let%expect_test "Int(bits) constructor" =
     (Ok
      ((bindings
        ((overflow (Value (Struct (27 ((value (Value (Integer 513))))))))
-        (i (Value (Struct (56 ((value (Value (Integer 100))))))))))
+        (i (Value (Struct (59 ((value (Value (Integer 100))))))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -38,7 +38,7 @@ let%expect_test "Int(bits) constructor" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -62,7 +62,7 @@ let%expect_test "Int(bits) constructor" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -70,11 +70,11 @@ let%expect_test "Int(bits) constructor" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -83,7 +83,7 @@ let%expect_test "Int(bits) constructor" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -92,7 +92,7 @@ let%expect_test "Int(bits) constructor" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -122,7 +122,7 @@ let%expect_test "Int(bits) constructor" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -134,13 +134,13 @@ let%expect_test "Int(bits) constructor" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Int(bits) serializer" =
@@ -211,7 +211,7 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (T_serializer <opaque>))
                     ((Value
                       (Struct
-                       (58
+                       (61
                         ((a
                           (FunctionCall
                            ((ResolvedReference (new <opaque>))
@@ -225,7 +225,7 @@ let%expect_test "demo struct serializer" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 58)) (b (StructType 3))))
+             ((function_params ((self (StructType 61)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -250,7 +250,7 @@ let%expect_test "demo struct serializer" =
                                   IntegerType))
                                 (Value (Integer 32))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 58))) a (StructType 46)))
+                        ((Reference (self (StructType 61))) a (StructType 46)))
                        (Reference (b (StructType 3)))))))))
                  (Let
                   ((b
@@ -259,7 +259,7 @@ let%expect_test "demo struct serializer" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 56)) (builder (StructType 3))))
+                            ((self (StructType 59)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -268,35 +268,35 @@ let%expect_test "demo struct serializer" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 56))) value
+                                 ((Reference (self (StructType 59))) value
                                   IntegerType))
                                 (Value (Integer 16))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 58))) b (StructType 56)))
+                        ((Reference (self (StructType 61))) b (StructType 59)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (T (Value (Type (StructType 58))))))
+        (T (Value (Type (StructType 61))))))
       (structs
-       ((58
+       ((61
          ((struct_fields
            ((a ((field_type (StructType 46))))
-            (b ((field_type (StructType 56))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 58)))
-        (56
+            (b ((field_type (StructType 59))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 61)))
+        (59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -305,7 +305,7 @@ let%expect_test "demo struct serializer" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 16)))))))))))
             (deserialize
              ((function_signature
@@ -329,7 +329,7 @@ let%expect_test "demo struct serializer" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -337,11 +337,11 @@ let%expect_test "demo struct serializer" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -350,7 +350,7 @@ let%expect_test "demo struct serializer" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -359,7 +359,7 @@ let%expect_test "demo struct serializer" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 16))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -389,7 +389,7 @@ let%expect_test "demo struct serializer" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -401,13 +401,13 @@ let%expect_test "demo struct serializer" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -431,26 +431,26 @@ let%expect_test "from interface" =
     {|
     (Ok
      ((bindings
-       ((var (Value (Struct (57 ((a (Value (Integer 10))))))))
+       ((var (Value (Struct (60 ((a (Value (Integer 10))))))))
         (check
          (Value
           (Function
            ((function_signature
-             ((function_params ((y (StructType 57))))
-              (function_returns (StructType 57))))
-            (function_impl (Fn ((Return (Reference (y (StructType 57)))))))))))
-        (Value (Value (Type (StructType 57))))))
+             ((function_params ((y (StructType 60))))
+              (function_returns (StructType 60))))
+            (function_impl (Fn ((Return (Reference (y (StructType 60)))))))))))
+        (Value (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ((a ((field_type IntegerType)))))
           (struct_methods
            ((from
              ((function_signature
                ((function_params ((x IntegerType)))
-                (function_returns (StructType 57))))
+                (function_returns (StructType 60))))
               (function_impl
                (Fn
-                ((Return (Value (Struct (57 ((a (Reference (x IntegerType)))))))))))))))
+                ((Return (Value (Struct (60 ((a (Reference (x IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
@@ -459,12 +459,12 @@ let%expect_test "from interface" =
                  (Function
                   ((function_signature
                     ((function_params ((x IntegerType)))
-                     (function_returns (StructType 57))))
+                     (function_returns (StructType 60))))
                    (function_impl
                     (Fn
                      ((Return
-                       (Value (Struct (57 ((a (Reference (x IntegerType))))))))))))))))))))
-          (struct_id 57)))))
+                       (Value (Struct (60 ((a (Reference (x IntegerType))))))))))))))))))))
+          (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "tensor2" =

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -824,9 +824,16 @@ let%expect_test "tensor2" =
 let%expect_test "deserialization api" =
   let source =
     {|
+     struct Empty { 
+      impl Deserialize {
+        fn deserialize(s: Slice) -> LoadResultBase(Slice, Self) {
+          return LoadResultBase(Slice, Self).new(s, Self{});
+        }
+      }
+    }
      fn test(c: Cell) {
        let s = Slice.parse(c);
-       let msg = CommonMsgInfo.deserialize(s);
+       let msg = Message(Empty).deserialize(s);
      }
      |}
   in
@@ -874,139 +881,165 @@ let%expect_test "deserialization api" =
     slice f0(cell cell_) {
       return builtin_slice_begin_parse(cell_);
     }
-    [slice, int] f2(slice self, int bits) {
+    [slice, int] f3(slice self, int bits) {
       (slice, int) output = builtin_slice_load_int(self, bits);
       slice slice_ = tensor2_value1(output);
       int int_ = tensor2_value2(output);
       return [slice_, int_];
     }
-    [slice, int] f7(slice s) {
-      [slice, int] res = f2(s, 9);
-      return [first(res), second(res)];
-    }
     [slice, int] f8(slice s) {
-      [slice, int] res = f2(s, 8);
+      [slice, int] res = f3(s, 9);
       return [first(res), second(res)];
     }
-    [slice, [int, int, int]] f9(slice s, [int, int, int] x) {
+    [slice, int] f9(slice s) {
+      [slice, int] res = f3(s, 8);
+      return [first(res), second(res)];
+    }
+    [slice, [int, int, int]] f10(slice s, [int, int, int] x) {
       return [s, x];
     }
-    [slice, [int, int, int]] f6(slice s) {
-      [slice, int] res_anycast = f2(s, 1);
+    [slice, [int, int, int]] f7(slice s) {
+      [slice, int] res_anycast = f3(s, 1);
       if (builtin_equal(second(res_anycast), 0)) {
-      [slice, int] res_len = f7(first(res_anycast));
+      [slice, int] res_len = f8(first(res_anycast));
     [slice, int] res_workchain =
-    f8(first(res_len));
+    f9(first(res_len));
     [slice, int] res_address =
-    f2(first(res_workchain), res_len);
+    f3(first(res_workchain), res_len);
     return
-    f9(first(res_address), [second(res_len), second(res_workchain), second(res_address)]);
+    f10(first(res_address), [second(res_len), second(res_workchain), second(res_address)]);
     } else
     {
       }}
-    [slice, tuple] f10(slice s, tuple x) {
+    [slice, tuple] f11(slice s, tuple x) {
       return [s, x];
     }
-    [slice, int] f12(slice s) {
-      [slice, int] res = f2(s, 256);
+    [slice, int] f13(slice s) {
+      [slice, int] res = f3(s, 256);
       return [first(res), second(res)];
     }
-    [slice, [int, int]] f13(slice s, [int, int] x) {
+    [slice, [int, int]] f14(slice s, [int, int] x) {
       return [s, x];
     }
-    [slice, [int, int]] f11(slice s) {
-      [slice, int] res_anycast = f2(s, 1);
+    [slice, [int, int]] f12(slice s) {
+      [slice, int] res_anycast = f3(s, 1);
       if (builtin_equal(second(res_anycast), 0)) {
-      [slice, int] res_workchain = f8(first(res_anycast));
+      [slice, int] res_workchain = f9(first(res_anycast));
     [slice, int] res_address =
-    f12(first(res_workchain));
+    f13(first(res_workchain));
     return
-    f13(first(res_address), [second(res_workchain), second(res_address)]);
+    f14(first(res_address), [second(res_workchain), second(res_address)]);
+    } else
+    {
+      }}
+    [slice, tuple] f6(slice s) {
+      [slice, int] res_discr = f3(s, 1);
+      if (builtin_equal(second(res_discr), 0)) {
+      [slice, [int, int]] res_addr = f12(second(res_discr));
+    return
+    f11(first(res_addr), second(res_addr));
+    } else
+    {
+      [slice, [int, int, int]] res_addr = f7(first(res_discr));
+    return
+    f11(first(res_addr), second(res_addr));
+    }}
+    [slice, tuple] f15(slice s, tuple x) {
+      return [s, x];
+    }
+    [slice, [int, int]] f17(slice s) {
+      [slice, int] res_len = f8(s);
+      [slice, int] res_bits = f3(first(res_len), second(res_len));
+      return [first(res_bits), [second(res_len), second(res_bits)]];
+    }
+    [slice, tuple] f18(slice s, tuple x) {
+      return [s, x];
+    }
+    [slice, tuple] f16(slice s) {
+      [slice, int] res_discr = f3(s, 1);
+      if (builtin_equal(second(res_discr), 0)) {
+      return f18(first(res_discr), []);
+    } else if (builtin_equal(second(res_discr), 1))
+    {
+      [slice, [int, int]] res_addr = f17(first(res_discr));
+    return
+    f18(first(res_addr), second(res_addr));
     } else
     {
       }}
     [slice, tuple] f5(slice s) {
-      [slice, int] res_discr = f2(s, 1);
+      [slice, int] res_discr = f3(s, 1);
       if (builtin_equal(second(res_discr), 0)) {
-      [slice, [int, int]] res_addr = f11(second(res_discr));
+      [slice, tuple] res_addr = f16(second(res_discr));
     return
-    f10(first(res_addr), second(res_addr));
+    f15(first(res_addr), second(res_addr));
     } else
     {
-      [slice, [int, int, int]] res_addr = f6(first(res_discr));
+      [slice, tuple] res_addr = f6(first(res_discr));
     return
-    f10(first(res_addr), second(res_addr));
+    f15(first(res_addr), second(res_addr));
     }}
-    [slice, tuple] f14(slice s, tuple x) {
-      return [s, x];
-    }
-    [slice, [int, int]] f16(slice s) {
-      [slice, int] res_len = f7(s);
-      [slice, int] res_bits = f2(first(res_len), second(res_len));
-      return [first(res_bits), [second(res_len), second(res_bits)]];
-    }
-    [slice, tuple] f17(slice s, tuple x) {
-      return [s, x];
-    }
-    [slice, tuple] f15(slice s) {
-      [slice, int] res_discr = f2(s, 1);
-      if (builtin_equal(second(res_discr), 0)) {
-      return f17(first(res_discr), []);
-    } else if (builtin_equal(second(res_discr), 1))
-    {
-      [slice, [int, int]] res_addr = f16(first(res_discr));
-    return
-    f17(first(res_addr), second(res_addr));
-    } else
-    {
-      }}
-    [slice, tuple] f4(slice s) {
-      [slice, int] res_discr = f2(s, 1);
-      if (builtin_equal(second(res_discr), 0)) {
-      [slice, tuple] res_addr = f15(second(res_discr));
-    return
-    f14(first(res_addr), second(res_addr));
-    } else
-    {
-      [slice, tuple] res_addr = f5(first(res_discr));
-    return
-    f14(first(res_addr), second(res_addr));
-    }}
-    [slice, int] f18(slice s) {
-      [slice, int] res = f2(s, 64);
+    [slice, int] f19(slice s) {
+      [slice, int] res = f3(s, 64);
       return [first(res), second(res)];
     }
-    [slice, [tuple, tuple, int, int]] f19(slice s, [tuple, tuple, int, int] x) {
+    [slice, [tuple, tuple, int, int]] f20(slice s, [tuple, tuple, int, int] x) {
       return [s, x];
     }
-    [slice, [tuple, tuple, int, int]] f3(slice s) {
-      [slice, tuple] res_src = f4(s);
-      [slice, tuple] res_dest = f15(first(res_src));
-      [slice, int] res_created_lt = f18(first(res_dest));
-      [slice, int] res_created_at = f18(first(res_created_lt));
+    [slice, [tuple, tuple, int, int]] f4(slice s) {
+      [slice, tuple] res_src = f5(s);
+      [slice, tuple] res_dest = f16(first(res_src));
+      [slice, int] res_created_lt = f19(first(res_dest));
+      [slice, int] res_created_at = f19(first(res_created_lt));
       return
-        f19(first(res_created_at), [second(res_src), second(res_dest), second(res_created_lt), second(res_created_at)]);
+        f20(first(res_created_at), [second(res_src), second(res_dest), second(res_created_lt), second(res_created_at)]);
     }
-    [slice, tuple] f20(slice s, tuple x) {
+    [slice, tuple] f21(slice s, tuple x) {
       return [s, x];
     }
-    [slice, tuple] f1(slice s) {
-      [slice, int] res_discr1 = f2(s, 1);
+    [slice, tuple] f2(slice s) {
+      [slice, int] res_discr1 = f3(s, 1);
       if (builtin_equal(second(res_discr1), 0)) {
       } else
     {
-      [slice, int] res_discr2 = f2(first(res_discr1), 1);
+      [slice, int] res_discr2 = f3(first(res_discr1), 1);
     if (builtin_equal(second(res_discr2), 0))
     {
       } else
     {
-      [slice, [tuple, tuple, int, int]] res_info = f3(first(res_discr2));
+      [slice, [tuple, tuple, int, int]] res_info = f4(first(res_discr2));
     return
-    f20(first(res_info), second(res_info));
+    f21(first(res_info), second(res_info));
     }}}
+    [slice, []] f23(slice s, [] x) {
+      return [s, x];
+    }
+    [slice, []] f22(slice s) {
+      return f23(s, []);
+    }
+    [slice, [tuple, []]] f24(slice s, [tuple, []] x) {
+      return [s, x];
+    }
+    [slice, [tuple, []]] f1(slice s) {
+      [slice, tuple] res_info = f2(s);
+      [slice, int] res_init = f3(first(res_info), 1);
+      if (builtin_equal(second(res_init), 0)) {
+      [slice, int] res_body_discr = f3(first(res_init), 1);
+    if (builtin_equal(second(res_body_discr), 0))
+    {
+      [slice, []] body = f22(first(res_body_discr));
+    [tuple, _] mes =
+    [second(res_info), second(body)];
+    return
+    f24(first(body), mes);
+    } else
+    {
+      }} else
+    {
+      }}
     _ test(cell c) {
       slice s = f0(c);
-      [slice, tuple] msg = f1(s);
+      [slice, [tuple, []]] msg = f1(s);
     } |}]
 
 let%expect_test "destructuring let" =

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -34,23 +34,23 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 53))))))
+     ((bindings ((T (Value (Type (StructType 56))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -59,12 +59,12 @@ let%expect_test "scope resolution" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -76,14 +76,14 @@ let%expect_test "scope resolution" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -91,26 +91,77 @@ let%expect_test "scope resolution" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
@@ -121,23 +172,23 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 53))))))
+     ((bindings ((T (Value (Type (StructType 56))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -146,12 +197,12 @@ let%expect_test "binding resolution" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -163,14 +214,14 @@ let%expect_test "binding resolution" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -178,26 +229,77 @@ let%expect_test "binding resolution" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -222,23 +324,23 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 53)))) (A (Value (Type (StructType 53))))))
+       ((B (Value (Type (StructType 56)))) (A (Value (Type (StructType 56))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -247,12 +349,12 @@ let%expect_test "scope resolution after let binding" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -264,14 +366,14 @@ let%expect_test "scope resolution after let binding" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -279,26 +381,77 @@ let%expect_test "scope resolution after let binding" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
@@ -309,26 +462,26 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 55))))))
+     ((bindings ((T (Value (Type (StructType 58))))))
       (structs
-       ((55
-         ((struct_fields ((t ((field_type (StructType 53))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 55)))
-        (53
+       ((58
+         ((struct_fields ((t ((field_type (StructType 56))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 58)))
+        (56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -337,12 +490,12 @@ let%expect_test "basic struct definition" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -354,14 +507,14 @@ let%expect_test "basic struct definition" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -369,26 +522,77 @@ let%expect_test "basic struct definition" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
@@ -419,30 +623,30 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a (Value (Struct (53 ((value (Value (Integer 1))))))))
+       ((a (Value (Struct (56 ((value (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 53))))
-              (function_returns (StructType 53))))
-            (function_impl (Fn ((Return (Reference (i (StructType 53)))))))))))))
+             ((function_params ((i (StructType 56))))
+              (function_returns (StructType 56))))
+            (function_impl (Fn ((Return (Reference (i (StructType 56)))))))))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -451,12 +655,12 @@ let%expect_test "Tact function evaluation" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -468,14 +672,14 @@ let%expect_test "Tact function evaluation" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -483,26 +687,77 @@ let%expect_test "Tact function evaluation" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -547,27 +802,27 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings ((MyType (Value (Type (StructType 55))))))
+       ((bindings ((MyType (Value (Type (StructType 58))))))
         (structs
-         ((55
+         ((58
            ((struct_fields
-             ((a ((field_type (StructType 53)))) (b ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 55)))
-          (53
+             ((a ((field_type (StructType 56)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 58)))
+          (56
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 53)) (builder (StructType 3))))
+                   ((self (StructType 56)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -576,12 +831,12 @@ let%expect_test "struct definition" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 53))) value IntegerType))
+                        ((Reference (self (StructType 56))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 9))))
+                  (function_returns (StructType 12))))
                 (function_impl
                  (Fn
                   ((Block
@@ -593,14 +848,14 @@ let%expect_test "struct definition" =
                      (Return
                       (Value
                        (Struct
-                        (9
+                        (12
                          ((slice
                            (StructField
                             ((Reference (res (StructType 6))) slice (StructType 7))))
                           (value
                            (Value
                             (Struct
-                             (53
+                             (56
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -608,26 +863,77 @@ let%expect_test "struct definition" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 8))))
+               (impl_methods
+                ((serialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 56)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       ((Return
+                         (FunctionCall
+                          ((ResolvedReference (serialize_int <opaque>))
+                           ((Reference (builder (StructType 3)))
+                            (StructField
+                             ((Reference (self (StructType 56))) value IntegerType))
+                            (Value (Integer 257))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
+               (impl_methods
+                ((deserialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params ((s (StructType 7))))
+                       (function_returns (StructType 12))))
+                     (function_impl
+                      (Fn
+                       ((Block
+                         ((Let
+                           ((res
+                             (FunctionCall
+                              ((ResolvedReference (load_int <opaque>))
+                               ((Reference (s (StructType 7)))
+                                (Value (Integer 257))))))))
+                          (Return
+                           (Value
+                            (Struct
+                             (12
+                              ((slice
+                                (StructField
+                                 ((Reference (res (StructType 6))) slice
+                                  (StructType 7))))
+                               (value
+                                (Value
+                                 (Struct
+                                  (56
+                                   ((value
+                                     (StructField
+                                      ((Reference (res (StructType 6))) value
+                                       IntegerType)))))))))))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 53))))
+                       (function_returns (StructType 56))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 53)))))
+                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 56)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -646,29 +952,29 @@ let%expect_test "duplicate type field" =
      (((DuplicateField
         (a
          ((mk_struct_fields
-           ((a (Value (Type (StructType 53)))) (a (Value (Type BoolType)))))
+           ((a (Value (Type (StructType 56)))) (a (Value (Type BoolType)))))
           (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
-       ((bindings ((MyType (Value (Type (StructType 55))))))
+       ((bindings ((MyType (Value (Type (StructType 58))))))
         (structs
-         ((55
+         ((58
            ((struct_fields
-             ((a ((field_type (StructType 53)))) (a ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 55)))
-          (53
+             ((a ((field_type (StructType 56)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 58)))
+          (56
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 53)) (builder (StructType 3))))
+                   ((self (StructType 56)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -677,12 +983,12 @@ let%expect_test "duplicate type field" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 53))) value IntegerType))
+                        ((Reference (self (StructType 56))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 9))))
+                  (function_returns (StructType 12))))
                 (function_impl
                  (Fn
                   ((Block
@@ -694,7 +1000,7 @@ let%expect_test "duplicate type field" =
                      (Return
                       (Value
                        (Struct
-                        (9
+                        (12
                          ((slice
                            (StructField
                             ((Reference (res (StructType 6))) slice
@@ -702,7 +1008,7 @@ let%expect_test "duplicate type field" =
                           (value
                            (Value
                             (Struct
-                             (53
+                             (56
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -710,26 +1016,78 @@ let%expect_test "duplicate type field" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 8))))
+               (impl_methods
+                ((serialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 56)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       ((Return
+                         (FunctionCall
+                          ((ResolvedReference (serialize_int <opaque>))
+                           ((Reference (builder (StructType 3)))
+                            (StructField
+                             ((Reference (self (StructType 56))) value
+                              IntegerType))
+                            (Value (Integer 257))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
+               (impl_methods
+                ((deserialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params ((s (StructType 7))))
+                       (function_returns (StructType 12))))
+                     (function_impl
+                      (Fn
+                       ((Block
+                         ((Let
+                           ((res
+                             (FunctionCall
+                              ((ResolvedReference (load_int <opaque>))
+                               ((Reference (s (StructType 7)))
+                                (Value (Integer 257))))))))
+                          (Return
+                           (Value
+                            (Struct
+                             (12
+                              ((slice
+                                (StructField
+                                 ((Reference (res (StructType 6))) slice
+                                  (StructType 7))))
+                               (value
+                                (Value
+                                 (Struct
+                                  (56
+                                   ((value
+                                     (StructField
+                                      ((Reference (res (StructType 6))) value
+                                       IntegerType)))))))))))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 53))))
+                       (function_returns (StructType 56))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 53)))))
+                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 56)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -744,7 +1102,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 55))))
+       ((TA (Value (Type (StructType 58))))
         (T
          (Value
           (Function
@@ -755,26 +1113,26 @@ let%expect_test "parametric struct instantiation" =
               ((Expr
                 (MkStructDef
                  ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                  (mk_methods ()) (mk_impls ()) (mk_struct_id 53)))))))))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 56)))))))))))))
       (structs
-       ((55
-         ((struct_fields ((a ((field_type (StructType 54))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 55)))
-        (54
+       ((58
+         ((struct_fields ((a ((field_type (StructType 57))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 58)))
+        (57
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 54))))
+                (function_returns (StructType 57))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (54 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 54)) (builder (StructType 3))))
+                 ((self (StructType 57)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -783,12 +1141,12 @@ let%expect_test "parametric struct instantiation" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 54))) value IntegerType))
+                      ((Reference (self (StructType 57))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -800,14 +1158,14 @@ let%expect_test "parametric struct instantiation" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (54
+                           (57
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -815,26 +1173,77 @@ let%expect_test "parametric struct instantiation" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 54))))
+                (function_returns (StructType 57))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (54 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 57)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 57))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (57
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 54))))
+                     (function_returns (StructType 57))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (54 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 54)))))
+                        (Struct (57 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -871,34 +1280,34 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b (Value (Struct (53 ((value (Value (Integer 1))))))))
+       ((b (Value (Struct (56 ((value (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 53))))
-              (function_returns (StructType 53))))
+             ((function_params ((i (StructType 56))))
+              (function_returns (StructType 56))))
             (function_impl
              (Fn
               ((Block
-                ((Let ((a (Reference (i (StructType 53))))))
-                 (Return (Reference (a (StructType 53)))))))))))))))
+                ((Let ((a (Reference (i (StructType 56))))))
+                 (Return (Reference (a (StructType 56)))))))))))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -907,12 +1316,12 @@ let%expect_test "scoping that `let` introduces in code" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -924,14 +1333,14 @@ let%expect_test "scoping that `let` introduces in code" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -939,26 +1348,77 @@ let%expect_test "scoping that `let` introduces in code" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
@@ -983,7 +1443,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 53))))
+             ((function_params ((x (StructType 56))))
               (function_returns HoleType)))
             (function_impl
              (Fn
@@ -992,37 +1452,37 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (x (StructType 53)))
-                       (Reference (x (StructType 53)))))))))
+                      ((Reference (x (StructType 56)))
+                       (Reference (x (StructType 56)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (a (StructType 53)))
-                       (Reference (a (StructType 53))))))))))))))))))
+                      ((Reference (a (StructType 56)))
+                       (Reference (a (StructType 56))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 53)) (i_ (StructType 53))))
-              (function_returns (StructType 53))))
-            (function_impl (Fn ((Return (Reference (i (StructType 53)))))))))))))
+             ((function_params ((i (StructType 56)) (i_ (StructType 56))))
+              (function_returns (StructType 56))))
+            (function_impl (Fn ((Return (Reference (i (StructType 56)))))))))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -1031,12 +1491,12 @@ let%expect_test "reference in function bodies" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -1048,14 +1508,14 @@ let%expect_test "reference in function bodies" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -1063,26 +1523,77 @@ let%expect_test "reference in function bodies" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -1127,18 +1638,18 @@ let%expect_test "struct method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (Struct (54 ()))))
-        (Foo (Value (Type (StructType 54))))))
+       ((res (Value (Integer 1))) (foo (Value (Struct (57 ()))))
+        (Foo (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 54)) (i IntegerType)))
+               ((function_params ((self (StructType 57)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
-          (struct_impls ()) (struct_id 54)))))
+          (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -1156,9 +1667,9 @@ let%expect_test "struct type method access" =
   [%expect
     {|
     (Ok
-     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 54))))))
+     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields ())
           (struct_methods
            ((bar
@@ -1166,7 +1677,7 @@ let%expect_test "struct type method access" =
                ((function_params ((i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
-          (struct_impls ()) (struct_id 54)))))
+          (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -1183,17 +1694,17 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 54))))))
+     ((bindings ((Foo (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 54))))
-                (function_returns (StructType 54))))
-              (function_impl (Fn ((Return (Reference (self (StructType 54)))))))))))
-          (struct_impls ()) (struct_id 54)))))
+               ((function_params ((self (StructType 57))))
+                (function_returns (StructType 57))))
+              (function_impl (Fn ((Return (Reference (self (StructType 57)))))))))))
+          (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -1217,42 +1728,42 @@ let%expect_test "union method access" =
     {|
       (Ok
        ((bindings
-         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 54))))
+         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 57))))
           (make_foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 54))))
-                (function_returns (UnionType 54))))
-              (function_impl (Fn ((Return (Reference (foo (UnionType 54)))))))))))
-          (Foo (Value (Type (UnionType 54))))))
+               ((function_params ((foo (UnionType 57))))
+                (function_returns (UnionType 57))))
+              (function_impl (Fn ((Return (Reference (foo (UnionType 57)))))))))))
+          (Foo (Value (Type (UnionType 57))))))
         (structs ())
         (unions
-         ((54
+         ((57
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (UnionType 54)) (i IntegerType)))
+                 ((function_params ((self (UnionType 57)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 55))))
+             (((impl_interface (Value (Type (InterfaceType 58))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 54))))
+                       (function_returns (UnionType 57))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 54)))))))))))))))
-            (union_id 54)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 57)))))))))))))))
+            (union_id 57)))))
         (interfaces
-         ((55
+         ((58
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1284,13 +1795,13 @@ let%expect_test "union type method access" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 54))))
-                (function_returns (UnionType 54))))
-              (function_impl (Fn ((Return (Reference (foo (UnionType 54)))))))))))
-          (Foo (Value (Type (UnionType 54))))))
+               ((function_params ((foo (UnionType 57))))
+                (function_returns (UnionType 57))))
+              (function_impl (Fn ((Return (Reference (foo (UnionType 57)))))))))))
+          (Foo (Value (Type (UnionType 57))))))
         (structs ())
         (unions
-         ((54
+         ((57
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
@@ -1299,22 +1810,22 @@ let%expect_test "union type method access" =
                   (function_returns IntegerType)))
                 (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 55))))
+             (((impl_interface (Value (Type (InterfaceType 58))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 54))))
+                       (function_returns (UnionType 57))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 54)))))))))))))))
-            (union_id 54)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 57)))))))))))))))
+            (union_id 57)))))
         (interfaces
-         ((55
+         ((58
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1338,13 +1849,13 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value (Struct (54 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 54))))))
+         (Value (Struct (57 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_methods ()) (struct_impls ()) (struct_id 54)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -1355,21 +1866,21 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 42) (StructType 43)))
+     (((TypeError ((StructType 45) (StructType 46)))
        ((bindings
          ((foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((i (StructType 43))))
-                (function_returns (StructType 42))))
-              (function_impl (Fn ((Return (Reference (i (StructType 43)))))))))))))
+               ((function_params ((i (StructType 46))))
+                (function_returns (StructType 45))))
+              (function_impl (Fn ((Return (Reference (i (StructType 46)))))))))))))
         (structs ())
         (interfaces
-         ((53
+         ((56
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 43))))
+               ((function_params ((from (StructType 46))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1461,24 +1972,24 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 53) (StructType 54)))
+     (((TypeError ((StructType 56) (StructType 57)))
        ((bindings ())
         (structs
-         ((54
+         ((57
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 54))))
+                  (function_returns (StructType 57))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (54 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 54)) (builder (StructType 3))))
+                   ((self (StructType 57)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1487,12 +1998,12 @@ let%expect_test "type check error" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 54))) value IntegerType))
+                        ((Reference (self (StructType 57))) value IntegerType))
                        (Value (Integer 10)))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 9))))
+                  (function_returns (StructType 12))))
                 (function_impl
                  (Fn
                   ((Block
@@ -1504,7 +2015,7 @@ let%expect_test "type check error" =
                      (Return
                       (Value
                        (Struct
-                        (9
+                        (12
                          ((slice
                            (StructField
                             ((Reference (res (StructType 6))) slice
@@ -1512,7 +2023,7 @@ let%expect_test "type check error" =
                           (value
                            (Value
                             (Struct
-                             (54
+                             (57
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -1520,41 +2031,93 @@ let%expect_test "type check error" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 54))))
+                  (function_returns (StructType 57))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (54 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 8))))
+               (impl_methods
+                ((serialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 57)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       ((Return
+                         (FunctionCall
+                          ((ResolvedReference (serialize_int <opaque>))
+                           ((Reference (builder (StructType 3)))
+                            (StructField
+                             ((Reference (self (StructType 57))) value
+                              IntegerType))
+                            (Value (Integer 10))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
+               (impl_methods
+                ((deserialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params ((s (StructType 7))))
+                       (function_returns (StructType 12))))
+                     (function_impl
+                      (Fn
+                       ((Block
+                         ((Let
+                           ((res
+                             (FunctionCall
+                              ((ResolvedReference (load_int <opaque>))
+                               ((Reference (s (StructType 7)))
+                                (Value (Integer 10))))))))
+                          (Return
+                           (Value
+                            (Struct
+                             (12
+                              ((slice
+                                (StructField
+                                 ((Reference (res (StructType 6))) slice
+                                  (StructType 7))))
+                               (value
+                                (Value
+                                 (Struct
+                                  (57
+                                   ((value
+                                     (StructField
+                                      ((Reference (res (StructType 6))) value
+                                       IntegerType)))))))))))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 54))))
+                       (function_returns (StructType 57))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (54 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 54)))
-          (53
+                          (Struct (57 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 57)))
+          (56
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 53)) (builder (StructType 3))))
+                   ((self (StructType 56)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1563,12 +2126,12 @@ let%expect_test "type check error" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 53))) value IntegerType))
+                        ((Reference (self (StructType 56))) value IntegerType))
                        (Value (Integer 99)))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 9))))
+                  (function_returns (StructType 12))))
                 (function_impl
                  (Fn
                   ((Block
@@ -1580,7 +2143,7 @@ let%expect_test "type check error" =
                      (Return
                       (Value
                        (Struct
-                        (9
+                        (12
                          ((slice
                            (StructField
                             ((Reference (res (StructType 6))) slice
@@ -1588,7 +2151,7 @@ let%expect_test "type check error" =
                           (value
                            (Value
                             (Struct
-                             (53
+                             (56
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -1596,31 +2159,83 @@ let%expect_test "type check error" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 8))))
+               (impl_methods
+                ((serialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 56)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       ((Return
+                         (FunctionCall
+                          ((ResolvedReference (serialize_int <opaque>))
+                           ((Reference (builder (StructType 3)))
+                            (StructField
+                             ((Reference (self (StructType 56))) value
+                              IntegerType))
+                            (Value (Integer 99))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
+               (impl_methods
+                ((deserialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params ((s (StructType 7))))
+                       (function_returns (StructType 12))))
+                     (function_impl
+                      (Fn
+                       ((Block
+                         ((Let
+                           ((res
+                             (FunctionCall
+                              ((ResolvedReference (load_int <opaque>))
+                               ((Reference (s (StructType 7)))
+                                (Value (Integer 99))))))))
+                          (Return
+                           (Value
+                            (Struct
+                             (12
+                              ((slice
+                                (StructField
+                                 ((Reference (res (StructType 6))) slice
+                                  (StructType 7))))
+                               (value
+                                (Value
+                                 (Struct
+                                  (56
+                                   ((value
+                                     (StructField
+                                      ((Reference (res (StructType 6))) value
+                                       IntegerType)))))))))))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 53))))
+                       (function_returns (StructType 56))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 53)))))
+                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 56)))))
         (interfaces
-         ((55
+         ((58
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 54))))
+               ((function_params ((from (StructType 57))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -1640,9 +2255,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 54))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 57))))))
       (structs
-       ((54
+       ((57
          ((struct_fields ())
           (struct_methods
            ((op
@@ -1660,7 +2275,7 @@ let%expect_test "implement interface op" =
                     ((function_params ((left IntegerType) (right IntegerType)))
                      (function_returns IntegerType)))
                    (function_impl (Fn ((Return (Reference (left IntegerType)))))))))))))))
-          (struct_id 54)))))
+          (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -1682,28 +2297,28 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (55 ())))) (Empty (Value (Type (StructType 55))))
-        (Make (Value (Type (InterfaceType 53))))))
+       ((empty (Value (Struct (58 ())))) (Empty (Value (Type (StructType 58))))
+        (Make (Value (Type (InterfaceType 56))))))
       (structs
-       ((55
+       ((58
          ((struct_fields ())
           (struct_methods
            ((new
              ((function_signature
-               ((function_params ()) (function_returns (StructType 55))))
-              (function_impl (Fn ((Return (Value (Struct (55 ())))))))))))
+               ((function_params ()) (function_returns (StructType 58))))
+              (function_impl (Fn ((Return (Value (Struct (58 ())))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 53))))
+           (((impl_interface (Value (Type (InterfaceType 56))))
              (impl_methods
               ((new
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 55))))
-                   (function_impl (Fn ((Return (Value (Struct (55 ()))))))))))))))))
-          (struct_id 55)))))
+                    ((function_params ()) (function_returns (StructType 58))))
+                   (function_impl (Fn ((Return (Value (Struct (58 ()))))))))))))))))
+          (struct_id 58)))))
       (interfaces
-       ((53
+       ((56
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
@@ -1725,7 +2340,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 56)) (b (StructType 3))))
+             ((function_params ((self (StructType 59)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -1737,7 +2352,7 @@ let%expect_test "serializer inner struct" =
                        (Function
                         ((function_signature
                           ((function_params
-                            ((self (StructType 43)) (builder (StructType 3))))
+                            ((self (StructType 46)) (builder (StructType 3))))
                            (function_returns (StructType 3))))
                          (function_impl
                           (Fn
@@ -1746,24 +2361,24 @@ let%expect_test "serializer inner struct" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 43))) value
+                                 ((Reference (self (StructType 46))) value
                                   IntegerType))
                                 (Value (Integer 32))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 56))) y (StructType 43)))
+                        ((Reference (self (StructType 59))) y (StructType 46)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (Outer (Value (Type (StructType 56))))
-        (Inner (Value (Type (StructType 54))))))
+        (Outer (Value (Type (StructType 59))))
+        (Inner (Value (Type (StructType 57))))))
       (structs
-       ((56
+       ((59
          ((struct_fields
-           ((y ((field_type (StructType 43))))
-            (z ((field_type (StructType 54))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 56)))
-        (54
-         ((struct_fields ((x ((field_type (StructType 43))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 54)))))
+           ((y ((field_type (StructType 46))))
+            (z ((field_type (StructType 57))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 59)))
+        (57
+         ((struct_fields ((x ((field_type (StructType 46))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -1909,24 +2524,24 @@ let%expect_test "union variants constructing" =
     (Ok
      ((bindings
        ((b
-         (Value (UnionVariant ((Struct (43 ((value (Value (Integer 1)))))) 54))))
-        (a (Value (UnionVariant ((Integer 10) 54))))
+         (Value (UnionVariant ((Struct (46 ((value (Value (Integer 1)))))) 57))))
+        (a (Value (UnionVariant ((Integer 10) 57))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 54))))
-              (function_returns (UnionType 54))))
-            (function_impl (Fn ((Return (Reference (value (UnionType 54)))))))))))
-        (Uni (Value (Type (UnionType 54))))))
+             ((function_params ((value (UnionType 57))))
+              (function_returns (UnionType 57))))
+            (function_impl (Fn ((Return (Reference (value (UnionType 57)))))))))))
+        (Uni (Value (Type (UnionType 57))))))
       (structs ())
       (unions
-       ((54
+       ((57
          ((cases
-           (((StructType 43) (Discriminator 0)) (IntegerType (Discriminator 1))))
+           (((StructType 46) (Discriminator 0)) (IntegerType (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
@@ -1934,35 +2549,35 @@ let%expect_test "union variants constructing" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type IntegerType))))))
-                     (function_returns (UnionType 54))))
+                     (function_returns (UnionType 57))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference (v (ExprType (Value (Type IntegerType)))))
-                         54)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 55))))
+                         57)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 58))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 43)))))))
-                     (function_returns (UnionType 54))))
+                      ((v (ExprType (Value (Type (StructType 46)))))))
+                     (function_returns (UnionType 57))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 43))))))
-                         54)))))))))))))))
-          (union_id 54)))))
+                          (v (ExprType (Value (Type (StructType 46))))))
+                         57)))))))))))))))
+          (union_id 57)))))
       (interfaces
-       ((55
+       ((58
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 43))))
+             ((function_params ((from (StructType 46))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -1985,7 +2600,7 @@ let%expect_test "unions duplicate variant" =
     (Error
      (((DuplicateVariant IntegerType)
        ((bindings
-         ((b (Value (Type (UnionType 56)))) (a (Value (Type (UnionType 54))))
+         ((b (Value (Type (UnionType 59)))) (a (Value (Type (UnionType 57))))
           (Test
            (Value
             (Function
@@ -2014,14 +2629,14 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 53))))
+                               (function_returns (UnionType 56))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Value
                                     (Type (ExprType (Reference (v IntegerType)))))
-                                   53)))))))))))))
+                                   56)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -2037,7 +2652,7 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v (Dependent T (TypeN 0)))))
-                               (function_returns (UnionType 53))))
+                               (function_returns (UnionType 56))))
                              (function_impl
                               (Fn
                                ((Return
@@ -2047,8 +2662,8 @@ let%expect_test "unions duplicate variant" =
                                      (ExprType
                                       (Reference
                                        (v (ExprType (Reference (T (TypeN 0)))))))))
-                                   53)))))))))))))))
-                    (mk_union_id 53)))))))
+                                   56)))))))))))))))
+                    (mk_union_id 56)))))))
               (function_impl
                (Fn
                 ((Return
@@ -2073,12 +2688,12 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 53))))
+                               (function_returns (UnionType 56))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
-                                  ((Reference (v IntegerType)) 53)))))))))))))
+                                  ((Reference (v IntegerType)) 56)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -2095,33 +2710,33 @@ let%expect_test "unions duplicate variant" =
                             ((function_signature
                               ((function_params
                                 ((v (ExprType (Reference (T (TypeN 0)))))))
-                               (function_returns (UnionType 53))))
+                               (function_returns (UnionType 56))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Reference
                                     (v (ExprType (Reference (T (TypeN 0))))))
-                                   53)))))))))))))))
-                    (mk_union_id 53)))))))))))))
+                                   56)))))))))))))))
+                    (mk_union_id 56)))))))))))))
         (structs ())
         (unions
-         ((56
+         ((59
            ((cases ((IntegerType (Discriminator 0)))) (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 56))))
+                       (function_returns (UnionType 59))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 56)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 10))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 59)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
@@ -2129,33 +2744,33 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 56))))
+                       (function_returns (UnionType 59))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           56)))))))))))))))
-            (union_id 56)))
-          (54
+                           59)))))))))))))))
+            (union_id 59)))
+          (57
            ((cases
              (((BuiltinType Builder) (Discriminator 0))
               (IntegerType (Discriminator 1))))
             (union_methods ())
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 54))))
+                       (function_returns (UnionType 57))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 54)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 55))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 57)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 58))))
                (impl_methods
                 ((from
                   (Value
@@ -2163,16 +2778,16 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 54))))
+                       (function_returns (UnionType 57))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           54)))))))))))))))
-            (union_id 54)))))
+                           57)))))))))))))))
+            (union_id 57)))))
         (interfaces
-         ((55
+         ((58
            ((interface_methods
              ((from
                ((function_params ((from (BuiltinType Builder))))
@@ -2195,23 +2810,23 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings ((Test (Value (Type (UnionType 55))))))
+     ((bindings ((Test (Value (Type (UnionType 58))))))
       (structs
-       ((53
+       ((56
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 53)) (builder (StructType 3))))
+                 ((self (StructType 56)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -2220,12 +2835,12 @@ let%expect_test "unions" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 53))) value IntegerType))
+                      ((Reference (self (StructType 56))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
                ((function_params ((s (StructType 7))))
-                (function_returns (StructType 9))))
+                (function_returns (StructType 12))))
               (function_impl
                (Fn
                 ((Block
@@ -2237,14 +2852,14 @@ let%expect_test "unions" =
                    (Return
                     (Value
                      (Struct
-                      (9
+                      (12
                        ((slice
                          (StructField
                           ((Reference (res (StructType 6))) slice (StructType 7))))
                         (value
                          (Value
                           (Struct
-                           (53
+                           (56
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -2252,81 +2867,132 @@ let%expect_test "unions" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 53))))
+                (function_returns (StructType 56))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 10))))
+           (((impl_interface (Value (Type (InterfaceType 8))))
+             (impl_methods
+              ((serialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 56)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     ((Return
+                       (FunctionCall
+                        ((ResolvedReference (serialize_int <opaque>))
+                         ((Reference (builder (StructType 3)))
+                          (StructField
+                           ((Reference (self (StructType 56))) value IntegerType))
+                          (Value (Integer 257))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 10))))
+             (impl_methods
+              ((deserialize
+                (Value
+                 (Function
+                  ((function_signature
+                    ((function_params ((s (StructType 7))))
+                     (function_returns (StructType 12))))
+                   (function_impl
+                    (Fn
+                     ((Block
+                       ((Let
+                         ((res
+                           (FunctionCall
+                            ((ResolvedReference (load_int <opaque>))
+                             ((Reference (s (StructType 7)))
+                              (Value (Integer 257))))))))
+                        (Return
+                         (Value
+                          (Struct
+                           (12
+                            ((slice
+                              (StructField
+                               ((Reference (res (StructType 6))) slice
+                                (StructType 7))))
+                             (value
+                              (Value
+                               (Struct
+                                (56
+                                 ((value
+                                   (StructField
+                                    ((Reference (res (StructType 6))) value
+                                     IntegerType)))))))))))))))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 13))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 53))))
+                     (function_returns (StructType 56))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 53)))))
+                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 56)))))
       (unions
-       ((55
+       ((58
          ((cases
-           (((StructType 42) (Discriminator 0))
-            ((StructType 53) (Discriminator 1))))
+           (((StructType 45) (Discriminator 0))
+            ((StructType 56) (Discriminator 1))))
           (union_methods
            ((id
              ((function_signature
-               ((function_params ((self (UnionType 55))))
-                (function_returns (UnionType 55))))
-              (function_impl (Fn ((Return (Reference (self (UnionType 55)))))))))))
+               ((function_params ((self (UnionType 58))))
+                (function_returns (UnionType 58))))
+              (function_impl (Fn ((Return (Reference (self (UnionType 58)))))))))))
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 56))))
+           (((impl_interface (Value (Type (InterfaceType 59))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 53)))))))
-                     (function_returns (UnionType 55))))
+                      ((v (ExprType (Value (Type (StructType 56)))))))
+                     (function_returns (UnionType 58))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 53))))))
-                         55)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 57))))
+                          (v (ExprType (Value (Type (StructType 56))))))
+                         58)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 60))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 42)))))))
-                     (function_returns (UnionType 55))))
+                      ((v (ExprType (Value (Type (StructType 45)))))))
+                     (function_returns (UnionType 58))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 42))))))
-                         55)))))))))))))))
-          (union_id 55)))))
+                          (v (ExprType (Value (Type (StructType 45))))))
+                         58)))))))))))))))
+          (union_id 58)))))
       (interfaces
-       ((57
+       ((60
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 42))))
+             ((function_params ((from (StructType 45))))
               (function_returns SelfType)))))))
-        (56
+        (59
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 53))))
+             ((function_params ((from (StructType 56))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2351,9 +3017,9 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct (56 ())))) (foo_empty (Value (Struct (57 ()))))
-        (Empty (Value (Type (StructType 56)))) (x (Value (Integer 10)))
-        (foo (Value (Struct (54 ()))))
+       ((y (Value (Struct (59 ())))) (foo_empty (Value (Struct (60 ()))))
+        (Empty (Value (Type (StructType 59)))) (x (Value (Integer 10)))
+        (foo (Value (Struct (57 ()))))
         (Foo
          (Value
           (Function
@@ -2369,36 +3035,36 @@ let%expect_test "methods monomorphization" =
                      (MkFunction
                       ((function_signature
                         ((function_params
-                          ((self (StructType 53))
+                          ((self (StructType 56))
                            (x (ExprType (Reference (X (TypeN 0)))))))
                          (function_returns (ExprType (Reference (X (TypeN 0)))))))
                        (function_impl
                         (Fn
                          ((Return
                            (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))
-                  (mk_impls ()) (mk_struct_id 53)))))))))))))
+                  (mk_impls ()) (mk_struct_id 56)))))))))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 57)) (x (StructType 56))))
-                (function_returns (StructType 56))))
-              (function_impl (Fn ((Return (Reference (x (StructType 56)))))))))))
-          (struct_impls ()) (struct_id 57)))
-        (56
+               ((function_params ((self (StructType 60)) (x (StructType 59))))
+                (function_returns (StructType 59))))
+              (function_impl (Fn ((Return (Reference (x (StructType 59)))))))))))
+          (struct_impls ()) (struct_id 60)))
+        (59
          ((struct_fields ()) (struct_methods ()) (struct_impls ())
-          (struct_id 56)))
-        (54
+          (struct_id 59)))
+        (57
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 54)) (x IntegerType)))
+               ((function_params ((self (StructType 57)) (x IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (x IntegerType))))))))))
-          (struct_impls ()) (struct_id 54)))))
+          (struct_impls ()) (struct_id 57)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -2428,70 +3094,70 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 54))))
+             ((function_params ((i (UnionType 57))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               ((Break
                 (Switch
-                 ((switch_condition (Reference (i (UnionType 54))))
+                 ((switch_condition (Reference (i (UnionType 57))))
                   (branches
-                   (((branch_ty (StructType 43)) (branch_var vax)
+                   (((branch_ty (StructType 46)) (branch_var vax)
                      (branch_stmt (Block ((Return (Value (Integer 32)))))))
-                    ((branch_ty (StructType 42)) (branch_var vax)
+                    ((branch_ty (StructType 45)) (branch_var vax)
                      (branch_stmt (Block ((Return (Value (Integer 64)))))))))))))))))))
-        (Ints (Value (Type (UnionType 54))))))
+        (Ints (Value (Type (UnionType 57))))))
       (structs ())
       (unions
-       ((54
+       ((57
          ((cases
-           (((StructType 42) (Discriminator 0))
-            ((StructType 43) (Discriminator 1))))
+           (((StructType 45) (Discriminator 0))
+            ((StructType 46) (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 55))))
+           (((impl_interface (Value (Type (InterfaceType 58))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 43)))))))
-                     (function_returns (UnionType 54))))
+                      ((v (ExprType (Value (Type (StructType 46)))))))
+                     (function_returns (UnionType 57))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 43))))))
-                         54)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 56))))
+                          (v (ExprType (Value (Type (StructType 46))))))
+                         57)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 59))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 42)))))))
-                     (function_returns (UnionType 54))))
+                      ((v (ExprType (Value (Type (StructType 45)))))))
+                     (function_returns (UnionType 57))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 42))))))
-                         54)))))))))))))))
-          (union_id 54)))))
+                          (v (ExprType (Value (Type (StructType 45))))))
+                         57)))))))))))))))
+          (union_id 57)))))
       (interfaces
-       ((56
+       ((59
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 42))))
+             ((function_params ((from (StructType 45))))
               (function_returns SelfType)))))))
-        (55
+        (58
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 43))))
+             ((function_params ((from (StructType 46))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -2568,24 +3234,24 @@ let%expect_test "let binding with type" =
     {|
       (Ok
        ((bindings
-         ((a (Value (Struct (43 ((value (Value (Integer 2))))))))
-          (a (Value (Struct (53 ((value (Value (Integer 1))))))))))
+         ((a (Value (Struct (46 ((value (Value (Integer 2))))))))
+          (a (Value (Struct (56 ((value (Value (Integer 1))))))))))
         (structs
-         ((53
+         ((56
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 53)) (builder (StructType 3))))
+                   ((self (StructType 56)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2594,12 +3260,12 @@ let%expect_test "let binding with type" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 53))) value IntegerType))
+                        ((Reference (self (StructType 56))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 9))))
+                  (function_returns (StructType 12))))
                 (function_impl
                  (Fn
                   ((Block
@@ -2611,14 +3277,14 @@ let%expect_test "let binding with type" =
                      (Return
                       (Value
                        (Struct
-                        (9
+                        (12
                          ((slice
                            (StructField
                             ((Reference (res (StructType 6))) slice (StructType 7))))
                           (value
                            (Value
                             (Struct
-                             (53
+                             (56
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -2626,26 +3292,77 @@ let%expect_test "let binding with type" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 53))))
+                  (function_returns (StructType 56))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (53 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
-             (((impl_interface (Value (Type (InterfaceType 10))))
+             (((impl_interface (Value (Type (InterfaceType 8))))
+               (impl_methods
+                ((serialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 56)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       ((Return
+                         (FunctionCall
+                          ((ResolvedReference (serialize_int <opaque>))
+                           ((Reference (builder (StructType 3)))
+                            (StructField
+                             ((Reference (self (StructType 56))) value IntegerType))
+                            (Value (Integer 257))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 10))))
+               (impl_methods
+                ((deserialize
+                  (Value
+                   (Function
+                    ((function_signature
+                      ((function_params ((s (StructType 7))))
+                       (function_returns (StructType 12))))
+                     (function_impl
+                      (Fn
+                       ((Block
+                         ((Let
+                           ((res
+                             (FunctionCall
+                              ((ResolvedReference (load_int <opaque>))
+                               ((Reference (s (StructType 7)))
+                                (Value (Integer 257))))))))
+                          (Return
+                           (Value
+                            (Struct
+                             (12
+                              ((slice
+                                (StructField
+                                 ((Reference (res (StructType 6))) slice
+                                  (StructType 7))))
+                               (value
+                                (Value
+                                 (Struct
+                                  (56
+                                   ((value
+                                     (StructField
+                                      ((Reference (res (StructType 6))) value
+                                       IntegerType)))))))))))))))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 53))))
+                       (function_returns (StructType 56))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (53 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 53)))))
+                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 56)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)))
       |}]
 
@@ -2691,7 +3408,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 55))))
+             ((function_params ((t (StructType 58))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -2700,18 +3417,18 @@ let%expect_test "interface constraints" =
                  ((Value
                    (Function
                     ((function_signature
-                      ((function_params ((self (StructType 55))))
+                      ((function_params ((self (StructType 58))))
                        (function_returns IntegerType)))
                      (function_impl (Fn ((Return (Value (Integer 1)))))))))
-                  ((Reference (t (StructType 55))))))))))))))
+                  ((Reference (t (StructType 58))))))))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 53))))
+             ((function_params ((T (InterfaceType 56))))
               (function_returns
                (FunctionType
-                ((function_params ((t (Dependent T (InterfaceType 53)))))
+                ((function_params ((t (Dependent T (InterfaceType 56)))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -2719,45 +3436,45 @@ let%expect_test "interface constraints" =
                 (MkFunction
                  ((function_signature
                    ((function_params
-                     ((t (ExprType (Reference (T (InterfaceType 53)))))))
+                     ((t (ExprType (Reference (T (InterfaceType 56)))))))
                     (function_returns IntegerType)))
                   (function_impl
                    (Fn
                     ((Return
                       (IntfMethodCall
-                       ((intf_instance (Reference (T (InterfaceType 53))))
-                        (intf_def 53)
+                       ((intf_instance (Reference (T (InterfaceType 56))))
+                        (intf_def 56)
                         (intf_method
                          (beep
                           ((function_params ((self SelfType)))
                            (function_returns IntegerType))))
                         (intf_args
                          ((Reference
-                           (t (ExprType (Reference (T (InterfaceType 53))))))))))))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 55))))
-        (Beep (Value (Type (InterfaceType 53))))))
+                           (t (ExprType (Reference (T (InterfaceType 56))))))))))))))))))))))))
+        (BeeperImpl1 (Value (Type (StructType 58))))
+        (Beep (Value (Type (InterfaceType 56))))))
       (structs
-       ((55
+       ((58
          ((struct_fields ())
           (struct_methods
            ((beep
              ((function_signature
-               ((function_params ((self (StructType 55))))
+               ((function_params ((self (StructType 58))))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Value (Integer 1))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 53))))
+           (((impl_interface (Value (Type (InterfaceType 56))))
              (impl_methods
               ((beep
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ((self (StructType 55))))
+                    ((function_params ((self (StructType 58))))
                      (function_returns IntegerType)))
                    (function_impl (Fn ((Return (Value (Integer 1)))))))))))))))
-          (struct_id 55)))))
+          (struct_id 58)))))
       (interfaces
-       ((53
+       ((56
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -34,23 +34,23 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 56))))))
+     ((bindings ((T (Value (Type (StructType 59))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -59,7 +59,7 @@ let%expect_test "scope resolution" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -83,7 +83,7 @@ let%expect_test "scope resolution" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -91,11 +91,11 @@ let%expect_test "scope resolution" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -104,7 +104,7 @@ let%expect_test "scope resolution" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -113,7 +113,7 @@ let%expect_test "scope resolution" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -143,7 +143,7 @@ let%expect_test "scope resolution" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -155,13 +155,13 @@ let%expect_test "scope resolution" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "binding resolution" =
@@ -172,23 +172,23 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 56))))))
+     ((bindings ((T (Value (Type (StructType 59))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -197,7 +197,7 @@ let%expect_test "binding resolution" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -221,7 +221,7 @@ let%expect_test "binding resolution" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -229,11 +229,11 @@ let%expect_test "binding resolution" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -242,7 +242,7 @@ let%expect_test "binding resolution" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -251,7 +251,7 @@ let%expect_test "binding resolution" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -281,7 +281,7 @@ let%expect_test "binding resolution" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -293,13 +293,13 @@ let%expect_test "binding resolution" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
@@ -324,23 +324,23 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 56)))) (A (Value (Type (StructType 56))))))
+       ((B (Value (Type (StructType 59)))) (A (Value (Type (StructType 59))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -349,7 +349,7 @@ let%expect_test "scope resolution after let binding" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -373,7 +373,7 @@ let%expect_test "scope resolution after let binding" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -381,11 +381,11 @@ let%expect_test "scope resolution after let binding" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -394,7 +394,7 @@ let%expect_test "scope resolution after let binding" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -403,7 +403,7 @@ let%expect_test "scope resolution after let binding" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -433,7 +433,7 @@ let%expect_test "scope resolution after let binding" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -445,13 +445,13 @@ let%expect_test "scope resolution after let binding" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
@@ -462,26 +462,26 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 58))))))
+     ((bindings ((T (Value (Type (StructType 61))))))
       (structs
-       ((58
-         ((struct_fields ((t ((field_type (StructType 56))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 58)))
-        (56
+       ((61
+         ((struct_fields ((t ((field_type (StructType 59))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 61)))
+        (59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -490,7 +490,7 @@ let%expect_test "basic struct definition" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -514,7 +514,7 @@ let%expect_test "basic struct definition" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -522,11 +522,11 @@ let%expect_test "basic struct definition" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -535,7 +535,7 @@ let%expect_test "basic struct definition" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -544,7 +544,7 @@ let%expect_test "basic struct definition" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -574,7 +574,7 @@ let%expect_test "basic struct definition" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -586,13 +586,13 @@ let%expect_test "basic struct definition" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "native function evaluation" =
@@ -623,30 +623,30 @@ let%expect_test "Tact function evaluation" =
     {|
     (Ok
      ((bindings
-       ((a (Value (Struct (56 ((value (Value (Integer 1))))))))
+       ((a (Value (Struct (59 ((value (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 56))))
-              (function_returns (StructType 56))))
-            (function_impl (Fn ((Return (Reference (i (StructType 56)))))))))))))
+             ((function_params ((i (StructType 59))))
+              (function_returns (StructType 59))))
+            (function_impl (Fn ((Return (Reference (i (StructType 59)))))))))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -655,7 +655,7 @@ let%expect_test "Tact function evaluation" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -679,7 +679,7 @@ let%expect_test "Tact function evaluation" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -687,11 +687,11 @@ let%expect_test "Tact function evaluation" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -700,7 +700,7 @@ let%expect_test "Tact function evaluation" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -709,7 +709,7 @@ let%expect_test "Tact function evaluation" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -739,7 +739,7 @@ let%expect_test "Tact function evaluation" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -751,13 +751,13 @@ let%expect_test "Tact function evaluation" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "compile-time function evaluation within a function" =
@@ -802,27 +802,27 @@ let%expect_test "struct definition" =
   [%expect
     {|
       (Ok
-       ((bindings ((MyType (Value (Type (StructType 58))))))
+       ((bindings ((MyType (Value (Type (StructType 61))))))
         (structs
-         ((58
+         ((61
            ((struct_fields
-             ((a ((field_type (StructType 56)))) (b ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 58)))
-          (56
+             ((a ((field_type (StructType 59)))) (b ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 61)))
+          (59
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 56)) (builder (StructType 3))))
+                   ((self (StructType 59)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -831,7 +831,7 @@ let%expect_test "struct definition" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 56))) value IntegerType))
+                        ((Reference (self (StructType 59))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
@@ -855,7 +855,7 @@ let%expect_test "struct definition" =
                           (value
                            (Value
                             (Struct
-                             (56
+                             (59
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -863,11 +863,11 @@ let%expect_test "struct definition" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
              (((impl_interface (Value (Type (InterfaceType 8))))
                (impl_methods
@@ -876,7 +876,7 @@ let%expect_test "struct definition" =
                    (Function
                     ((function_signature
                       ((function_params
-                        ((self (StructType 56)) (builder (StructType 3))))
+                        ((self (StructType 59)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -885,7 +885,7 @@ let%expect_test "struct definition" =
                           ((ResolvedReference (serialize_int <opaque>))
                            ((Reference (builder (StructType 3)))
                             (StructField
-                             ((Reference (self (StructType 56))) value IntegerType))
+                             ((Reference (self (StructType 59))) value IntegerType))
                             (Value (Integer 257))))))))))))))))
               ((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
@@ -915,7 +915,7 @@ let%expect_test "struct definition" =
                                (value
                                 (Value
                                  (Struct
-                                  (56
+                                  (59
                                    ((value
                                      (StructField
                                       ((Reference (res (StructType 6))) value
@@ -927,13 +927,13 @@ let%expect_test "struct definition" =
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 56))))
+                       (function_returns (StructType 59))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 56)))))
+                          (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 59)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -952,29 +952,29 @@ let%expect_test "duplicate type field" =
      (((DuplicateField
         (a
          ((mk_struct_fields
-           ((a (Value (Type (StructType 56)))) (a (Value (Type BoolType)))))
+           ((a (Value (Type (StructType 59)))) (a (Value (Type BoolType)))))
           (mk_methods ()) (mk_impls ()) (mk_struct_id -1))))
-       ((bindings ((MyType (Value (Type (StructType 58))))))
+       ((bindings ((MyType (Value (Type (StructType 61))))))
         (structs
-         ((58
+         ((61
            ((struct_fields
-             ((a ((field_type (StructType 56)))) (a ((field_type BoolType)))))
-            (struct_methods ()) (struct_impls ()) (struct_id 58)))
-          (56
+             ((a ((field_type (StructType 59)))) (a ((field_type BoolType)))))
+            (struct_methods ()) (struct_impls ()) (struct_id 61)))
+          (59
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 56)) (builder (StructType 3))))
+                   ((self (StructType 59)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -983,7 +983,7 @@ let%expect_test "duplicate type field" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 56))) value IntegerType))
+                        ((Reference (self (StructType 59))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
@@ -1008,7 +1008,7 @@ let%expect_test "duplicate type field" =
                           (value
                            (Value
                             (Struct
-                             (56
+                             (59
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -1016,11 +1016,11 @@ let%expect_test "duplicate type field" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
              (((impl_interface (Value (Type (InterfaceType 8))))
                (impl_methods
@@ -1029,7 +1029,7 @@ let%expect_test "duplicate type field" =
                    (Function
                     ((function_signature
                       ((function_params
-                        ((self (StructType 56)) (builder (StructType 3))))
+                        ((self (StructType 59)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -1038,7 +1038,7 @@ let%expect_test "duplicate type field" =
                           ((ResolvedReference (serialize_int <opaque>))
                            ((Reference (builder (StructType 3)))
                             (StructField
-                             ((Reference (self (StructType 56))) value
+                             ((Reference (self (StructType 59))) value
                               IntegerType))
                             (Value (Integer 257))))))))))))))))
               ((impl_interface (Value (Type (InterfaceType 10))))
@@ -1069,7 +1069,7 @@ let%expect_test "duplicate type field" =
                                (value
                                 (Value
                                  (Struct
-                                  (56
+                                  (59
                                    ((value
                                      (StructField
                                       ((Reference (res (StructType 6))) value
@@ -1081,13 +1081,13 @@ let%expect_test "duplicate type field" =
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 56))))
+                       (function_returns (StructType 59))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 56)))))
+                          (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 59)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -1102,7 +1102,7 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 58))))
+       ((TA (Value (Type (StructType 61))))
         (T
          (Value
           (Function
@@ -1113,26 +1113,26 @@ let%expect_test "parametric struct instantiation" =
               ((Expr
                 (MkStructDef
                  ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                  (mk_methods ()) (mk_impls ()) (mk_struct_id 56)))))))))))))
+                  (mk_methods ()) (mk_impls ()) (mk_struct_id 59)))))))))))))
       (structs
-       ((58
-         ((struct_fields ((a ((field_type (StructType 57))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 58)))
-        (57
+       ((61
+         ((struct_fields ((a ((field_type (StructType 60))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 61)))
+        (60
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 57))))
+                (function_returns (StructType 60))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (60 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 57)) (builder (StructType 3))))
+                 ((self (StructType 60)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -1141,7 +1141,7 @@ let%expect_test "parametric struct instantiation" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 57))) value IntegerType))
+                      ((Reference (self (StructType 60))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -1165,7 +1165,7 @@ let%expect_test "parametric struct instantiation" =
                         (value
                          (Value
                           (Struct
-                           (57
+                           (60
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -1173,11 +1173,11 @@ let%expect_test "parametric struct instantiation" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 57))))
+                (function_returns (StructType 60))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (60 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -1186,7 +1186,7 @@ let%expect_test "parametric struct instantiation" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 57)) (builder (StructType 3))))
+                      ((self (StructType 60)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1195,7 +1195,7 @@ let%expect_test "parametric struct instantiation" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 57))) value IntegerType))
+                           ((Reference (self (StructType 60))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -1225,7 +1225,7 @@ let%expect_test "parametric struct instantiation" =
                              (value
                               (Value
                                (Struct
-                                (57
+                                (60
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -1237,13 +1237,13 @@ let%expect_test "parametric struct instantiation" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 57))))
+                     (function_returns (StructType 60))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (57 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 57)))))
+                        (Struct (60 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -1280,34 +1280,34 @@ let%expect_test "scoping that `let` introduces in code" =
     {|
     (Ok
      ((bindings
-       ((b (Value (Struct (56 ((value (Value (Integer 1))))))))
+       ((b (Value (Struct (59 ((value (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 56))))
-              (function_returns (StructType 56))))
+             ((function_params ((i (StructType 59))))
+              (function_returns (StructType 59))))
             (function_impl
              (Fn
               ((Block
-                ((Let ((a (Reference (i (StructType 56))))))
-                 (Return (Reference (a (StructType 56)))))))))))))))
+                ((Let ((a (Reference (i (StructType 59))))))
+                 (Return (Reference (a (StructType 59)))))))))))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -1316,7 +1316,7 @@ let%expect_test "scoping that `let` introduces in code" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -1340,7 +1340,7 @@ let%expect_test "scoping that `let` introduces in code" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -1348,11 +1348,11 @@ let%expect_test "scoping that `let` introduces in code" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -1361,7 +1361,7 @@ let%expect_test "scoping that `let` introduces in code" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1370,7 +1370,7 @@ let%expect_test "scoping that `let` introduces in code" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -1400,7 +1400,7 @@ let%expect_test "scoping that `let` introduces in code" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -1412,13 +1412,13 @@ let%expect_test "scoping that `let` introduces in code" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
@@ -1443,7 +1443,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 56))))
+             ((function_params ((x (StructType 59))))
               (function_returns HoleType)))
             (function_impl
              (Fn
@@ -1452,37 +1452,37 @@ let%expect_test "reference in function bodies" =
                   ((a
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (x (StructType 56)))
-                       (Reference (x (StructType 56)))))))))
+                      ((Reference (x (StructType 59)))
+                       (Reference (x (StructType 59)))))))))
                  (Let
                   ((b
                     (FunctionCall
                      ((ResolvedReference (op <opaque>))
-                      ((Reference (a (StructType 56)))
-                       (Reference (a (StructType 56))))))))))))))))))
+                      ((Reference (a (StructType 59)))
+                       (Reference (a (StructType 59))))))))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 56)) (i_ (StructType 56))))
-              (function_returns (StructType 56))))
-            (function_impl (Fn ((Return (Reference (i (StructType 56)))))))))))))
+             ((function_params ((i (StructType 59)) (i_ (StructType 59))))
+              (function_returns (StructType 59))))
+            (function_impl (Fn ((Return (Reference (i (StructType 59)))))))))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -1491,7 +1491,7 @@ let%expect_test "reference in function bodies" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -1515,7 +1515,7 @@ let%expect_test "reference in function bodies" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -1523,11 +1523,11 @@ let%expect_test "reference in function bodies" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -1536,7 +1536,7 @@ let%expect_test "reference in function bodies" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1545,7 +1545,7 @@ let%expect_test "reference in function bodies" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -1575,7 +1575,7 @@ let%expect_test "reference in function bodies" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -1587,13 +1587,13 @@ let%expect_test "reference in function bodies" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
@@ -1638,18 +1638,18 @@ let%expect_test "struct method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (Struct (57 ()))))
-        (Foo (Value (Type (StructType 57))))))
+       ((res (Value (Integer 1))) (foo (Value (Struct (60 ()))))
+        (Foo (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 57)) (i IntegerType)))
+               ((function_params ((self (StructType 60)) (i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
-          (struct_impls ()) (struct_id 57)))))
+          (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -1667,9 +1667,9 @@ let%expect_test "struct type method access" =
   [%expect
     {|
     (Ok
-     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 57))))))
+     ((bindings ((res (Value (Integer 1))) (Foo (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ())
           (struct_methods
            ((bar
@@ -1677,7 +1677,7 @@ let%expect_test "struct type method access" =
                ((function_params ((i IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
-          (struct_impls ()) (struct_id 57)))))
+          (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -1694,17 +1694,17 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 57))))))
+     ((bindings ((Foo (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ())
           (struct_methods
            ((bar
              ((function_signature
-               ((function_params ((self (StructType 57))))
-                (function_returns (StructType 57))))
-              (function_impl (Fn ((Return (Reference (self (StructType 57)))))))))))
-          (struct_impls ()) (struct_id 57)))))
+               ((function_params ((self (StructType 60))))
+                (function_returns (StructType 60))))
+              (function_impl (Fn ((Return (Reference (self (StructType 60)))))))))))
+          (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -1728,42 +1728,42 @@ let%expect_test "union method access" =
     {|
       (Ok
        ((bindings
-         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 57))))
+         ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 60))))
           (make_foo
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 57))))
-                (function_returns (UnionType 57))))
-              (function_impl (Fn ((Return (Reference (foo (UnionType 57)))))))))))
-          (Foo (Value (Type (UnionType 57))))))
+               ((function_params ((foo (UnionType 60))))
+                (function_returns (UnionType 60))))
+              (function_impl (Fn ((Return (Reference (foo (UnionType 60)))))))))))
+          (Foo (Value (Type (UnionType 60))))))
         (structs ())
         (unions
-         ((57
+         ((60
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (UnionType 57)) (i IntegerType)))
+                 ((function_params ((self (UnionType 60)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 58))))
+             (((impl_interface (Value (Type (InterfaceType 61))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 57))))
+                       (function_returns (UnionType 60))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 57)))))))))))))))
-            (union_id 57)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 60)))))))))))))))
+            (union_id 60)))))
         (interfaces
-         ((58
+         ((61
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1795,13 +1795,13 @@ let%expect_test "union type method access" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((foo (UnionType 57))))
-                (function_returns (UnionType 57))))
-              (function_impl (Fn ((Return (Reference (foo (UnionType 57)))))))))))
-          (Foo (Value (Type (UnionType 57))))))
+               ((function_params ((foo (UnionType 60))))
+                (function_returns (UnionType 60))))
+              (function_impl (Fn ((Return (Reference (foo (UnionType 60)))))))))))
+          (Foo (Value (Type (UnionType 60))))))
         (structs ())
         (unions
-         ((57
+         ((60
            ((cases ((BoolType (Discriminator 0))))
             (union_methods
              ((bar
@@ -1810,22 +1810,22 @@ let%expect_test "union type method access" =
                   (function_returns IntegerType)))
                 (function_impl (Fn ((Return (Reference (i IntegerType))))))))))
             (union_impls
-             (((impl_interface (Value (Type (InterfaceType 58))))
+             (((impl_interface (Value (Type (InterfaceType 61))))
                (impl_methods
                 ((from
                   (Value
                    (Function
                     ((function_signature
                       ((function_params ((v (ExprType (Value (Type BoolType))))))
-                       (function_returns (UnionType 57))))
+                       (function_returns (UnionType 60))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
-                          ((Reference (v (ExprType (Value (Type BoolType))))) 57)))))))))))))))
-            (union_id 57)))))
+                          ((Reference (v (ExprType (Value (Type BoolType))))) 60)))))))))))))))
+            (union_id 60)))))
         (interfaces
-         ((58
+         ((61
            ((interface_methods
              ((from
                ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -1849,13 +1849,13 @@ let%expect_test "struct instantiation" =
     (Ok
      ((bindings
        ((t
-         (Value (Struct (57 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 57))))))
+         (Value (Struct (60 ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_methods ()) (struct_impls ()) (struct_id 57)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -1877,7 +1877,7 @@ let%expect_test "type check error" =
               (function_impl (Fn ((Return (Reference (i (StructType 46)))))))))))))
         (structs ())
         (interfaces
-         ((56
+         ((59
            ((interface_methods
              ((from
                ((function_params ((from (StructType 46))))
@@ -1972,24 +1972,24 @@ let%expect_test "type check error" =
   [%expect
     {|
     (Error
-     (((TypeError ((StructType 56) (StructType 57)))
+     (((TypeError ((StructType 59) (StructType 60)))
        ((bindings ())
         (structs
-         ((57
+         ((60
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 57))))
+                  (function_returns (StructType 60))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (60 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 57)) (builder (StructType 3))))
+                   ((self (StructType 60)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1998,7 +1998,7 @@ let%expect_test "type check error" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 57))) value IntegerType))
+                        ((Reference (self (StructType 60))) value IntegerType))
                        (Value (Integer 10)))))))))))
               (deserialize
                ((function_signature
@@ -2023,7 +2023,7 @@ let%expect_test "type check error" =
                           (value
                            (Value
                             (Struct
-                             (57
+                             (60
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -2031,11 +2031,11 @@ let%expect_test "type check error" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 57))))
+                  (function_returns (StructType 60))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (57 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (60 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
              (((impl_interface (Value (Type (InterfaceType 8))))
                (impl_methods
@@ -2044,7 +2044,7 @@ let%expect_test "type check error" =
                    (Function
                     ((function_signature
                       ((function_params
-                        ((self (StructType 57)) (builder (StructType 3))))
+                        ((self (StructType 60)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -2053,7 +2053,7 @@ let%expect_test "type check error" =
                           ((ResolvedReference (serialize_int <opaque>))
                            ((Reference (builder (StructType 3)))
                             (StructField
-                             ((Reference (self (StructType 57))) value
+                             ((Reference (self (StructType 60))) value
                               IntegerType))
                             (Value (Integer 10))))))))))))))))
               ((impl_interface (Value (Type (InterfaceType 10))))
@@ -2084,7 +2084,7 @@ let%expect_test "type check error" =
                                (value
                                 (Value
                                  (Struct
-                                  (57
+                                  (60
                                    ((value
                                      (StructField
                                       ((Reference (res (StructType 6))) value
@@ -2096,28 +2096,28 @@ let%expect_test "type check error" =
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 57))))
+                       (function_returns (StructType 60))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (57 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 57)))
-          (56
+                          (Struct (60 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 60)))
+          (59
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 56)) (builder (StructType 3))))
+                   ((self (StructType 59)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2126,7 +2126,7 @@ let%expect_test "type check error" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 56))) value IntegerType))
+                        ((Reference (self (StructType 59))) value IntegerType))
                        (Value (Integer 99)))))))))))
               (deserialize
                ((function_signature
@@ -2151,7 +2151,7 @@ let%expect_test "type check error" =
                           (value
                            (Value
                             (Struct
-                             (56
+                             (59
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -2159,11 +2159,11 @@ let%expect_test "type check error" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
              (((impl_interface (Value (Type (InterfaceType 8))))
                (impl_methods
@@ -2172,7 +2172,7 @@ let%expect_test "type check error" =
                    (Function
                     ((function_signature
                       ((function_params
-                        ((self (StructType 56)) (builder (StructType 3))))
+                        ((self (StructType 59)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -2181,7 +2181,7 @@ let%expect_test "type check error" =
                           ((ResolvedReference (serialize_int <opaque>))
                            ((Reference (builder (StructType 3)))
                             (StructField
-                             ((Reference (self (StructType 56))) value
+                             ((Reference (self (StructType 59))) value
                               IntegerType))
                             (Value (Integer 99))))))))))))))))
               ((impl_interface (Value (Type (InterfaceType 10))))
@@ -2212,7 +2212,7 @@ let%expect_test "type check error" =
                                (value
                                 (Value
                                  (Struct
-                                  (56
+                                  (59
                                    ((value
                                      (StructField
                                       ((Reference (res (StructType 6))) value
@@ -2224,18 +2224,18 @@ let%expect_test "type check error" =
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 56))))
+                       (function_returns (StructType 59))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 56)))))
+                          (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 59)))))
         (interfaces
-         ((58
+         ((61
            ((interface_methods
              ((from
-               ((function_params ((from (StructType 57))))
+               ((function_params ((from (StructType 60))))
                 (function_returns SelfType)))))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>))))) |}]
 
@@ -2255,9 +2255,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 57))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 60))))))
       (structs
-       ((57
+       ((60
          ((struct_fields ())
           (struct_methods
            ((op
@@ -2275,7 +2275,7 @@ let%expect_test "implement interface op" =
                     ((function_params ((left IntegerType) (right IntegerType)))
                      (function_returns IntegerType)))
                    (function_impl (Fn ((Return (Reference (left IntegerType)))))))))))))))
-          (struct_id 57)))))
+          (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -2297,28 +2297,28 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct (58 ())))) (Empty (Value (Type (StructType 58))))
-        (Make (Value (Type (InterfaceType 56))))))
+       ((empty (Value (Struct (61 ())))) (Empty (Value (Type (StructType 61))))
+        (Make (Value (Type (InterfaceType 59))))))
       (structs
-       ((58
+       ((61
          ((struct_fields ())
           (struct_methods
            ((new
              ((function_signature
-               ((function_params ()) (function_returns (StructType 58))))
-              (function_impl (Fn ((Return (Value (Struct (58 ())))))))))))
+               ((function_params ()) (function_returns (StructType 61))))
+              (function_impl (Fn ((Return (Value (Struct (61 ())))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 56))))
+           (((impl_interface (Value (Type (InterfaceType 59))))
              (impl_methods
               ((new
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 58))))
-                   (function_impl (Fn ((Return (Value (Struct (58 ()))))))))))))))))
-          (struct_id 58)))))
+                    ((function_params ()) (function_returns (StructType 61))))
+                   (function_impl (Fn ((Return (Value (Struct (61 ()))))))))))))))))
+          (struct_id 61)))))
       (interfaces
-       ((56
+       ((59
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
@@ -2340,7 +2340,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 59)) (b (StructType 3))))
+             ((function_params ((self (StructType 62)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -2365,20 +2365,20 @@ let%expect_test "serializer inner struct" =
                                   IntegerType))
                                 (Value (Integer 32))))))))))))
                       ((StructField
-                        ((Reference (self (StructType 59))) y (StructType 46)))
+                        ((Reference (self (StructType 62))) y (StructType 46)))
                        (Reference (b (StructType 3)))))))))
                  (Return (Reference (b (StructType 3)))))))))))))
-        (Outer (Value (Type (StructType 59))))
-        (Inner (Value (Type (StructType 57))))))
+        (Outer (Value (Type (StructType 62))))
+        (Inner (Value (Type (StructType 60))))))
       (structs
-       ((59
+       ((62
          ((struct_fields
            ((y ((field_type (StructType 46))))
-            (z ((field_type (StructType 57))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 59)))
-        (57
+            (z ((field_type (StructType 60))))))
+          (struct_methods ()) (struct_impls ()) (struct_id 62)))
+        (60
          ((struct_fields ((x ((field_type (StructType 46))))))
-          (struct_methods ()) (struct_impls ()) (struct_id 57)))))
+          (struct_methods ()) (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -2524,19 +2524,19 @@ let%expect_test "union variants constructing" =
     (Ok
      ((bindings
        ((b
-         (Value (UnionVariant ((Struct (46 ((value (Value (Integer 1)))))) 57))))
-        (a (Value (UnionVariant ((Integer 10) 57))))
+         (Value (UnionVariant ((Struct (46 ((value (Value (Integer 1)))))) 60))))
+        (a (Value (UnionVariant ((Integer 10) 60))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 57))))
-              (function_returns (UnionType 57))))
-            (function_impl (Fn ((Return (Reference (value (UnionType 57)))))))))))
-        (Uni (Value (Type (UnionType 57))))))
+             ((function_params ((value (UnionType 60))))
+              (function_returns (UnionType 60))))
+            (function_impl (Fn ((Return (Reference (value (UnionType 60)))))))))))
+        (Uni (Value (Type (UnionType 60))))))
       (structs ())
       (unions
-       ((57
+       ((60
          ((cases
            (((StructType 46) (Discriminator 0)) (IntegerType (Discriminator 1))))
           (union_methods ())
@@ -2549,14 +2549,14 @@ let%expect_test "union variants constructing" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type IntegerType))))))
-                     (function_returns (UnionType 57))))
+                     (function_returns (UnionType 60))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference (v (ExprType (Value (Type IntegerType)))))
-                         57)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 58))))
+                         60)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 61))))
              (impl_methods
               ((from
                 (Value
@@ -2564,17 +2564,17 @@ let%expect_test "union variants constructing" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type (StructType 46)))))))
-                     (function_returns (UnionType 57))))
+                     (function_returns (UnionType 60))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
                           (v (ExprType (Value (Type (StructType 46))))))
-                         57)))))))))))))))
-          (union_id 57)))))
+                         60)))))))))))))))
+          (union_id 60)))))
       (interfaces
-       ((58
+       ((61
          ((interface_methods
            ((from
              ((function_params ((from (StructType 46))))
@@ -2600,7 +2600,7 @@ let%expect_test "unions duplicate variant" =
     (Error
      (((DuplicateVariant IntegerType)
        ((bindings
-         ((b (Value (Type (UnionType 59)))) (a (Value (Type (UnionType 57))))
+         ((b (Value (Type (UnionType 62)))) (a (Value (Type (UnionType 60))))
           (Test
            (Value
             (Function
@@ -2629,14 +2629,14 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 56))))
+                               (function_returns (UnionType 59))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Value
                                     (Type (ExprType (Reference (v IntegerType)))))
-                                   56)))))))))))))
+                                   59)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -2652,7 +2652,7 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v (Dependent T (TypeN 0)))))
-                               (function_returns (UnionType 56))))
+                               (function_returns (UnionType 59))))
                              (function_impl
                               (Fn
                                ((Return
@@ -2662,8 +2662,8 @@ let%expect_test "unions duplicate variant" =
                                      (ExprType
                                       (Reference
                                        (v (ExprType (Reference (T (TypeN 0)))))))))
-                                   56)))))))))))))))
-                    (mk_union_id 56)))))))
+                                   59)))))))))))))))
+                    (mk_union_id 59)))))))
               (function_impl
                (Fn
                 ((Return
@@ -2688,12 +2688,12 @@ let%expect_test "unions duplicate variant" =
                            (Function
                             ((function_signature
                               ((function_params ((v IntegerType)))
-                               (function_returns (UnionType 56))))
+                               (function_returns (UnionType 59))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
-                                  ((Reference (v IntegerType)) 56)))))))))))))
+                                  ((Reference (v IntegerType)) 59)))))))))))))
                       ((impl_interface
                         (FunctionCall
                          ((Value
@@ -2710,18 +2710,18 @@ let%expect_test "unions duplicate variant" =
                             ((function_signature
                               ((function_params
                                 ((v (ExprType (Reference (T (TypeN 0)))))))
-                               (function_returns (UnionType 56))))
+                               (function_returns (UnionType 59))))
                              (function_impl
                               (Fn
                                ((Return
                                  (MakeUnionVariant
                                   ((Reference
                                     (v (ExprType (Reference (T (TypeN 0))))))
-                                   56)))))))))))))))
-                    (mk_union_id 56)))))))))))))
+                                   59)))))))))))))))
+                    (mk_union_id 59)))))))))))))
         (structs ())
         (unions
-         ((59
+         ((62
            ((cases ((IntegerType (Discriminator 0)))) (union_methods ())
             (union_impls
              (((impl_interface (Value (Type (InterfaceType 13))))
@@ -2731,11 +2731,11 @@ let%expect_test "unions duplicate variant" =
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 59))))
+                       (function_returns (UnionType 62))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 59)))))))))))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 62)))))))))))))
               ((impl_interface (Value (Type (InterfaceType 13))))
                (impl_methods
                 ((from
@@ -2744,15 +2744,15 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 59))))
+                       (function_returns (UnionType 62))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           59)))))))))))))))
-            (union_id 59)))
-          (57
+                           62)))))))))))))))
+            (union_id 62)))
+          (60
            ((cases
              (((BuiltinType Builder) (Discriminator 0))
               (IntegerType (Discriminator 1))))
@@ -2765,12 +2765,12 @@ let%expect_test "unions duplicate variant" =
                    (Function
                     ((function_signature
                       ((function_params ((v IntegerType)))
-                       (function_returns (UnionType 57))))
+                       (function_returns (UnionType 60))))
                      (function_impl
                       (Fn
                        ((Return
-                         (MakeUnionVariant ((Reference (v IntegerType)) 57)))))))))))))
-              ((impl_interface (Value (Type (InterfaceType 58))))
+                         (MakeUnionVariant ((Reference (v IntegerType)) 60)))))))))))))
+              ((impl_interface (Value (Type (InterfaceType 61))))
                (impl_methods
                 ((from
                   (Value
@@ -2778,16 +2778,16 @@ let%expect_test "unions duplicate variant" =
                     ((function_signature
                       ((function_params
                         ((v (ExprType (Reference (T (TypeN 0)))))))
-                       (function_returns (UnionType 57))))
+                       (function_returns (UnionType 60))))
                      (function_impl
                       (Fn
                        ((Return
                          (MakeUnionVariant
                           ((Reference (v (ExprType (Reference (T (TypeN 0))))))
-                           57)))))))))))))))
-            (union_id 57)))))
+                           60)))))))))))))))
+            (union_id 60)))))
         (interfaces
-         ((58
+         ((61
            ((interface_methods
              ((from
                ((function_params ((from (BuiltinType Builder))))
@@ -2810,23 +2810,23 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings ((Test (Value (Type (UnionType 58))))))
+     ((bindings ((Test (Value (Type (UnionType 61))))))
       (structs
-       ((56
+       ((59
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_methods
            ((new
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
             (serialize
              ((function_signature
                ((function_params
-                 ((self (StructType 56)) (builder (StructType 3))))
+                 ((self (StructType 59)) (builder (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -2835,7 +2835,7 @@ let%expect_test "unions" =
                    ((ResolvedReference (serialize_int <opaque>))
                     ((Reference (builder (StructType 3)))
                      (StructField
-                      ((Reference (self (StructType 56))) value IntegerType))
+                      ((Reference (self (StructType 59))) value IntegerType))
                      (Value (Integer 257)))))))))))
             (deserialize
              ((function_signature
@@ -2859,7 +2859,7 @@ let%expect_test "unions" =
                         (value
                          (Value
                           (Struct
-                           (56
+                           (59
                             ((value
                               (StructField
                                ((Reference (res (StructType 6))) value
@@ -2867,11 +2867,11 @@ let%expect_test "unions" =
             (from
              ((function_signature
                ((function_params ((i IntegerType)))
-                (function_returns (StructType 56))))
+                (function_returns (StructType 59))))
               (function_impl
                (Fn
                 ((Return
-                  (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                  (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
           (struct_impls
            (((impl_interface (Value (Type (InterfaceType 8))))
              (impl_methods
@@ -2880,7 +2880,7 @@ let%expect_test "unions" =
                  (Function
                   ((function_signature
                     ((function_params
-                      ((self (StructType 56)) (builder (StructType 3))))
+                      ((self (StructType 59)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2889,7 +2889,7 @@ let%expect_test "unions" =
                         ((ResolvedReference (serialize_int <opaque>))
                          ((Reference (builder (StructType 3)))
                           (StructField
-                           ((Reference (self (StructType 56))) value IntegerType))
+                           ((Reference (self (StructType 59))) value IntegerType))
                           (Value (Integer 257))))))))))))))))
             ((impl_interface (Value (Type (InterfaceType 10))))
              (impl_methods
@@ -2919,7 +2919,7 @@ let%expect_test "unions" =
                              (value
                               (Value
                                (Struct
-                                (56
+                                (59
                                  ((value
                                    (StructField
                                     ((Reference (res (StructType 6))) value
@@ -2931,42 +2931,42 @@ let%expect_test "unions" =
                  (Function
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 56))))
+                     (function_returns (StructType 59))))
                    (function_impl
                     (Fn
                      ((Return
                        (Value
-                        (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-          (struct_id 56)))))
+                        (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+          (struct_id 59)))))
       (unions
-       ((58
+       ((61
          ((cases
            (((StructType 45) (Discriminator 0))
-            ((StructType 56) (Discriminator 1))))
+            ((StructType 59) (Discriminator 1))))
           (union_methods
            ((id
              ((function_signature
-               ((function_params ((self (UnionType 58))))
-                (function_returns (UnionType 58))))
-              (function_impl (Fn ((Return (Reference (self (UnionType 58)))))))))))
+               ((function_params ((self (UnionType 61))))
+                (function_returns (UnionType 61))))
+              (function_impl (Fn ((Return (Reference (self (UnionType 61)))))))))))
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 59))))
+           (((impl_interface (Value (Type (InterfaceType 62))))
              (impl_methods
               ((from
                 (Value
                  (Function
                   ((function_signature
                     ((function_params
-                      ((v (ExprType (Value (Type (StructType 56)))))))
-                     (function_returns (UnionType 58))))
+                      ((v (ExprType (Value (Type (StructType 59)))))))
+                     (function_returns (UnionType 61))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
-                          (v (ExprType (Value (Type (StructType 56))))))
-                         58)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 60))))
+                          (v (ExprType (Value (Type (StructType 59))))))
+                         61)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 63))))
              (impl_methods
               ((from
                 (Value
@@ -2974,25 +2974,25 @@ let%expect_test "unions" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type (StructType 45)))))))
-                     (function_returns (UnionType 58))))
+                     (function_returns (UnionType 61))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
                           (v (ExprType (Value (Type (StructType 45))))))
-                         58)))))))))))))))
-          (union_id 58)))))
+                         61)))))))))))))))
+          (union_id 61)))))
       (interfaces
-       ((60
+       ((63
          ((interface_methods
            ((from
              ((function_params ((from (StructType 45))))
               (function_returns SelfType)))))))
-        (59
+        (62
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 56))))
+             ((function_params ((from (StructType 59))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
@@ -3017,9 +3017,9 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct (59 ())))) (foo_empty (Value (Struct (60 ()))))
-        (Empty (Value (Type (StructType 59)))) (x (Value (Integer 10)))
-        (foo (Value (Struct (57 ()))))
+       ((y (Value (Struct (62 ())))) (foo_empty (Value (Struct (63 ()))))
+        (Empty (Value (Type (StructType 62)))) (x (Value (Integer 10)))
+        (foo (Value (Struct (60 ()))))
         (Foo
          (Value
           (Function
@@ -3035,36 +3035,36 @@ let%expect_test "methods monomorphization" =
                      (MkFunction
                       ((function_signature
                         ((function_params
-                          ((self (StructType 56))
+                          ((self (StructType 59))
                            (x (ExprType (Reference (X (TypeN 0)))))))
                          (function_returns (ExprType (Reference (X (TypeN 0)))))))
                        (function_impl
                         (Fn
                          ((Return
                            (Reference (x (ExprType (Reference (X (TypeN 0)))))))))))))))
-                  (mk_impls ()) (mk_struct_id 56)))))))))))))
+                  (mk_impls ()) (mk_struct_id 59)))))))))))))
       (structs
-       ((60
+       ((63
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 60)) (x (StructType 59))))
-                (function_returns (StructType 59))))
-              (function_impl (Fn ((Return (Reference (x (StructType 59)))))))))))
-          (struct_impls ()) (struct_id 60)))
-        (59
+               ((function_params ((self (StructType 63)) (x (StructType 62))))
+                (function_returns (StructType 62))))
+              (function_impl (Fn ((Return (Reference (x (StructType 62)))))))))))
+          (struct_impls ()) (struct_id 63)))
+        (62
          ((struct_fields ()) (struct_methods ()) (struct_impls ())
-          (struct_id 59)))
-        (57
+          (struct_id 62)))
+        (60
          ((struct_fields ())
           (struct_methods
            ((id
              ((function_signature
-               ((function_params ((self (StructType 57)) (x IntegerType)))
+               ((function_params ((self (StructType 60)) (x IntegerType)))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Reference (x IntegerType))))))))))
-          (struct_impls ()) (struct_id 57)))))
+          (struct_impls ()) (struct_id 60)))))
       (type_counter <opaque>) (memoized_fcalls <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -3094,28 +3094,28 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 57))))
+             ((function_params ((i (UnionType 60))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               ((Break
                 (Switch
-                 ((switch_condition (Reference (i (UnionType 57))))
+                 ((switch_condition (Reference (i (UnionType 60))))
                   (branches
                    (((branch_ty (StructType 46)) (branch_var vax)
                      (branch_stmt (Block ((Return (Value (Integer 32)))))))
                     ((branch_ty (StructType 45)) (branch_var vax)
                      (branch_stmt (Block ((Return (Value (Integer 64)))))))))))))))))))
-        (Ints (Value (Type (UnionType 57))))))
+        (Ints (Value (Type (UnionType 60))))))
       (structs ())
       (unions
-       ((57
+       ((60
          ((cases
            (((StructType 45) (Discriminator 0))
             ((StructType 46) (Discriminator 1))))
           (union_methods ())
           (union_impls
-           (((impl_interface (Value (Type (InterfaceType 58))))
+           (((impl_interface (Value (Type (InterfaceType 61))))
              (impl_methods
               ((from
                 (Value
@@ -3123,15 +3123,15 @@ let%expect_test "switch statement" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type (StructType 46)))))))
-                     (function_returns (UnionType 57))))
+                     (function_returns (UnionType 60))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
                           (v (ExprType (Value (Type (StructType 46))))))
-                         57)))))))))))))
-            ((impl_interface (Value (Type (InterfaceType 59))))
+                         60)))))))))))))
+            ((impl_interface (Value (Type (InterfaceType 62))))
              (impl_methods
               ((from
                 (Value
@@ -3139,22 +3139,22 @@ let%expect_test "switch statement" =
                   ((function_signature
                     ((function_params
                       ((v (ExprType (Value (Type (StructType 45)))))))
-                     (function_returns (UnionType 57))))
+                     (function_returns (UnionType 60))))
                    (function_impl
                     (Fn
                      ((Return
                        (MakeUnionVariant
                         ((Reference
                           (v (ExprType (Value (Type (StructType 45))))))
-                         57)))))))))))))))
-          (union_id 57)))))
+                         60)))))))))))))))
+          (union_id 60)))))
       (interfaces
-       ((59
+       ((62
          ((interface_methods
            ((from
              ((function_params ((from (StructType 45))))
               (function_returns SelfType)))))))
-        (58
+        (61
          ((interface_methods
            ((from
              ((function_params ((from (StructType 46))))
@@ -3235,23 +3235,23 @@ let%expect_test "let binding with type" =
       (Ok
        ((bindings
          ((a (Value (Struct (46 ((value (Value (Integer 2))))))))
-          (a (Value (Struct (56 ((value (Value (Integer 1))))))))))
+          (a (Value (Struct (59 ((value (Value (Integer 1))))))))))
         (structs
-         ((56
+         ((59
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 56)) (builder (StructType 3))))
+                   ((self (StructType 59)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3260,7 +3260,7 @@ let%expect_test "let binding with type" =
                      ((ResolvedReference (serialize_int <opaque>))
                       ((Reference (builder (StructType 3)))
                        (StructField
-                        ((Reference (self (StructType 56))) value IntegerType))
+                        ((Reference (self (StructType 59))) value IntegerType))
                        (Value (Integer 257)))))))))))
               (deserialize
                ((function_signature
@@ -3284,7 +3284,7 @@ let%expect_test "let binding with type" =
                           (value
                            (Value
                             (Struct
-                             (56
+                             (59
                               ((value
                                 (StructField
                                  ((Reference (res (StructType 6))) value
@@ -3292,11 +3292,11 @@ let%expect_test "let binding with type" =
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 56))))
+                  (function_returns (StructType 59))))
                 (function_impl
                  (Fn
                   ((Return
-                    (Value (Struct (56 ((value (Reference (i IntegerType)))))))))))))))
+                    (Value (Struct (59 ((value (Reference (i IntegerType)))))))))))))))
             (struct_impls
              (((impl_interface (Value (Type (InterfaceType 8))))
                (impl_methods
@@ -3305,7 +3305,7 @@ let%expect_test "let binding with type" =
                    (Function
                     ((function_signature
                       ((function_params
-                        ((self (StructType 56)) (builder (StructType 3))))
+                        ((self (StructType 59)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -3314,7 +3314,7 @@ let%expect_test "let binding with type" =
                           ((ResolvedReference (serialize_int <opaque>))
                            ((Reference (builder (StructType 3)))
                             (StructField
-                             ((Reference (self (StructType 56))) value IntegerType))
+                             ((Reference (self (StructType 59))) value IntegerType))
                             (Value (Integer 257))))))))))))))))
               ((impl_interface (Value (Type (InterfaceType 10))))
                (impl_methods
@@ -3344,7 +3344,7 @@ let%expect_test "let binding with type" =
                                (value
                                 (Value
                                  (Struct
-                                  (56
+                                  (59
                                    ((value
                                      (StructField
                                       ((Reference (res (StructType 6))) value
@@ -3356,13 +3356,13 @@ let%expect_test "let binding with type" =
                    (Function
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 56))))
+                       (function_returns (StructType 59))))
                      (function_impl
                       (Fn
                        ((Return
                          (Value
-                          (Struct (56 ((value (Reference (i IntegerType))))))))))))))))))))
-            (struct_id 56)))))
+                          (Struct (59 ((value (Reference (i IntegerType))))))))))))))))))))
+            (struct_id 59)))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)))
       |}]
 
@@ -3408,7 +3408,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 58))))
+             ((function_params ((t (StructType 61))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -3417,18 +3417,18 @@ let%expect_test "interface constraints" =
                  ((Value
                    (Function
                     ((function_signature
-                      ((function_params ((self (StructType 58))))
+                      ((function_params ((self (StructType 61))))
                        (function_returns IntegerType)))
                      (function_impl (Fn ((Return (Value (Integer 1)))))))))
-                  ((Reference (t (StructType 58))))))))))))))
+                  ((Reference (t (StructType 61))))))))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 56))))
+             ((function_params ((T (InterfaceType 59))))
               (function_returns
                (FunctionType
-                ((function_params ((t (Dependent T (InterfaceType 56)))))
+                ((function_params ((t (Dependent T (InterfaceType 59)))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -3436,45 +3436,45 @@ let%expect_test "interface constraints" =
                 (MkFunction
                  ((function_signature
                    ((function_params
-                     ((t (ExprType (Reference (T (InterfaceType 56)))))))
+                     ((t (ExprType (Reference (T (InterfaceType 59)))))))
                     (function_returns IntegerType)))
                   (function_impl
                    (Fn
                     ((Return
                       (IntfMethodCall
-                       ((intf_instance (Reference (T (InterfaceType 56))))
-                        (intf_def 56)
+                       ((intf_instance (Reference (T (InterfaceType 59))))
+                        (intf_def 59)
                         (intf_method
                          (beep
                           ((function_params ((self SelfType)))
                            (function_returns IntegerType))))
                         (intf_args
                          ((Reference
-                           (t (ExprType (Reference (T (InterfaceType 56))))))))))))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 58))))
-        (Beep (Value (Type (InterfaceType 56))))))
+                           (t (ExprType (Reference (T (InterfaceType 59))))))))))))))))))))))))
+        (BeeperImpl1 (Value (Type (StructType 61))))
+        (Beep (Value (Type (InterfaceType 59))))))
       (structs
-       ((58
+       ((61
          ((struct_fields ())
           (struct_methods
            ((beep
              ((function_signature
-               ((function_params ((self (StructType 58))))
+               ((function_params ((self (StructType 61))))
                 (function_returns IntegerType)))
               (function_impl (Fn ((Return (Value (Integer 1))))))))))
           (struct_impls
-           (((impl_interface (Value (Type (InterfaceType 56))))
+           (((impl_interface (Value (Type (InterfaceType 59))))
              (impl_methods
               ((beep
                 (Value
                  (Function
                   ((function_signature
-                    ((function_params ((self (StructType 58))))
+                    ((function_params ((self (StructType 61))))
                      (function_returns IntegerType)))
                    (function_impl (Fn ((Return (Value (Integer 1)))))))))))))))
-          (struct_id 58)))))
+          (struct_id 61)))))
       (interfaces
-       ((56
+       ((59
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))


### PR DESCRIPTION
While I was implementing this PR I concerned with that current interfaces model not works as expected, but this is a problem of the current execution model that does not correctly handles interfaces with `SelfType`.

The issue is that when `X.call()` was occured where `X: SomeInterface` then the compiler place method definition from the interface which contains `SelfType`.