### PR TITLE
Introduce default case syntax to `switch` statements

### DIFF
--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -300,7 +300,8 @@ functor
           in
           {branch_ty = ty; branch_var = ref; branch_stmt = stmt}
 
-        method build_switch _env cond branches =
+        (* TODO: handle default *)
+        method build_switch _env cond branches _default =
           {switch_condition = Syntax.value cond; branches}
 
         method build_Struct _env s = MkStructDef s

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -254,14 +254,16 @@ let code_block :=
     case Type1 var => { <stmts> }
     case Type2 var => { <stmts> }
     ...
+    [else => { <stmts> }]
   }
 *)
 
 let switch :=
   | SWITCH; LPAREN; switch_condition = located(expr); RPAREN; LBRACE;
     branches = list(switch_branch);
+    default = option(default_branch);
     RBRACE;
-    { Switch (make_switch ~switch_condition ~branches ()) }
+    { Switch (make_switch ~switch_condition ~branches ?default ()) }
 
 let switch_branch := 
   | CASE; 
@@ -272,6 +274,12 @@ let switch_branch :=
     stmt = code_block;
     { make_switch_branch ~ty ~var ~stmt () }
 
+let default_branch := 
+  | ELSE; 
+    REARROW;
+    (* TODO: what kind of stmts should be allowed here? *)
+    stmt = code_block;
+    { stmt } 
 
 
 let block_stmt :=

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -725,8 +725,8 @@ program: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 405, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 410, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 
 Invalid syntax
@@ -1003,7 +1003,7 @@ program: SWITCH VAL
 ##
 ## Ends in an error in state: 116.
 ##
-## switch -> SWITCH . LPAREN expr RPAREN LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH . LPAREN expr RPAREN LBRACE list(switch_branch) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH
@@ -1015,7 +1015,7 @@ program: SWITCH LPAREN VAL
 ##
 ## Ends in an error in state: 117.
 ##
-## switch -> SWITCH LPAREN . expr RPAREN LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN . expr RPAREN LBRACE list(switch_branch) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH LPAREN
@@ -1067,9 +1067,9 @@ program: RETURN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -1103,9 +1103,9 @@ program: RETURN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -1358,7 +1358,7 @@ program: SWITCH LPAREN BOOL VAL
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT ]
-## switch -> SWITCH LPAREN expr . RPAREN LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN expr . RPAREN LBRACE list(switch_branch) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH LPAREN expr
@@ -1376,7 +1376,7 @@ program: SWITCH LPAREN BOOL RPAREN VAL
 ##
 ## Ends in an error in state: 163.
 ##
-## switch -> SWITCH LPAREN expr RPAREN . LBRACE list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN expr RPAREN . LBRACE list(switch_branch) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH LPAREN expr RPAREN
@@ -1388,7 +1388,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE VAL
 ##
 ## Ends in an error in state: 164.
 ##
-## switch -> SWITCH LPAREN expr RPAREN LBRACE . list(switch_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN expr RPAREN LBRACE . list(switch_branch) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH LPAREN expr RPAREN LBRACE
@@ -1400,7 +1400,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
 ##
 ## Ends in an error in state: 165.
 ##
-## switch_branch -> CASE . type_expr IDENT REARROW code_block [ RBRACE CASE ]
+## switch_branch -> CASE . type_expr IDENT REARROW code_block [ RBRACE ELSE CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE
@@ -1412,7 +1412,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT LBRACE
 ##
 ## Ends in an error in state: 167.
 ##
-## switch_branch -> CASE type_expr . IDENT REARROW code_block [ RBRACE CASE ]
+## switch_branch -> CASE type_expr . IDENT REARROW code_block [ RBRACE ELSE CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE type_expr
@@ -1430,7 +1430,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT VAL
 ##
 ## Ends in an error in state: 168.
 ##
-## switch_branch -> CASE type_expr IDENT . REARROW code_block [ RBRACE CASE ]
+## switch_branch -> CASE type_expr IDENT . REARROW code_block [ RBRACE ELSE CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE type_expr IDENT
@@ -1442,7 +1442,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW VAL
 ##
 ## Ends in an error in state: 169.
 ##
-## switch_branch -> CASE type_expr IDENT REARROW . code_block [ RBRACE CASE ]
+## switch_branch -> CASE type_expr IDENT REARROW . code_block [ RBRACE ELSE CASE ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE type_expr IDENT REARROW
@@ -1467,7 +1467,7 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW LBRACE RBRACE
 ##
 ## Ends in an error in state: 172.
 ##
