### PR TITLE
Basic REPL for Tact for quick experiments

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,4 +3,4 @@
  (package tact)
  (name main)
  (modules main)
- (libraries tact))
+ (libraries tact linenoise base))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,9 +1,55 @@
 open Base
+module Show = Tact.Compiler.Show
+module Lang = Tact.Compiler.Lang
+module Syntax = Tact.Compiler.Syntax
 
-let () =
-  let filename = Array.get (Sys.get_argv ()) 1 in
+let interpret_file argv =
+  let filename = Array.get argv 1 in
   match Tact.Compiler.compile ~filename (Caml.open_in filename) with
   | Ok program ->
       Caml.Format.print_string program
   | Error errors ->
       Caml.Format.print_string errors
+
+let prompt = "# "
+
+let rec repl ?(program = Lang.default_program ()) ?(prompt = prompt) () =
+  match LNoise.linenoise prompt with
+  | None ->
+      ()
+  | Some input -> (
+      ignore @@ LNoise.history_add input ;
+      match
+        Tact.Compiler.compile_to_ir ~filename:"<stdin>" ~prev_program:program
+          input
+      with
+      | Ok ({result = Some result; _} as program) ->
+          Show.pp_value Caml.Format.std_formatter result ;
+          Caml.Format.print_newline () ;
+          Caml.Format.print_flush () ;
+          repl ~program ~prompt ()
+      | Ok ({bindings; _} as program') ->
+          List.iter bindings ~f:(fun (name, value) ->
+              if
+                Option.is_none
+                @@ List.find program.bindings ~f:(fun (name', value') ->
+                       Syntax.equal_located String.equal name name'
+                       && Syntax.equal_located Lang.equal_expr_kind value value' )
+              then (
+                Caml.Format.print_string @@ Syntax.value name ;
+                Caml.Format.print_string " = " ;
+                Show.pp_expr Caml.Format.std_formatter value ;
+                Caml.Format.print_newline () ) ) ;
+          Caml.Format.print_flush () ;
+          repl ~program:program' ~prompt ()
+      | Error errors ->
+          Caml.Format.print_string errors ;
+          Caml.Format.print_flush () ;
+          repl ~prompt () )
+
+let () =
+  let argv = Sys.get_argv () in
+  if Array.length argv > 2 then interpret_file argv
+  else LNoise.set_multiline true ;
+  ignore @@ LNoise.history_set ~max_length:1000 ;
+  repl ()

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -2,6 +2,7 @@ open Base
 module Show = Tact.Compiler.Show
 module Lang = Tact.Compiler.Lang
 module Syntax = Tact.Compiler.Syntax
+module Builtin = Tact.Compiler.Builtin
 
 let interpret_file argv =
   let filename = Array.get argv 1 in
@@ -13,7 +14,13 @@ let interpret_file argv =
 
 let prompt = "# "
 
-let rec repl ?(program = Lang.default_program ()) ?(prompt = prompt) () =
+let default_program () =
+  let program = Lang.default_program () in
+  Result.ok_or_failwith
+  @@ Tact.Compiler.compile_to_ir ~filename:"std.tact" ~prev_program:program
+       Builtin.std
+
+let rec repl ?(program = default_program ()) ?(prompt = prompt) () =
   match LNoise.linenoise prompt with
   | None ->
       ()

--- a/dune-project
+++ b/dune-project
@@ -44,6 +44,7 @@
    (ppx_jane (>= 0.15.0))
    (visitors (= 20210608))
    (containers (>= 3.8.0))
+   (linenoise (>= 1.3.1))
    (core (and :with-test (>= 0.15.0)))
    (ppx_expect (and :with-test (>= 0.15.0)))
    (ppx_matches (and :with-test (>= 0.1)))

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -6,6 +6,7 @@ module Show = Show.Make (Config)
 module Syntax = Syntax.Make (Config)
 module Parser = Parser.Make (Config)
 module Codegen_func = Codegen_func.Make (Config)
+module Builtin = Builtin.Make (Config)
 
 open struct
   open Printf

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -1,17 +1,17 @@
 (* Compiler frontend *)
 
+module Config = Located.Enabled
+module Lang = Lang.Make (Config)
+module Show = Show.Make (Config)
+module Syntax = Syntax.Make (Config)
+module Parser = Parser.Make (Config)
+module Codegen_func = Codegen_func.Make (Config)
+
 open struct
   open Printf
   module I = UnitActionsParser.MenhirInterpreter
   module E = MenhirLib.ErrorReports
   module L = MenhirLib.LexerUtil
-  module Config = Located.Enabled
-  module Syntax = Syntax.Make (Config)
-  module Parser = Parser.Make (Config)
-  module Lang = Lang.Make (Config)
-  module Show = Show.Make (Config)
-  module Codegen_func = Codegen_func.Make (Config)
-
   (* [env checkpoint] extracts a parser environment out of a checkpoint,
      which must be of the form [HandlingError env]. *)
 

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -130,6 +130,7 @@ functor
 
     and program =
       { bindings : (string located * expr) list;
+        result : value option; [@sexp.option]
         mutable structs : (int * struct_) list; [@hash.ignore]
         mutable unions : (int * union) list; [@sexp.list] [@hash.ignore]
         mutable interfaces : (int * interface) list; [@sexp.list] [@hash.ignore]

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -51,6 +51,14 @@ functor
           pp_print_string f b
       | Type t ->
           pp_type f t
+      | Bool true ->
+          pp_print_string f "true"
+      | Bool false ->
+          pp_print_string f "false"
+      | String s ->
+          pp_print_string f {|"|} ;
+          pp_print_string f s ;
+          pp_print_string f {|"|}
       | _ ->
           pp_print_string f "<anonymous>"
 

--- a/tact.opam
+++ b/tact.opam
@@ -23,6 +23,7 @@ depends: [
   "ppx_jane" {>= "0.15.0"}
   "visitors" {= "20210608"}
   "containers" {>= "3.8.0"}
+  "linenoise" {>= "1.3.1"}
   "core" {with-test & >= "0.15.0"}
   "ppx_expect" {with-test & >= "0.15.0"}
   "ppx_matches" {with-test & >= "0.1"}

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -16,6 +16,101 @@ let add_bin_op_intf p =
   in
   {p with bindings = (bl "BinOp", bl intf_ty) :: p.bindings}
 
+let%expect_test "program returns" =
+  let sources =
+    [{| 1 |}; {| return 1|}; {| fn x() { 1 } x() |}; {| struct T {} |}]
+  in
+  List.iter ~f:pp_compile sources ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ()) (result (Integer 1)) (structs ()) (type_counter <opaque>)
+      (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (5
+        (((un_sig_cases ((StructType 59) (StructType 76))) (un_sig_methods ())
+          (un_sig_base_id 77))
+         ((un_sig_cases ((StructType 55))) (un_sig_methods ())
+          (un_sig_base_id 60))
+         ((un_sig_cases ((UnionType 21) (UnionType 39))) (un_sig_methods ())
+          (un_sig_base_id 44))
+         ((un_sig_cases ((StructType 31) (StructType 35))) (un_sig_methods ())
+          (un_sig_base_id 38))
+         ((un_sig_cases ((StructType 14) (StructType 18))) (un_sig_methods ())
+          (un_sig_base_id 20)))))))
+    (Ok
+                                    ((bindings ()) (result (Integer 1))
+                                     (structs ()) (type_counter <opaque>)
+                                     (memoized_fcalls <opaque>)
+                                     (struct_signs (0 ()))
+                                     (union_signs
+                                      (5
+                                       (((un_sig_cases
+                                          ((StructType 59) (StructType 76)))
+                                         (un_sig_methods ()) (un_sig_base_id 77))
+                                        ((un_sig_cases ((StructType 55)))
+                                         (un_sig_methods ()) (un_sig_base_id 60))
+                                        ((un_sig_cases
+                                          ((UnionType 21) (UnionType 39)))
+                                         (un_sig_methods ()) (un_sig_base_id 44))
+                                        ((un_sig_cases
+                                          ((StructType 31) (StructType 35)))
+                                         (un_sig_methods ()) (un_sig_base_id 38))
+                                        ((un_sig_cases
+                                          ((StructType 14) (StructType 18)))
+                                         (un_sig_methods ()) (un_sig_base_id 20)))))))
+
+    (Ok
+     ((bindings
+       ((x
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ()) (function_returns IntegerType)))
+            (function_impl (Fn (Return (Value (Integer 1)))))))))))
+      (result (Integer 1)) (structs ()) (type_counter <opaque>)
+      (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (5
+        (((un_sig_cases ((StructType 59) (StructType 76))) (un_sig_methods ())
+          (un_sig_base_id 77))
+         ((un_sig_cases ((StructType 55))) (un_sig_methods ())
+          (un_sig_base_id 60))
+         ((un_sig_cases ((UnionType 21) (UnionType 39))) (un_sig_methods ())
+          (un_sig_base_id 44))
+         ((un_sig_cases ((StructType 31) (StructType 35))) (un_sig_methods ())
+          (un_sig_base_id 38))
+         ((un_sig_cases ((StructType 14) (StructType 18))) (un_sig_methods ())
+          (un_sig_base_id 20)))))))
+    (Ok
+                                    ((bindings
+                                      ((T (Value (Type (StructType 84))))))
+                                     (structs
+                                      ((84
+                                        ((struct_fields ())
+                                         (struct_details
+                                          ((uty_methods ()) (uty_impls ())
+                                           (uty_id 84) (uty_base_id 83)))))))
+                                     (type_counter <opaque>)
+                                     (memoized_fcalls <opaque>)
+                                     (struct_signs (0 ()))
+                                     (union_signs
+                                      (5
+                                       (((un_sig_cases
+                                          ((StructType 59) (StructType 76)))
+                                         (un_sig_methods ()) (un_sig_base_id 77))
+                                        ((un_sig_cases ((StructType 55)))
+                                         (un_sig_methods ()) (un_sig_base_id 60))
+                                        ((un_sig_cases
+                                          ((UnionType 21) (UnionType 39)))
+                                         (un_sig_methods ()) (un_sig_base_id 44))
+                                        ((un_sig_cases
+                                          ((StructType 31) (StructType 35)))
+                                         (un_sig_methods ()) (un_sig_base_id 38))
+                                        ((un_sig_cases
+                                          ((StructType 14) (StructType 18)))
+                                         (un_sig_methods ()) (un_sig_base_id 20))))))) |}]
+
 let%expect_test "scope resolution" =
   let source = {|
     let T = Int(257);

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -88,11 +88,12 @@ functor
       parse_program s
       |> build_program ~prev_program ~strip_defaults ~codegen:(fun x -> x)
       |> fun res ->
-      match res with
+      ( match res with
       | Ok t ->
           pp_sexp @@ Result.sexp_of_t Lang.sexp_of_program sexp_of_errors (Ok t)
       | Error e ->
-          show_errors e s
+          show_errors e s ) ;
+      Caml.print_newline ()
 
     let pp_codegen ?(prev_program = Lang.default_program ())
         ?(strip_defaults = false) s =

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -1105,3 +1105,8 @@ let%expect_test "destructuring let with rest ignored" =
             (fields_construction
              (((Ident x) (Int 1)) ((Ident y) (Int 2)) ((Ident z) (Int 3)))))))
          (destructuring_binding_rest true)))))) |}]
+
+let%expect_test "program returns" =
+  let sources = [{| 1 |}; {| return 1|}] in
+  List.iter ~f:pp sources ;
+  [%expect {| ((stmts ((Expr (Int 1)))))((stmts ((Return (Int 1))))) |}]


### PR DESCRIPTION
When invoked without any arguments, `tact` will now work as a REPL.
Please note that printing facilities are still very limited and a lot of
values are not printed correctly, but we can address this as an ongoing
concern.

In terms of internal changes, this brings an optional `result` into
the program and allows `return` to be used in the top level.