-## list(switch_branch) -> switch_branch . list(switch_branch) [ RBRACE ]
+## list(switch_branch) -> switch_branch . list(switch_branch) [ RBRACE ELSE ]
 ##
 ## The known suffix of the stack is as follows:
 ## switch_branch
@@ -1475,9 +1475,45 @@ program: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW LBRACE RBRACE
 
 Invalid syntax
 
-program: STRUCT VAL
+program: SWITCH LPAREN BOOL RPAREN LBRACE ELSE VAL
+##
+## Ends in an error in state: 175.
+##
+## default_branch -> ELSE . REARROW code_block [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## ELSE
+##
+
+Invalid syntax
+
+program: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW VAL
 ##
 ## Ends in an error in state: 176.
+##
+## default_branch -> ELSE REARROW . code_block [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## ELSE REARROW
+##
+
+Invalid syntax
+
+program: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW LBRACE RBRACE VAL
+##
+## Ends in an error in state: 178.
+##
+## switch -> SWITCH LPAREN expr RPAREN LBRACE list(switch_branch) option(default_branch) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+##
+## The known suffix of the stack is as follows:
+## SWITCH LPAREN expr RPAREN LBRACE list(switch_branch) option(default_branch)
+##
+
+Invalid syntax
+
+program: STRUCT VAL
+##
+## Ends in an error in state: 181.
 ##
 ## expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1494,7 +1530,7 @@ Invalid syntax
 
 program: STRUCT IDENT VAL
 ##
-## Ends in an error in state: 177.
+## Ends in an error in state: 182.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> STRUCT IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -1508,7 +1544,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 178.
+## Ends in an error in state: 183.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -1521,7 +1557,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 180.
+## Ends in an error in state: 185.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1533,7 +1569,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 181.
+## Ends in an error in state: 186.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1545,7 +1581,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 192.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1557,7 +1593,7 @@ Invalid syntax
 
 program: STRUCT IDENT LPAREN RPAREN LBRACE UNION
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 193.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1569,7 +1605,7 @@ Invalid syntax
 
 program: STRUCT IDENT LBRACE UNION
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 198.
 ##
 ## non_semicolon_stmt -> STRUCT IDENT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -1581,7 +1617,7 @@ Invalid syntax
 
 program: STRUCT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 203.
 ##
 ## expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1595,7 +1631,7 @@ Invalid syntax
 
 program: STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 199.
+## Ends in an error in state: 204.
 ##
 ## expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ DOT ]
 ## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ LPAREN ]
@@ -1609,7 +1645,7 @@ Invalid syntax
 
 program: STRUCT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 208.
 ##
 ## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ DOT ]
 ## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
@@ -1623,7 +1659,7 @@ Invalid syntax
 
 program: STRING VAL
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 209.
 ##
 ## expr -> STRING . [ DOT ]
 ## fexpr -> STRING . [ LPAREN ]
@@ -1637,7 +1673,7 @@ Invalid syntax
 
 program: RETURN VAL
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 210.
 ##
 ## semicolon_stmt -> RETURN . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1649,7 +1685,7 @@ Invalid syntax
 
 program: RETURN BOOL VAL
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 211.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1670,7 +1706,7 @@ Invalid syntax
 
 program: LET VAL
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 213.
 ##
 ## semicolon_stmt -> LET . IDENT option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1686,7 +1722,7 @@ Invalid syntax
 
 program: LET LBRACE VAL
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 214.
 ##
 ## semicolon_stmt -> LET LBRACE . nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET LBRACE . loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1699,7 +1735,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT VAL
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 215.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . AS IDENT COMMA [ RBRACE DOUBLEDOT ]
@@ -1718,7 +1754,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 216.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1732,7 +1768,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS VAL
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 219.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1747,7 +1783,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS IDENT VAL
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 220.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1762,7 +1798,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT AS IDENT COMMA VAL
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 221.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1776,7 +1812,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA DOUBLEDOT VAL
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 227.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1788,7 +1824,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 228.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1800,7 +1836,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 229.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1812,7 +1848,7 @@ Invalid syntax
 
 program: LET LBRACE IDENT COMMA RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 225.
+## Ends in an error in state: 230.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1833,7 +1869,7 @@ Invalid syntax
 
 program: LET LBRACE DOUBLEDOT VAL
 ##
-## Ends in an error in state: 227.
+## Ends in an error in state: 232.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1845,7 +1881,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 228.
+## Ends in an error in state: 233.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1857,7 +1893,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 229.
+## Ends in an error in state: 234.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1869,7 +1905,7 @@ Invalid syntax
 
 program: LET LBRACE RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 230.
+## Ends in an error in state: 235.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1890,7 +1926,7 @@ Invalid syntax
 
 program: LET IDENT VAL
 ##
-## Ends in an error in state: 231.
+## Ends in an error in state: 236.
 ##
 ## semicolon_stmt -> LET IDENT . option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1904,7 +1940,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN VAL
 ##
-## Ends in an error in state: 232.
+## Ends in an error in state: 237.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1917,7 +1953,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 234.
+## Ends in an error in state: 239.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1929,7 +1965,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 240.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1941,7 +1977,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 236.
+## Ends in an error in state: 241.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1962,7 +1998,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 238.
+## Ends in an error in state: 243.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1974,7 +2010,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 239.
+## Ends in an error in state: 244.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1986,7 +2022,7 @@ Invalid syntax
 
 program: LET IDENT LPAREN RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 245.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2007,7 +2043,7 @@ Invalid syntax
 
 program: LET IDENT COLON VAL
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 246.
 ##
 ## option(__anonymous_0) -> COLON . type_expr [ EQUALS ]
 ##
@@ -2019,7 +2055,7 @@ Invalid syntax
 
 program: LET IDENT COLON IDENT LBRACE
 ##
-## Ends in an error in state: 243.
+## Ends in an error in state: 248.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2031,14 +2067,14 @@ program: LET IDENT COLON IDENT LBRACE
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
 ## In state 89, spurious reduction of production type_expr -> IDENT
-## In state 242, spurious reduction of production option(__anonymous_0) -> COLON type_expr
+## In state 247, spurious reduction of production option(__anonymous_0) -> COLON type_expr
 ##
 
 Invalid syntax
 
 program: LET IDENT EQUALS VAL
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 249.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2050,7 +2086,7 @@ Invalid syntax
 
 program: LET IDENT EQUALS BOOL VAL
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 250.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2071,7 +2107,7 @@ Invalid syntax
 
 program: INTERFACE VAL
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 251.
 ##
 ## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -2088,7 +2124,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 252.
 ##
 ## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ DOT ]
 ## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN ]
@@ -2102,7 +2138,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 254.
 ##
 ## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ DOT ]
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
@@ -2116,7 +2152,7 @@ Invalid syntax
 
 program: INTERFACE IDENT VAL
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 255.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> INTERFACE IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2130,7 +2166,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 251.
+## Ends in an error in state: 256.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2143,7 +2179,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 253.
+## Ends in an error in state: 258.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2155,7 +2191,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 259.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2167,7 +2203,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 258.
+## Ends in an error in state: 263.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2179,7 +2215,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 259.
+## Ends in an error in state: 264.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2191,7 +2227,7 @@ Invalid syntax
 
 program: INTERFACE IDENT LBRACE VAL
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 267.
 ##
 ## non_semicolon_stmt -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2203,7 +2239,7 @@ Invalid syntax
 
 program: INT VAL
 ##
-## Ends in an error in state: 265.
+## Ends in an error in state: 270.
 ##
 ## expr -> INT . [ DOT ]
 ## fexpr -> INT . [ LPAREN ]
@@ -2217,7 +2253,7 @@ Invalid syntax
 
 program: IF VAL
 ##
-## Ends in an error in state: 266.
+## Ends in an error in state: 271.
 ##
 ## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2229,7 +2265,7 @@ Invalid syntax
 
 program: IF LPAREN VAL
 ##
-## Ends in an error in state: 267.
+## Ends in an error in state: 272.
 ##
 ## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2241,7 +2277,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL VAL
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 273.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
@@ -2262,7 +2298,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL RPAREN VAL
 ##
-## Ends in an error in state: 269.
+## Ends in an error in state: 274.
 ##
 ## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2274,7 +2310,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 270.
+## Ends in an error in state: 275.
 ##
 ## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2286,7 +2322,7 @@ Invalid syntax
 
 program: IF LPAREN BOOL RPAREN LBRACE RBRACE ELSE VAL
 ##
-## Ends in an error in state: 271.
+## Ends in an error in state: 276.
 ##
 ## else_ -> ELSE . if_ [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## else_ -> ELSE . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2299,7 +2335,7 @@ Invalid syntax
 
 program: IDENT VAL
 ##
-## Ends in an error in state: 276.
+## Ends in an error in state: 281.
 ##
 ## expr -> IDENT . [ DOT ]
 ## fexpr -> IDENT . [ LPAREN ]
@@ -2314,7 +2350,7 @@ Invalid syntax
 
 program: FN VAL
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 282.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2335,7 +2371,7 @@ Invalid syntax
 
 program: FN LPAREN VAL
 ##
-## Ends in an error in state: 278.
+## Ends in an error in state: 283.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,option(code_block)) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
@@ -2350,7 +2386,7 @@ Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 280.
+## Ends in an error in state: 285.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -2363,7 +2399,7 @@ Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 281.
+## Ends in an error in state: 286.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -2375,14 +2411,14 @@ program: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 283.
+## Ends in an error in state: 288.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -2395,7 +2431,7 @@ Invalid syntax
 
 program: FN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 285.
+## Ends in an error in state: 290.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
@@ -2408,7 +2444,7 @@ Invalid syntax
 
 program: FN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 286.
+## Ends in an error in state: 291.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ DOT ]
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
@@ -2420,14 +2456,14 @@ program: FN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN LPAREN RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 288.
+## Ends in an error in state: 293.
 ##
 ## function_definition(nothing,some(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
 ## option(code_block) -> code_block . [ DOT ]
@@ -2440,7 +2476,7 @@ Invalid syntax
 
 program: FN IDENT VAL
 ##
-## Ends in an error in state: 289.
+## Ends in an error in state: 294.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2457,7 +2493,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN VAL
 ##
-## Ends in an error in state: 290.
+## Ends in an error in state: 295.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2474,7 +2510,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 297.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2488,7 +2524,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 298.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2501,7 +2537,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 295.
+## Ends in an error in state: 300.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2513,7 +2549,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 301.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2524,14 +2560,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL C
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 304.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2543,7 +2579,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 300.
+## Ends in an error in state: 305.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2554,14 +2590,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW IDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 307.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2572,14 +2608,14 @@ program: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 305.
+## Ends in an error in state: 310.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2593,7 +2629,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 306.
+## Ends in an error in state: 311.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2606,7 +2642,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 308.
+## Ends in an error in state: 313.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2618,7 +2654,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 309.
+## Ends in an error in state: 314.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2629,14 +2665,14 @@ program: FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDEN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 312.
+## Ends in an error in state: 317.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2648,7 +2684,7 @@ Invalid syntax
 
 program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 313.
+## Ends in an error in state: 318.
 ##
 ## function_definition(located_ident_with_params,some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2659,14 +2695,14 @@ program: FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 320.
 ##
 ## function_definition(located(ident),some(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2677,14 +2713,14 @@ program: FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM VAL
 ##
-## Ends in an error in state: 317.
+## Ends in an error in state: 322.
 ##
 ## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2707,7 +2743,7 @@ Invalid syntax
 
 program: ENUM LBRACE VAL
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 323.
 ##
 ## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
 ## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ DOT ]
@@ -2724,7 +2760,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 320.
+## Ends in an error in state: 325.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ DOT ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -2737,9 +2773,9 @@ program: ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2748,7 +2784,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 321.
+## Ends in an error in state: 326.
 ##
 ## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2762,7 +2798,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 323.
+## Ends in an error in state: 328.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ DOT ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
@@ -2775,9 +2811,9 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2786,7 +2822,7 @@ Invalid syntax
 
 program: ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 324.
+## Ends in an error in state: 329.
 ##
 ## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ DOT ]
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
@@ -2800,7 +2836,7 @@ Invalid syntax
 
 program: ENUM IDENT VAL
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 330.
 ##
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2817,7 +2853,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN VAL
 ##
-## Ends in an error in state: 326.
+## Ends in an error in state: 331.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2832,7 +2868,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 328.
+## Ends in an error in state: 333.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2845,7 +2881,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 334.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2858,7 +2894,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 336.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2869,9 +2905,9 @@ program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE IDENT COMMA FN I
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2880,7 +2916,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 334.
+## Ends in an error in state: 339.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2891,9 +2927,9 @@ program: ENUM IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE FN IDENT LPAREN 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2902,7 +2938,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 337.
+## Ends in an error in state: 342.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2915,7 +2951,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 343.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2928,7 +2964,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 340.
+## Ends in an error in state: 345.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2939,9 +2975,9 @@ program: ENUM IDENT LPAREN RPAREN LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2950,7 +2986,7 @@ Invalid syntax
 
 program: ENUM IDENT LPAREN RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 348.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2961,9 +2997,9 @@ program: ENUM IDENT LPAREN RPAREN LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -2972,7 +3008,7 @@ Invalid syntax
 
 program: ENUM IDENT LBRACE VAL
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 350.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -2985,7 +3021,7 @@ Invalid syntax
 
 program: ENUM IDENT LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 347.
+## Ends in an error in state: 352.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -2996,9 +3032,9 @@ program: ENUM IDENT LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3007,7 +3043,7 @@ Invalid syntax
 
 program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 355.
 ##
 ## non_semicolon_stmt -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -3018,9 +3054,9 @@ program: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3029,7 +3065,7 @@ Invalid syntax
 
 program: BOOL VAL
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 357.
 ##
 ## expr -> BOOL . [ DOT ]
 ## fexpr -> BOOL . [ LPAREN ]
@@ -3043,7 +3079,7 @@ Invalid syntax
 
 program: IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 359.
 ##
 ## expr -> struct_constructor . [ DOT ]
 ## stmt_expr -> struct_constructor . [ SEMICOLON RBRACE EOF ]
@@ -3056,7 +3092,7 @@ Invalid syntax
 
 program: BOOL SEMICOLON VAL
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 363.
 ##
 ## block_stmt -> semicolon_stmt SEMICOLON . block_stmt [ RBRACE EOF ]
 ## block_stmt -> semicolon_stmt SEMICOLON . [ RBRACE EOF ]
@@ -3069,7 +3105,7 @@ Invalid syntax
 
 program: LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 359.
+## Ends in an error in state: 364.
 ##
 ## block_stmt -> non_semicolon_stmt . block_stmt [ RBRACE EOF ]
 ## stmt -> non_semicolon_stmt . [ RBRACE EOF ]
@@ -3082,7 +3118,7 @@ Invalid syntax
 
 program: BOOL LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 369.
 ##
 ## expr -> function_call . [ DOT ]
 ## fexpr -> function_call . [ LPAREN ]
@@ -3097,7 +3133,7 @@ Invalid syntax
 
 program: BOOL DOT VAL
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 371.
 ##
 ## expr -> expr DOT . IDENT [ DOT ]
 ## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3114,7 +3150,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT VAL
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 372.
 ##
 ## expr -> expr DOT IDENT . [ DOT ]
 ## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3131,7 +3167,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 368.
+## Ends in an error in state: 373.
 ##
 ## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
 ## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
@@ -3146,7 +3182,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 375.
 ##
 ## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3159,7 +3195,7 @@ Invalid syntax
 
 program: BOOL DOT IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 372.
+## Ends in an error in state: 377.
 ##
 ## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3172,7 +3208,7 @@ Invalid syntax
 
 program: LBRACE BOOL EOF
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 381.
 ##
 ## code_block -> LBRACE block_stmt . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
 ##
@@ -3183,17 +3219,17 @@ program: LBRACE BOOL EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 352, spurious reduction of production stmt_expr -> BOOL
-## In state 355, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 357, spurious reduction of production stmt -> semicolon_stmt
-## In state 356, spurious reduction of production block_stmt -> stmt
+## In state 357, spurious reduction of production stmt_expr -> BOOL
+## In state 360, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 362, spurious reduction of production stmt -> semicolon_stmt
+## In state 361, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax
 
 program: RETURN FN LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 385.
 ##
 ## function_definition(nothing,option(code_block)) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3205,7 +3241,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT EQUALS BOOL VAL
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 387.
 ##
 ## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN DOT COMMA ]
@@ -3229,7 +3265,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT EQUALS BOOL COMMA VAL
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 388.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -3243,7 +3279,7 @@ Invalid syntax
 
 program: ENUM LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 386.
+## Ends in an error in state: 391.
 ##
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
 ## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
@@ -3257,7 +3293,7 @@ Invalid syntax
 
 program: LET IDENT COLON ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 395.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3268,9 +3304,9 @@ program: LET IDENT COLON ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3279,7 +3315,7 @@ Invalid syntax
 
 program: LET IDENT COLON ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 398.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3290,9 +3326,9 @@ program: LET IDENT COLON ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3301,7 +3337,7 @@ Invalid syntax
 
 program: LPAREN IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 395.
+## Ends in an error in state: 400.
 ##
 ## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3313,7 +3349,7 @@ Invalid syntax
 
 program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 402.
 ##
 ## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ##
@@ -3324,7 +3360,7 @@ program: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ## In state 97, spurious reduction of production function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 
@@ -3332,7 +3368,7 @@ Invalid syntax
 
 program: FN LPAREN RPAREN RARROW IDENT UNION
 ##
-## Ends in an error in state: 401.
+## Ends in an error in state: 406.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACE LPAREN LBRACE IMPL FN EOF DOT COMMA ]
@@ -3346,7 +3382,7 @@ Invalid syntax
 
 program: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 404.
+## Ends in an error in state: 409.
 ##
 ## function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
 ##
@@ -3358,7 +3394,7 @@ Invalid syntax
 
 program: LPAREN INTERFACE LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 407.
+## Ends in an error in state: 412.
 ##
 ## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3371,7 +3407,7 @@ Invalid syntax
 
 program: LPAREN INT VAL
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 414.
 ##
 ## fexpr -> INT . [ LPAREN ]
 ## type_expr -> LPAREN INT . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3384,7 +3420,7 @@ Invalid syntax
 
 program: LPAREN IDENT VAL
 ##
-## Ends in an error in state: 411.
+## Ends in an error in state: 416.
 ##
 ## fexpr -> IDENT . [ LPAREN ]
 ## type_expr -> LPAREN IDENT . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3398,7 +3434,7 @@ Invalid syntax
 
 program: LPAREN ENUM VAL
 ##
-## Ends in an error in state: 413.
+## Ends in an error in state: 418.
 ##
 ## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -3413,7 +3449,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE VAL
 ##
-## Ends in an error in state: 414.
+## Ends in an error in state: 419.
 ##
 ## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
 ## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ LPAREN ]
@@ -3428,7 +3464,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 416.
+## Ends in an error in state: 421.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -3440,9 +3476,9 @@ program: LPAREN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3451,7 +3487,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 417.
+## Ends in an error in state: 422.
 ##
 ## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3464,7 +3500,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 425.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
@@ -3476,9 +3512,9 @@ program: LPAREN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3487,7 +3523,7 @@ Invalid syntax
 
 program: LPAREN ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 421.
+## Ends in an error in state: 426.
 ##
 ## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . [ LPAREN ]
 ## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3500,7 +3536,7 @@ Invalid syntax
 
 program: LPAREN BOOL VAL
 ##
-## Ends in an error in state: 423.
+## Ends in an error in state: 428.
 ##
 ## fexpr -> BOOL . [ LPAREN ]
 ## type_expr -> LPAREN BOOL . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3513,7 +3549,7 @@ Invalid syntax
 
 program: LPAREN BOOL LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 430.
 ##
 ## fexpr -> function_call . [ LPAREN ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE IDENT EQUALS ]
@@ -3527,7 +3563,7 @@ Invalid syntax
 
 program: STRUCT LBRACE VAL IDENT COLON BOOL RPAREN
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 432.
 ##
 ## expr -> expr . DOT IDENT [ VAL SEMICOLON RBRACE IMPL FN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT ]
@@ -3548,7 +3584,7 @@ Invalid syntax
 
 program: STRUCT LBRACE VAL IDENT COLON BOOL SEMICOLON UNION
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 434.
 ##
 ## list(struct_field) -> VAL IDENT COLON expr option(SEMICOLON) . list(struct_field) [ RBRACE IMPL FN ]
 ##
@@ -3560,7 +3596,7 @@ Invalid syntax
 
 program: UNION LBRACE IMPL IDENT VAL
 ##
-## Ends in an error in state: 435.
+## Ends in an error in state: 440.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ LPAREN LBRACE ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ LPAREN LBRACE ]
@@ -3574,7 +3610,7 @@ Invalid syntax
 
 program: UNION LBRACE IMPL IDENT LBRACE VAL
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 441.
 ##
 ## list(impl) -> IMPL fexpr LBRACE . list(sugared_function_definition(option(code_block))) RBRACE list(impl) [ RBRACE ]
 ##
@@ -3586,7 +3622,7 @@ Invalid syntax
 
 program: UNION LBRACE IMPL IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 442.
 ##
 ## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) . RBRACE list(impl) [ RBRACE ]
 ##
@@ -3597,9 +3633,9 @@ program: UNION LBRACE IMPL IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -3608,7 +3644,7 @@ Invalid syntax
 
 program: UNION LBRACE IMPL IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 443.
 ##
 ## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(code_block))) RBRACE . list(impl) [ RBRACE ]
 ##
@@ -3620,7 +3656,7 @@ Invalid syntax
 
 program: RETURN UNION LBRACE RBRACE UNION
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 446.
 ##
 ## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACE IMPL FN EOF DOT COMMA ]
 ## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
@@ -3633,7 +3669,7 @@ Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL VAL
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 447.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT COMMA ]
@@ -3657,7 +3693,7 @@ Invalid syntax
 
 program: FN LPAREN IDENT COLON BOOL COMMA VAL
 ##
-## Ends in an error in state: 443.
+## Ends in an error in state: 448.
 ##
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN ]
 ## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN ]
@@ -3671,7 +3707,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 447.
+## Ends in an error in state: 452.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3685,7 +3721,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 453.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3698,7 +3734,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 450.
+## Ends in an error in state: 455.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3710,7 +3746,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 451.
+## Ends in an error in state: 456.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3721,14 +3757,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 454.
+## Ends in an error in state: 459.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3740,7 +3776,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 455.
+## Ends in an error in state: 460.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3751,14 +3787,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LPAREN RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 457.
+## Ends in an error in state: 462.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3769,14 +3805,14 @@ program: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 460.
+## Ends in an error in state: 465.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3790,7 +3826,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN VAL
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 466.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
@@ -3803,7 +3839,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 463.
+## Ends in an error in state: 468.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3815,7 +3851,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 469.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3826,14 +3862,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN IDENT COLON BOOL COMMA RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 467.
+## Ends in an error in state: 472.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3845,7 +3881,7 @@ Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 473.
 ##
 ## function_definition(located_ident_with_params,option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3856,14 +3892,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 475.
 ##
 ## function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(code_block) [ RBRACE IMPL FN ]
 ##
@@ -3874,14 +3910,14 @@ program: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 401, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 406, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 program: UNION LBRACE CASE STRUCT VAL
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 480.
 ##
 ## union_member -> STRUCT . LBRACE list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -3893,7 +3929,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE STRUCT LBRACE UNION
 ##
-## Ends in an error in state: 476.
+## Ends in an error in state: 481.
 ##
 ## union_member -> STRUCT LBRACE . list(struct_field) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -3905,7 +3941,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE INTERFACE VAL
 ##
-## Ends in an error in state: 481.
+## Ends in an error in state: 486.
 ##
 ## union_member -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -3917,7 +3953,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 487.
 ##
 ## union_member -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -3929,7 +3965,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE IDENT VAL
 ##
-## Ends in an error in state: 485.
+## Ends in an error in state: 490.
 ##
 ## union_member -> IDENT . [ RBRACE IMPL FN CASE ]
 ## union_member -> IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN CASE ]
@@ -3943,7 +3979,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE IDENT LPAREN VAL
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 491.
 ##
 ## union_member -> IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN CASE ]
 ## union_member -> IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE IMPL FN CASE ]
@@ -3956,7 +3992,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM VAL
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 496.
 ##
 ## union_member -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
 ## union_member -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
@@ -3969,7 +4005,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE VAL
 ##
-## Ends in an error in state: 492.
+## Ends in an error in state: 497.
 ##
 ## union_member -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
 ## union_member -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) RBRACE [ RBRACE IMPL FN CASE ]
@@ -3982,7 +4018,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 499.
 ##
 ## union_member -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -3993,9 +4029,9 @@ program: UNION LBRACE CASE ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -4004,7 +4040,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ##
-## Ends in an error in state: 497.
+## Ends in an error in state: 502.
 ##
 ## union_member -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(code_block))) . RBRACE [ RBRACE IMPL FN CASE ]
 ##
@@ -4015,9 +4051,9 @@ program: UNION LBRACE CASE ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 470, spurious reduction of production option(code_block) ->
-## In state 471, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
+## In state 465, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 475, spurious reduction of production option(code_block) ->
+## In state 476, spurious reduction of production function_definition(located(ident),option(code_block)) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(code_block)
 ## In state 25, spurious reduction of production list(sugared_function_definition(option(code_block))) ->
 ## In state 26, spurious reduction of production list(sugared_function_definition(option(code_block))) -> function_definition(located(ident),option(code_block)) list(sugared_function_definition(option(code_block)))
 ##
@@ -4026,7 +4062,7 @@ Invalid syntax
 
 program: UNION LBRACE CASE ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 504.
 ##
 ## list(preceded(CASE,located(union_member))) -> CASE union_member . list(preceded(CASE,located(union_member))) [ RBRACE IMPL FN ]
 ##
@@ -4038,7 +4074,7 @@ Invalid syntax
 
 program: UNION LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 509.
 ##
 ## expr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ DOT ]
 ## fexpr -> UNION LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE . [ LPAREN ]
@@ -4052,7 +4088,7 @@ Invalid syntax
 
 program: UNION IDENT VAL
 ##
-## Ends in an error in state: 505.
+## Ends in an error in state: 510.
 ##
 ## non_semicolon_stmt -> UNION IDENT . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> UNION IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -4066,7 +4102,7 @@ Invalid syntax
 
 program: UNION IDENT LPAREN VAL
 ##
-## Ends in an error in state: 506.
+## Ends in an error in state: 511.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ## non_semicolon_stmt -> UNION IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
@@ -4079,7 +4115,7 @@ Invalid syntax
 
 program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 513.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -4091,7 +4127,7 @@ Invalid syntax
 
 program: UNION IDENT LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 509.
+## Ends in an error in state: 514.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -4103,7 +4139,7 @@ Invalid syntax
 
 program: UNION IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 515.
+## Ends in an error in state: 520.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . LBRACE list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -4115,7 +4151,7 @@ Invalid syntax
 
 program: UNION IDENT LPAREN RPAREN LBRACE VAL
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 521.
 ##
 ## non_semicolon_stmt -> UNION IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -4127,7 +4163,7 @@ Invalid syntax
 
 program: UNION IDENT LBRACE VAL
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 526.
 ##
 ## non_semicolon_stmt -> UNION IDENT LBRACE . list(preceded(CASE,located(union_member))) list(sugared_function_definition(option(code_block))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
 ##
@@ -4139,7 +4175,7 @@ Invalid syntax
 
 program: BOOL RBRACE
 ##
-## Ends in an error in state: 528.
+## Ends in an error in state: 533.
 ##
 ## program -> block_stmt . EOF [ # ]
 ##
@@ -4150,10 +4186,10 @@ program: BOOL RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 352, spurious reduction of production stmt_expr -> BOOL
-## In state 355, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 357, spurious reduction of production stmt -> semicolon_stmt
-## In state 356, spurious reduction of production block_stmt -> stmt
+## In state 357, spurious reduction of production stmt_expr -> BOOL
+## In state 360, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 362, spurious reduction of production stmt -> semicolon_stmt
+## In state 361, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -79,7 +79,10 @@ functor
       | Expr of expr
       | Switch of switch
 
-    and switch = {switch_condition : expr located; branches : switch_branch list}
+    and switch =
+      { switch_condition : expr located;
+        branches : switch_branch list;
+        default : stmt option [@sexp.option] }
 
     and switch_branch = {ty : expr located; var : ident located; stmt : stmt}
 

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -900,6 +900,59 @@ let%expect_test "switch statement" =
                           (Let
                            ((binding_name (Ident b)) (binding_expr (Int 20)))))))))))))))))))))))))) |}]
 
+let%expect_test "switch statement with a default case" =
+  let source =
+    {|
+    fn test() {
+      switch (expr) {
+        case Type(T) vax => { let a = 10; }
+        case Baz vax => {
+          let a = 10;
+          let b = 20;
+        }
+        else => {
+           let c = 30;
+        }
+      }
+    }
+  |}
+  in
+  pp source ;
+  [%expect
+    {|
+      ((stmts
+        ((Let
+          ((binding_name (Ident test))
+           (binding_expr
+            (Function
+             ((function_body
+               ((function_stmt
+                 (CodeBlock
+                  ((Break
+                    (Switch
+                     ((switch_condition (Reference (Ident expr)))
+                      (branches
+                       (((ty
+                          (FunctionCall
+                           ((fn (Reference (Ident Type)))
+                            (arguments ((Reference (Ident T)))))))
+                         (var (Ident vax))
+                         (stmt
+                          (CodeBlock
+                           ((Let
+                             ((binding_name (Ident a)) (binding_expr (Int 10))))))))
+                        ((ty (Reference (Ident Baz))) (var (Ident vax))
+                         (stmt
+                          (CodeBlock
+                           ((Let
+                             ((binding_name (Ident a)) (binding_expr (Int 10))))
+                            (Let
+                             ((binding_name (Ident b)) (binding_expr (Int 20))))))))))
+                      (default
+                       (CodeBlock
+                        ((Let ((binding_name (Ident c)) (binding_expr (Int 30)))))))))))))))))))))))
+      |}]
+
 let%expect_test "destructuring let" =
   let source =
     {|


### PR DESCRIPTION
This enables handling "other" cases without enumerating them all. `else`
keyword was chosen because we use `default` as an identifier already.

This change introduces *syntax only* and does not propagate to lang.