### PR TITLE
Initial support for attributes

### DIFF
--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -28,7 +28,8 @@ functor
     let bl = builtin_located
 
     let make_load_result_with_id base_id id t =
-      { struct_fields =
+      { struct_attributes = [];
+        struct_fields =
           [ (bl "slice", {field_type = slice_struct});
             (bl "value", {field_type = t}) ];
         struct_details =
@@ -37,7 +38,8 @@ functor
                   bl
                     { function_signature =
                         bl
-                          { function_params =
+                          { function_attributes = [];
+                            function_params =
                               [(bl "s", slice_struct); (bl "v", t)];
                             function_returns = StructType id };
                       function_impl =
@@ -64,11 +66,13 @@ functor
       let base_id = -500 in
       let function_signature =
         bl
-          { function_params = [(bl "T", type0)];
+          { function_attributes = [];
+            function_params = [(bl "T", type0)];
             function_returns =
               (let id, _ =
                  Arena.with_id a ~f:(fun id ->
-                     { st_sig_fields =
+                     { st_sig_attributes = [];
+                       st_sig_fields =
                          [ (bl "slice", bl @@ Value (Type slice_struct));
                            ( bl "value",
                              bl
@@ -79,7 +83,8 @@ functor
                        st_sig_methods =
                          [ ( bl "new",
                              bl
-                               { function_params =
+                               { function_attributes = [];
+                                 function_params =
                                    [ (bl "s", slice_struct);
                                      ( bl "v",
                                        ExprType (bl @@ Reference (bl "T", type0))
@@ -113,10 +118,12 @@ functor
 
     let serialize_intf =
       let intf =
-        { interface_methods =
+        { interface_attributes = [];
+          interface_methods =
             [ ( "serialize",
                 bl
-                  { function_params =
+                  { function_attributes = [];
+                    function_params =
                       [(bl "self", SelfType); (bl "b", builder_struct)];
                     function_returns = builder_struct } ) ] }
       in
@@ -130,10 +137,12 @@ functor
             if String.equal name.value "LoadResult" then Some v else None )
       in
       let intf =
-        { interface_methods =
+        { interface_attributes = [];
+          interface_methods =
             [ ( "deserialize",
                 bl
-                  { function_params = [(bl "b", builder_struct)];
+                  { function_attributes = [];
+                    function_params = [(bl "b", builder_struct)];
                     function_returns =
                       ExprType
                         ( bl
@@ -149,11 +158,13 @@ functor
     let serializer =
       let function_signature =
         bl
-          { function_params = [(bl "t", type0)];
+          { function_attributes = [];
+            function_params = [(bl "t", type0)];
             function_returns =
               FunctionType
                 (bl
-                   { function_params =
+                   { function_attributes = [];
+                     function_params =
                        [(bl "t", HoleType); (bl "b", builder_struct)];
                      function_returns = builder_struct } ) }
       in
@@ -242,7 +253,8 @@ functor
         let body = Switch switch in
         { function_signature =
             bl
-              { function_params =
+              { function_attributes = [];
+                function_params =
                   [ (bl "self", UnionType union.union_details.uty_id);
                     (bl "b", builder_struct) ];
                 function_returns = builder_struct };
@@ -290,7 +302,8 @@ functor
         in
         { function_signature =
             bl
-              { function_params =
+              { function_attributes = [];
+                function_params =
                   [ (bl "self", StructType s.struct_details.uty_id);
                     (bl "b", builder_struct) ];
                 function_returns = builder_struct };
@@ -319,11 +332,13 @@ functor
       in
       let function_signature =
         bl
-          { function_params = [(bl "t", type0)];
+          { function_attributes = [];
+            function_params = [(bl "t", type0)];
             function_returns =
               FunctionType
                 (bl
-                   { function_params = [(bl "slice", slice_ty)];
+                   { function_attributes = [];
+                     function_params = [(bl "slice", slice_ty)];
                      function_returns =
                        ExprType
                          ( bl
@@ -392,7 +407,8 @@ functor
         let body = Block (deserialize_fields @ [bl @@ Return out]) in
         { function_signature =
             bl
-              { function_params = [(bl "slice", slice_ty)];
+              { function_attributes = [];
+                function_params = [(bl "slice", slice_ty)];
                 function_returns = load_result_ty };
           function_impl = Fn (bl body) }
       in
@@ -415,14 +431,19 @@ functor
 
     let from_intf_ =
       let function_signature =
-        bl {function_params = [(bl "T", type0)]; function_returns = HoleType}
+        bl
+          { function_attributes = [];
+            function_params = [(bl "T", type0)];
+            function_returns = HoleType }
       in
       let make_from p t =
         let intf =
-          { interface_methods =
+          { interface_attributes = [];
+            interface_methods =
               [ ( "from",
                   bl
-                    { function_params = [(bl "from", t)];
+                    { function_attributes = [];
+                      function_params = [(bl "from", t)];
                       function_returns = SelfType } ) ] }
         in
         let intf_ty = Program.insert_interface p intf in
@@ -445,7 +466,8 @@ functor
 
     let tensor2 t1 t2 =
       Hashtbl.find_or_add tensor2_hashtbl (t1, t2) ~default:(fun () ->
-          { struct_fields =
+          { struct_attributes = [];
+            struct_fields =
               [ (bl "value1", {field_type = t1});
                 (bl "value2", {field_type = t2}) ];
             struct_details =
@@ -487,7 +509,10 @@ functor
               (Function
                  (bl
                     { function_signature =
-                        bl {function_params = args; function_returns = ret_ty};
+                        bl
+                          { function_attributes = [];
+                            function_params = args;
+                            function_returns = ret_ty };
                       function_impl =
                         Fn
                           (bl

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -44,6 +44,7 @@ let whitespace = [' ' '\t']+
 rule token = parse
  | whitespace { token lexbuf }
  | newline  { next_line lexbuf; token lexbuf }
+ | "@" { AT }
  | ".." { DOUBLEDOT }
  | ',' { COMMA }
  | ':' { COLON }

--- a/lib/parserMessages.messages
+++ b/lib/parserMessages.messages
@@ -10,810 +10,9 @@ just_stmt: VAL
 
 Invalid syntax
 
-just_stmt: UNION VAL
-##
-## Ends in an error in state: 1.
-##
-## expr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ DOT ]
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## non_semicolon_stmt -> UNION . IDENT LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## stmt_expr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## UNION
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE VAL
-##
-## Ends in an error in state: 2.
-##
-## expr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ DOT ]
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE CASE VAL
-##
-## Ends in an error in state: 3.
-##
-## list(preceded(CASE,located(expr))) -> CASE . expr list(preceded(CASE,located(expr))) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## CASE
-##
-
-Invalid syntax
-
-just_stmt: RETURN UNION VAL
-##
-## Ends in an error in state: 4.
-##
-## expr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## UNION
-##
-
-Invalid syntax
-
-just_stmt: RETURN UNION LBRACE VAL
-##
-## Ends in an error in state: 5.
-##
-## expr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN VAL
-##
-## Ends in an error in state: 7.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located(ident),option(located(code_block))) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT VAL
-##
-## Ends in an error in state: 8.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN VAL
-##
-## Ends in an error in state: 9.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT VAL
-##
-## Ends in an error in state: 10.
-##
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT . COLON expr COMMA [ RPAREN RBRACKET ]
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT . COLON expr [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT . COLON expr COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON VAL
-##
-## Ends in an error in state: 11.
-##
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON . expr COMMA [ RPAREN RBRACKET ]
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT COLON . expr [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT COLON . expr COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## IDENT COLON
-##
-
-Invalid syntax
-
-just_stmt: RETURN TILDE VAL
-##
-## Ends in an error in state: 12.
-##
-## expr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> TILDE . IDENT [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## TILDE
-##
-
-Invalid syntax
-
-just_stmt: RETURN TILDE IDENT UNION
-##
-## Ends in an error in state: 13.
-##
-## expr -> TILDE IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> TILDE IDENT . [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## TILDE IDENT
-##
-
-Invalid syntax
-
-just_stmt: RETURN STRUCT VAL
-##
-## Ends in an error in state: 14.
-##
-## expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACKET VAL
-##
-## Ends in an error in state: 15.
-##
-## option(params) -> LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET [ LBRACE ]
-## option(params) -> LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 17.
-##
-## option(params) -> LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 19.
-##
-## option(params) -> LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LBRACKET loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: RETURN STRUCT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 21.
-##
-## expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params)
-##
-
-Invalid syntax
-
-just_stmt: RETURN STRUCT LBRACE UNION
-##
-## Ends in an error in state: 22.
-##
-## expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE VAL VAL
-##
-## Ends in an error in state: 23.
-##
-## list(struct_field) -> VAL . IDENT COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE VAL IDENT VAL
-##
-## Ends in an error in state: 24.
-##
-## list(struct_field) -> VAL IDENT . COLON expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL IDENT
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE VAL IDENT COLON VAL
-##
-## Ends in an error in state: 25.
-##
-## list(struct_field) -> VAL IDENT COLON . expr option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL IDENT COLON
-##
-
-Invalid syntax
-
-just_stmt: RETURN STRING UNION
-##
-## Ends in an error in state: 26.
-##
-## expr -> STRING . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> STRING . [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## STRING
-##
-
-Invalid syntax
-
-just_stmt: LPAREN VAL
-##
-## Ends in an error in state: 27.
-##
-## fexpr -> LPAREN . struct_constructor RPAREN [ LPAREN LBRACKET ]
-## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ LPAREN LBRACKET ]
-## type_expr -> LPAREN . STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . IDENT RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . function_call RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . INT RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . BOOL RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . STRING RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN . TILDE IDENT RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
-##
-
-Invalid syntax
-
-just_stmt: LPAREN UNION VAL
-##
-## Ends in an error in state: 28.
-##
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN UNION
-##
-
-Invalid syntax
-
-just_stmt: LPAREN UNION LBRACE VAL
-##
-## Ends in an error in state: 29.
-##
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN UNION LBRACE
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE IMPL VAL
-##
-## Ends in an error in state: 32.
-##
-## list(impl) -> IMPL . fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON UNION VAL
-##
-## Ends in an error in state: 33.
-##
-## fexpr -> UNION . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## UNION
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON UNION LBRACE VAL
-##
-## Ends in an error in state: 34.
-##
-## fexpr -> UNION LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## UNION LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN LBRACE RBRACE VAL
-##
-## Ends in an error in state: 39.
-##
-## list(sugared_function_definition(option(located(code_block)))) -> function_definition(located_ident_with_params,option(located(code_block))) . list(sugared_function_definition(option(located(code_block)))) [ RBRACE IMPL ]
-##
-## The known suffix of the stack is as follows:
-## function_definition(located_ident_with_params,option(located(code_block)))
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN RPAREN LBRACE RBRACE VAL
-##
-## Ends in an error in state: 41.
-##
-## list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) . list(sugared_function_definition(option(located(code_block)))) [ RBRACE IMPL ]
-##
-## The known suffix of the stack is as follows:
-## function_definition(located(ident),option(located(code_block)))
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON TILDE VAL
-##
-## Ends in an error in state: 43.
-##
-## fexpr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## TILDE
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON STRUCT VAL
-##
-## Ends in an error in state: 45.
-##
-## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON STRUCT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 46.
-##
-## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params)
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON STRUCT LBRACE UNION
-##
-## Ends in an error in state: 47.
-##
-## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE IMPL LPAREN VAL
-##
-## Ends in an error in state: 53.
-##
-## fexpr -> LPAREN . struct_constructor RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON INTERFACE VAL
-##
-## Ends in an error in state: 54.
-##
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON INTERFACE LBRACE VAL
-##
-## Ends in an error in state: 55.
-##
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE LBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN VAL
-##
-## Ends in an error in state: 56.
-##
-## function_definition(located(ident),nothing) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-## function_definition(located(ident),nothing) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## FN
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN IDENT VAL
-##
-## Ends in an error in state: 57.
-##
-## function_definition(located(ident),nothing) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-## function_definition(located(ident),nothing) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN VAL
-##
-## Ends in an error in state: 58.
-##
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 59.
-##
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 60.
-##
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN RPAREN RARROW VAL
-##
-## Ends in an error in state: 61.
-##
-## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ VAL SEMICOLON RPAREN RBRACKET RBRACE LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## RARROW
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON ENUM VAL
-##
-## Ends in an error in state: 64.
-##
-## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## ENUM
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON ENUM LBRACE VAL
-##
-## Ends in an error in state: 65.
-##
-## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE IDENT VAL
-##
-## Ends in an error in state: 66.
-##
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT . [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT . EQUALS expr [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT . COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT . EQUALS expr COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE IDENT EQUALS VAL
-##
-## Ends in an error in state: 67.
-##
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS . expr [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS . expr COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## IDENT EQUALS
-##
-
-Invalid syntax
-
-just_stmt: RETURN INTERFACE VAL
-##
-## Ends in an error in state: 68.
-##
-## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE
-##
-
-Invalid syntax
-
-just_stmt: RETURN INTERFACE LBRACE VAL
-##
-## Ends in an error in state: 69.
-##
-## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE LBRACE
-##
-
-Invalid syntax
-
-just_stmt: RETURN INTERFACE LBRACE RBRACE UNION
-##
-## Ends in an error in state: 71.
-##
-## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 72.
-##
-## list(located(function_signature_binding)) -> function_definition(located(ident),nothing) . list(located(function_signature_binding)) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## function_definition(located(ident),nothing)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 384, spurious reduction of production function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-
-Invalid syntax
-
-just_stmt: RETURN INT UNION
-##
-## Ends in an error in state: 74.
-##
-## expr -> INT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> INT . [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## INT
-##
-
-Invalid syntax
-
-just_stmt: RETURN IDENT UNION
-##
-## Ends in an error in state: 75.
-##
-## expr -> IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> IDENT . [ LPAREN LBRACKET ]
-## type_expr -> IDENT . [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IDENT
-##
-
-Invalid syntax
-
-just_stmt: RETURN FN VAL
-##
-## Ends in an error in state: 76.
-##
-## function_definition(nothing,option(located(code_block))) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## function_definition(nothing,option(located(code_block))) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## FN
-##
-
-Invalid syntax
-
-just_stmt: RETURN FN LPAREN VAL
-##
-## Ends in an error in state: 77.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN
-##
-
-Invalid syntax
-
-just_stmt: RETURN FN LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 78.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: RETURN FN LPAREN IDENT COLON BOOL COMMA RPAREN UNION
-##
-## Ends in an error in state: 79.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: LBRACE VAL
-##
-## Ends in an error in state: 81.
-##
-## code_block -> LBRACE . block_stmt RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
-## code_block -> LBRACE . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
-##
-## The known suffix of the stack is as follows:
-## LBRACE
-##
-
-Invalid syntax
-
 just_stmt: TILDE VAL
 ##
-## Ends in an error in state: 82.
+## Ends in an error in state: 1.
 ##
 ## expr -> TILDE . IDENT [ DOT ]
 ## fexpr -> TILDE . IDENT [ LPAREN LBRACKET ]
@@ -827,7 +26,7 @@ Invalid syntax
 
 just_stmt: TILDE IDENT VAL
 ##
-## Ends in an error in state: 83.
+## Ends in an error in state: 2.
 ##
 ## expr -> TILDE IDENT . [ DOT ]
 ## fexpr -> TILDE IDENT . [ LPAREN LBRACKET ]
@@ -841,9 +40,9 @@ Invalid syntax
 
 just_stmt: SWITCH VAL
 ##
-## Ends in an error in state: 84.
+## Ends in an error in state: 3.
 ##
-## switch -> SWITCH . LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH . LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH
@@ -853,9 +52,9 @@ Invalid syntax
 
 just_stmt: SWITCH LPAREN VAL
 ##
-## Ends in an error in state: 85.
+## Ends in an error in state: 4.
 ##
-## switch -> SWITCH LPAREN . expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN . expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## SWITCH LPAREN
@@ -863,113 +62,217 @@ just_stmt: SWITCH LPAREN VAL
 
 Invalid syntax
 
-just_stmt: RETURN ENUM VAL
+just_stmt: RETURN TILDE VAL
 ##
-## Ends in an error in state: 86.
+## Ends in an error in state: 5.
 ##
-## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## expr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> TILDE . IDENT [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM
+## TILDE
 ##
 
 Invalid syntax
 
-just_stmt: RETURN ENUM LBRACE VAL
+just_stmt: RETURN TILDE IDENT UNION
 ##
-## Ends in an error in state: 87.
+## Ends in an error in state: 6.
 ##
-## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## expr -> TILDE IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> TILDE IDENT . [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE
+## TILDE IDENT
 ##
 
 Invalid syntax
 
-just_stmt: RETURN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
+just_stmt: RETURN STRING UNION
 ##
-## Ends in an error in state: 90.
+## Ends in an error in state: 7.
 ##
-## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
+## expr -> STRING . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> STRING . [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
+## STRING
 ##
 
 Invalid syntax
 
-just_stmt: RETURN ENUM LBRACE IDENT COMMA RBRACE UNION
+just_stmt: LPAREN VAL
 ##
-## Ends in an error in state: 91.
+## Ends in an error in state: 8.
 ##
-## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## fexpr -> LPAREN . struct_constructor RPAREN [ LPAREN LBRACKET ]
+## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ LPAREN LBRACKET ]
+## type_expr -> LPAREN . attributes STRUCT option(params) LBRACE list(struct_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . attributes UNION LBRACE list(union_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . IDENT RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . function_call RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . INT RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . BOOL RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . STRING RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN . TILDE IDENT RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+## LPAREN
 ##
 
 Invalid syntax
 
-just_stmt: RETURN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
+just_stmt: LPAREN TILDE VAL
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 9.
 ##
-## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
+## fexpr -> TILDE . IDENT [ LPAREN LBRACKET ]
+## type_expr -> LPAREN TILDE . IDENT RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
+## LPAREN TILDE
 ##
 
 Invalid syntax
 
-just_stmt: RETURN ENUM LBRACE RBRACE UNION
+just_stmt: LPAREN TILDE IDENT VAL
 ##
-## Ends in an error in state: 94.
+## Ends in an error in state: 10.
 ##
-## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## fexpr -> TILDE IDENT . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN TILDE IDENT . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+## LPAREN TILDE IDENT
+##
+
+Invalid syntax
+
+just_stmt: LPAREN STRING VAL
+##
+## Ends in an error in state: 12.
+##
+## fexpr -> STRING . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN STRING . RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN STRING
+##
+
+Invalid syntax
+
+just_stmt: LPAREN INT VAL
+##
+## Ends in an error in state: 14.
+##
+## fexpr -> INT . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN INT . RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN INT
+##
+
+Invalid syntax
+
+just_stmt: LPAREN IDENT VAL
+##
+## Ends in an error in state: 16.
+##
+## fexpr -> IDENT . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN IDENT . RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> IDENT . [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN IDENT
+##
+
+Invalid syntax
+
+just_stmt: LPAREN BOOL VAL
+##
+## Ends in an error in state: 18.
+##
+## fexpr -> BOOL . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN BOOL . RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN BOOL
+##
+
+Invalid syntax
+
+just_stmt: AT VAL
+##
+## Ends in an error in state: 20.
+##
+## attribute -> AT . IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+##
+## The known suffix of the stack is as follows:
+## AT
+##
+
+Invalid syntax
+
+just_stmt: AT IDENT TILDE
+##
+## Ends in an error in state: 21.
+##
+## attribute -> AT IDENT . option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+##
+## The known suffix of the stack is as follows:
+## AT IDENT
+##
+
+Invalid syntax
+
+just_stmt: AT IDENT LPAREN VAL
+##
+## Ends in an error in state: 22.
+##
+## option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) -> LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+## option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) -> LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN
+##
+
+Invalid syntax
+
+just_stmt: RETURN INT UNION
+##
+## Ends in an error in state: 23.
+##
+## expr -> INT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> INT . [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## INT
+##
+
+Invalid syntax
+
+just_stmt: RETURN IDENT UNION
+##
+## Ends in an error in state: 24.
+##
+## expr -> IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> IDENT . [ LPAREN LBRACKET ]
+## type_expr -> IDENT . [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
 ##
 
 Invalid syntax
 
 just_stmt: RETURN BOOL UNION
 ##
-## Ends in an error in state: 95.
+## Ends in an error in state: 25.
 ##
-## expr -> BOOL . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> BOOL . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ## fexpr -> BOOL . [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
@@ -980,10 +283,10 @@ Invalid syntax
 
 just_stmt: LPAREN BOOL RPAREN IDENT
 ##
-## Ends in an error in state: 96.
+## Ends in an error in state: 26.
 ##
-## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## struct_constructor -> type_expr . LBRACE nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## struct_constructor -> type_expr . LBRACE loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_expr
@@ -993,10 +296,10 @@ Invalid syntax
 
 just_stmt: IDENT LBRACE VAL
 ##
-## Ends in an error in state: 97.
+## Ends in an error in state: 27.
 ##
-## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## struct_constructor -> type_expr LBRACE . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## struct_constructor -> type_expr LBRACE . loption(separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_expr LBRACE
@@ -1006,7 +309,7 @@ Invalid syntax
 
 just_stmt: IDENT LBRACE IDENT VAL
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 28.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1021,7 +324,7 @@ Invalid syntax
 
 just_stmt: IDENT LBRACE IDENT COLON VAL
 ##
-## Ends in an error in state: 99.
+## Ends in an error in state: 29.
 ##
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA [ RBRACE ]
 ## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
@@ -1036,9 +339,9 @@ Invalid syntax
 
 just_stmt: RETURN BOOL LBRACKET RBRACKET UNION
 ##
-## Ends in an error in state: 102.
+## Ends in an error in state: 33.
 ##
-## expr -> function_call . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> function_call . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ## fexpr -> function_call . [ LPAREN LBRACKET ]
 ## type_expr -> function_call . [ LBRACE ]
 ##
@@ -1050,12 +353,12 @@ Invalid syntax
 
 just_stmt: LET IDENT COLON BOOL VAL
 ##
-## Ends in an error in state: 103.
+## Ends in an error in state: 34.
 ##
-## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr
@@ -1065,10 +368,10 @@ Invalid syntax
 
 just_stmt: BOOL LPAREN VAL
 ##
-## Ends in an error in state: 104.
+## Ends in an error in state: 35.
 ##
-## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## function_call -> fexpr LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+## function_call -> fexpr LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr LPAREN
@@ -1078,9 +381,9 @@ Invalid syntax
 
 just_stmt: BOOL LPAREN BOOL COMMA RBRACKET
 ##
-## Ends in an error in state: 106.
+## Ends in an error in state: 37.
 ##
-## function_call -> fexpr LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## function_call -> fexpr LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr LPAREN nonempty_list(terminated(located(expr),COMMA))
@@ -1089,16 +392,16 @@ just_stmt: BOOL LPAREN BOOL COMMA RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 118, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+## In state 459, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
 ##
 
 Invalid syntax
 
 just_stmt: BOOL LPAREN BOOL RBRACKET
 ##
-## Ends in an error in state: 108.
+## Ends in an error in state: 39.
 ##
-## function_call -> fexpr LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## function_call -> fexpr LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## fexpr LPAREN loption(separated_nonempty_list(COMMA,located(expr)))
@@ -1107,16 +410,16 @@ just_stmt: BOOL LPAREN BOOL RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 110, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
-## In state 105, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 41, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
+## In state 36, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
 ##
 
 Invalid syntax
 
 just_stmt: BOOL LBRACKET BOOL VAL
 ##
-## Ends in an error in state: 110.
+## Ends in an error in state: 41.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN RBRACKET DOT COMMA ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN RBRACKET DOT COMMA ]
@@ -1133,18 +436,18 @@ just_stmt: BOOL LBRACKET BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: RETURN BOOL DOT VAL
 ##
-## Ends in an error in state: 111.
+## Ends in an error in state: 42.
 ##
-## expr -> expr DOT . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> expr DOT . IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> expr DOT . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> expr DOT . IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT
@@ -1154,11 +457,11 @@ Invalid syntax
 
 just_stmt: RETURN BOOL DOT IDENT UNION
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 43.
 ##
-## expr -> expr DOT IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> expr DOT IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> expr DOT IDENT . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> expr DOT IDENT . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT IDENT
@@ -1168,10 +471,10 @@ Invalid syntax
 
 just_stmt: RETURN BOOL DOT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 113.
+## Ends in an error in state: 44.
 ##
-## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT IDENT LPAREN
@@ -1181,9 +484,9 @@ Invalid syntax
 
 just_stmt: RETURN BOOL DOT IDENT LPAREN BOOL COMMA RBRACKET
 ##
-## Ends in an error in state: 114.
+## Ends in an error in state: 45.
 ##
-## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA))
@@ -1192,16 +495,16 @@ just_stmt: RETURN BOOL DOT IDENT LPAREN BOOL COMMA RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 118, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+## In state 459, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
 ##
 
 Invalid syntax
 
 just_stmt: RETURN BOOL DOT IDENT LPAREN BOOL RBRACKET
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 47.
 ##
-## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr)))
@@ -1210,166 +513,77 @@ just_stmt: RETURN BOOL DOT IDENT LPAREN BOOL RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 110, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
-## In state 105, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 41, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
+## In state 36, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
 ##
 
 Invalid syntax
 
-just_stmt: BOOL LBRACKET BOOL COMMA VAL
+just_stmt: RETURN AT IDENT IMPL
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 49.
 ##
-## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN RBRACKET ]
-## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,located(expr)) -> expr COMMA . separated_nonempty_list(COMMA,located(expr)) [ RPAREN RBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: BOOL LBRACKET VAL
-##
-## Ends in an error in state: 121.
-##
-## function_call -> fexpr LBRACKET . nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-## function_call -> fexpr LBRACKET . loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## expr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes . UNION LBRACE list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . UNION LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## function_definition(nothing,option(located(code_block))) -> attributes . FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_definition(nothing,option(located(code_block))) -> attributes . FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## fexpr LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: BOOL LBRACKET BOOL COMMA RPAREN
-##
-## Ends in an error in state: 122.
-##
-## function_call -> fexpr LBRACKET nonempty_list(terminated(located(expr),COMMA)) . RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## fexpr LBRACKET nonempty_list(terminated(located(expr),COMMA))
+## attributes
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 118, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
 ##
 
 Invalid syntax
 
-just_stmt: BOOL LBRACKET BOOL RPAREN
+just_stmt: RETURN UNION VAL
 ##
-## Ends in an error in state: 124.
+## Ends in an error in state: 50.
 ##
-## function_call -> fexpr LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) . RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE ]
+## expr -> attributes UNION . LBRACE list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes UNION . LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## fexpr LBRACKET loption(separated_nonempty_list(COMMA,located(expr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 110, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
-## In state 105, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
+## attributes UNION
 ##
 
 Invalid syntax
 
-just_stmt: IDENT LBRACE IDENT COLON BOOL VAL
+just_stmt: RETURN UNION LBRACE VAL
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 51.
 ##
-## expr -> expr . DOT IDENT [ RBRACE DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE DOT COMMA ]
-## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
-## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
-## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . [ RBRACE ]
-## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . COMMA separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) [ RBRACE ]
+## expr -> attributes UNION LBRACE . list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes UNION LBRACE . list(union_item) RBRACE [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## IDENT COLON expr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## attributes UNION LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: IDENT LBRACE IDENT COLON BOOL COMMA VAL
+just_stmt: UNION LBRACE CASE VAL
 ##
-## Ends in an error in state: 127.
+## Ends in an error in state: 52.
 ##
-## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
-## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
-## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr COMMA . separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL VAL
-##
-## Ends in an error in state: 135.
-##
-## expr -> expr . DOT IDENT [ RPAREN DOT ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT ]
-## switch -> SWITCH LPAREN expr . RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## SWITCH LPAREN expr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL RPAREN VAL
-##
-## Ends in an error in state: 136.
-##
-## switch -> SWITCH LPAREN expr RPAREN . LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## SWITCH LPAREN expr RPAREN
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE VAL
-##
-## Ends in an error in state: 137.
-##
-## switch -> SWITCH LPAREN expr RPAREN LBRACE . list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## SWITCH LPAREN expr RPAREN LBRACE
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
-##
-## Ends in an error in state: 138.
-##
-## switch_branch -> CASE . type_expr IDENT REARROW code_block [ RBRACE ELSE CASE ]
+## list(union_item) -> CASE . expr list(union_item) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE
@@ -1377,9 +591,135 @@ just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
 
 Invalid syntax
 
+just_stmt: UNION LBRACE CASE BOOL VAL
+##
+## Ends in an error in state: 53.
+##
+## expr -> expr . DOT IDENT [ RBRACE IMPL FN DOT CASE AT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN DOT CASE AT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE IMPL FN DOT CASE AT ]
+## list(union_item) -> CASE expr . list(union_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## CASE expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN VAL
+##
+## Ends in an error in state: 55.
+##
+## list(union_item) -> function_definition(located_ident_with_params,option(located(code_block))) . list(union_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located_ident_with_params,option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 416, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 417, spurious reduction of production option(located(code_block)) ->
+## In state 418, spurious reduction of production function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LPAREN RPAREN VAL
+##
+## Ends in an error in state: 57.
+##
+## list(union_item) -> function_definition(located(ident),option(located(code_block))) . list(union_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located(ident),option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 393, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 394, spurious reduction of production option(located(code_block)) ->
+## In state 395, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE AT IDENT UNION
+##
+## Ends in an error in state: 59.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN CASE AT ]
+## list(union_item) -> attributes . IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(union_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE IMPL VAL
+##
+## Ends in an error in state: 60.
+##
+## list(union_item) -> attributes IMPL . fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(union_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes IMPL
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON TILDE VAL
+##
+## Ends in an error in state: 61.
+##
+## fexpr -> TILDE . IDENT [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## TILDE
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE IMPL LPAREN VAL
+##
+## Ends in an error in state: 64.
+##
+## fexpr -> LPAREN . struct_constructor RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> LPAREN . function_definition(nothing,nothing) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN
+##
+
+Invalid syntax
+
 just_stmt: LET IDENT COLON IDENT VAL
 ##
-## Ends in an error in state: 139.
+## Ends in an error in state: 66.
 ##
 ## fexpr -> IDENT . [ LPAREN LBRACKET ]
 ## type_expr -> IDENT . [ LBRACE IDENT EQUALS ]
@@ -1390,51 +730,40 @@ just_stmt: LET IDENT COLON IDENT VAL
 
 Invalid syntax
 
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT LBRACE
+just_stmt: LPAREN IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 68.
 ##
-## switch_branch -> CASE type_expr . IDENT REARROW code_block [ RBRACE ELSE CASE ]
+## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## CASE type_expr
+## LPAREN struct_constructor
+##
+
+Invalid syntax
+
+just_stmt: LPAREN FN LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 70.
+##
+## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN function_definition(nothing,nothing)
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 139, spurious reduction of production type_expr -> IDENT
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT VAL
-##
-## Ends in an error in state: 142.
-##
-## switch_branch -> CASE type_expr IDENT . REARROW code_block [ RBRACE ELSE CASE ]
-##
-## The known suffix of the stack is as follows:
-## CASE type_expr IDENT
-##
-
-Invalid syntax
-
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW VAL
-##
-## Ends in an error in state: 143.
-##
-## switch_branch -> CASE type_expr IDENT REARROW . code_block [ RBRACE ELSE CASE ]
-##
-## The known suffix of the stack is as follows:
-## CASE type_expr IDENT REARROW
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 426, spurious reduction of production function_definition(nothing,nothing) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT COLON BOOL LBRACKET RBRACKET VAL
 ##
-## Ends in an error in state: 145.
+## Ends in an error in state: 72.
 ##
 ## fexpr -> function_call . [ LPAREN LBRACKET ]
 ## type_expr -> function_call . [ LBRACE IDENT EQUALS ]
@@ -1445,241 +774,977 @@ just_stmt: LET IDENT COLON BOOL LBRACKET RBRACKET VAL
 
 Invalid syntax
 
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW LBRACE RBRACE VAL
+just_stmt: UNION LBRACE IMPL LPAREN AT IDENT IMPL
+##
+## Ends in an error in state: 73.
+##
+## fexpr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . UNION LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## function_definition(nothing,nothing) -> attributes . FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes . FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON UNION VAL
+##
+## Ends in an error in state: 74.
+##
+## fexpr -> attributes UNION . LBRACE list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON UNION LBRACE VAL
+##
+## Ends in an error in state: 75.
+##
+## fexpr -> attributes UNION LBRACE . list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION LBRACE
+##
+
+Invalid syntax
+
+just_stmt: AT IDENT LPAREN RPAREN TILDE
+##
+## Ends in an error in state: 78.
+##
+## list(attribute) -> attribute . list(attribute) [ VAL UNION STRUCT INTERFACE IMPL FN ENUM ]
+##
+## The known suffix of the stack is as follows:
+## attribute
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON STRUCT VAL
+##
+## Ends in an error in state: 80.
+##
+## fexpr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET VAL
+##
+## Ends in an error in state: 81.
+##
+## option(params) -> LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET [ LBRACE ]
+## option(params) -> LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT VAL
+##
+## Ends in an error in state: 82.
+##
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT . COLON expr COMMA [ RPAREN RBRACKET ]
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT . COLON expr COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT . COLON expr [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT . COLON expr COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT COLON VAL
+##
+## Ends in an error in state: 83.
+##
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON . expr COMMA [ RPAREN RBRACKET ]
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON . expr COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT COLON . expr [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT COLON . expr COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT COLON BOOL VAL
+##
+## Ends in an error in state: 84.
+##
+## expr -> expr . DOT IDENT [ RPAREN RBRACKET DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN RBRACKET DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN RBRACKET DOT COMMA ]
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN RBRACKET ]
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT COLON BOOL COMMA VAL
+##
+## Ends in an error in state: 85.
+##
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN RBRACKET ]
+## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr COMMA . separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 89.
+##
+## option(params) -> LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 91.
+##
+## option(params) -> LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET [ LBRACE ]
+##
+## The known suffix of the stack is as follows:
+## LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON STRUCT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 93.
+##
+## fexpr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params)
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON STRUCT LBRACE UNION
+##
+## Ends in an error in state: 94.
+##
+## fexpr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params) LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN CASE
+##
+## Ends in an error in state: 97.
+##
+## list(struct_item) -> function_definition(located_ident_with_params,option(located(code_block))) . list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located_ident_with_params,option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 416, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 417, spurious reduction of production option(located(code_block)) ->
+## In state 418, spurious reduction of production function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE FN IDENT LPAREN RPAREN CASE
+##
+## Ends in an error in state: 99.
+##
+## list(struct_item) -> function_definition(located(ident),option(located(code_block))) . list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located(ident),option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 393, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 394, spurious reduction of production option(located(code_block)) ->
+## In state 395, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE AT IDENT UNION
+##
+## Ends in an error in state: 101.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN AT ]
+## list(struct_item) -> attributes . VAL IDENT COLON expr option(SEMICOLON) list(struct_item) [ RBRACE ]
+## list(struct_item) -> attributes . IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE VAL VAL
+##
+## Ends in an error in state: 102.
+##
+## list(struct_item) -> attributes VAL . IDENT COLON expr option(SEMICOLON) list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes VAL
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE VAL IDENT VAL
+##
+## Ends in an error in state: 103.
+##
+## list(struct_item) -> attributes VAL IDENT . COLON expr option(SEMICOLON) list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes VAL IDENT
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE VAL IDENT COLON VAL
+##
+## Ends in an error in state: 104.
+##
+## list(struct_item) -> attributes VAL IDENT COLON . expr option(SEMICOLON) list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes VAL IDENT COLON
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE VAL IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 105.
+##
+## expr -> expr . DOT IDENT [ VAL SEMICOLON RBRACE IMPL FN DOT AT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT AT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT AT ]
+## list(struct_item) -> attributes VAL IDENT COLON expr . option(SEMICOLON) list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes VAL IDENT COLON expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE VAL IDENT COLON BOOL SEMICOLON UNION
+##
+## Ends in an error in state: 107.
+##
+## list(struct_item) -> attributes VAL IDENT COLON expr option(SEMICOLON) . list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes VAL IDENT COLON expr option(SEMICOLON)
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE IMPL VAL
+##
+## Ends in an error in state: 109.
+##
+## list(struct_item) -> attributes IMPL . fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes IMPL
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE IMPL IDENT VAL
+##
+## Ends in an error in state: 112.
+##
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ LPAREN LBRACKET LBRACE ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ LPAREN LBRACKET LBRACE ]
+## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ LPAREN LBRACKET LBRACE ]
+## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ LPAREN LBRACKET LBRACE ]
+## list(struct_item) -> attributes IMPL fexpr . LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes IMPL fexpr
+##
+
+Invalid syntax
+
+just_stmt: BOOL LBRACKET VAL
+##
+## Ends in an error in state: 113.
+##
+## function_call -> fexpr LBRACKET . nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+## function_call -> fexpr LBRACKET . loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## fexpr LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: BOOL LBRACKET BOOL COMMA RPAREN
+##
+## Ends in an error in state: 114.
+##
+## function_call -> fexpr LBRACKET nonempty_list(terminated(located(expr),COMMA)) . RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## fexpr LBRACKET nonempty_list(terminated(located(expr),COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 459, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: BOOL LBRACKET BOOL RPAREN
+##
+## Ends in an error in state: 116.
+##
+## function_call -> fexpr LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) . RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL IDENT FN EQUALS EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## fexpr LBRACKET loption(separated_nonempty_list(COMMA,located(expr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 41, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
+## In state 36, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE IMPL IDENT LBRACE VAL
+##
+## Ends in an error in state: 118.
+##
+## list(struct_item) -> attributes IMPL fexpr LBRACE . list(sugared_function_definition(option(located(code_block)))) RBRACE list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes IMPL fexpr LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE IMPL IDENT LBRACE RBRACE UNION
+##
+## Ends in an error in state: 120.
+##
+## list(struct_item) -> attributes IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE . list(struct_item) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## attributes IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN VAL
+##
+## Ends in an error in state: 122.
+##
+## list(sugared_function_definition(option(located(code_block)))) -> function_definition(located_ident_with_params,option(located(code_block))) . list(sugared_function_definition(option(located(code_block)))) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located_ident_with_params,option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 416, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 417, spurious reduction of production option(located(code_block)) ->
+## In state 418, spurious reduction of production function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
+##
+## Ends in an error in state: 124.
+##
+## list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) . list(sugared_function_definition(option(located(code_block)))) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located(ident),option(located(code_block)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 393, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
+## In state 394, spurious reduction of production option(located(code_block)) ->
+## In state 395, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE AT IDENT UNION
+##
+## Ends in an error in state: 126.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes . FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN VAL
+##
+## Ends in an error in state: 127.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT VAL
+##
+## Ends in an error in state: 128.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LPAREN VAL
+##
+## Ends in an error in state: 129.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 130.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN UNION
+##
+## Ends in an error in state: 131.
+##
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN RPAREN RARROW VAL
+##
+## Ends in an error in state: 132.
+##
+## option(preceded(RARROW,located(fexpr))) -> RARROW . fexpr [ VAL SEMICOLON RPAREN RBRACKET RBRACE LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## RARROW
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN RPAREN RARROW IDENT UNION
+##
+## Ends in an error in state: 133.
+##
+## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## option(preceded(RARROW,located(fexpr))) -> RARROW fexpr . [ VAL SEMICOLON RPAREN RBRACKET RBRACE LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON AT IDENT FN
+##
+## Ends in an error in state: 134.
+##
+## fexpr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes . UNION LBRACE list(union_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON INTERFACE VAL
+##
+## Ends in an error in state: 135.
+##
+## fexpr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE
+##
+
+Invalid syntax
+
+just_stmt: LET IDENT COLON INTERFACE LBRACE VAL
+##
+## Ends in an error in state: 136.
+##
+## fexpr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE LBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 139.
+##
+## list(located(function_signature_binding)) -> function_definition(located(ident),nothing) . list(located(function_signature_binding)) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## function_definition(located(ident),nothing)
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## In state 150, spurious reduction of production function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE AT IDENT UNION
+##
+## Ends in an error in state: 141.
+##
+## function_definition(located(ident),nothing) -> attributes . FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+## function_definition(located(ident),nothing) -> attributes . FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN VAL
+##
+## Ends in an error in state: 142.
+##
+## function_definition(located(ident),nothing) -> attributes FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+## function_definition(located(ident),nothing) -> attributes FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT VAL
+##
+## Ends in an error in state: 143.
+##
+## function_definition(located(ident),nothing) -> attributes FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+## function_definition(located(ident),nothing) -> attributes FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN VAL
+##
+## Ends in an error in state: 144.
+##
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 145.
+##
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
 ## Ends in an error in state: 146.
 ##
-## list(located(switch_branch)) -> switch_branch . list(located(switch_branch)) [ RBRACE ELSE ]
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
 ##
 ## The known suffix of the stack is as follows:
-## switch_branch
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE VAL
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 148.
+##
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
 ##
 ## Ends in an error in state: 149.
 ##
-## default_branch -> ELSE . REARROW code_block [ RBRACE ]
+## function_definition(located(ident),nothing) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN AT ]
 ##
 ## The known suffix of the stack is as follows:
-## ELSE
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW VAL
+just_stmt: LET IDENT COLON ENUM VAL
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 151.
 ##
-## default_branch -> ELSE REARROW . code_block [ RBRACE ]
+## fexpr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## ELSE REARROW
+## attributes ENUM
 ##
 
 Invalid syntax
 
-just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW LBRACE RBRACE VAL
+just_stmt: LET IDENT COLON ENUM LBRACE VAL
 ##
 ## Ends in an error in state: 152.
 ##
-## switch -> SWITCH LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## fexpr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## SWITCH LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch)
+## attributes ENUM LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: STRUCT VAL
+just_stmt: ENUM LBRACE IDENT VAL
+##
+## Ends in an error in state: 153.
+##
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT . EQUALS expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT . [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT . EQUALS expr [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT . COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT . EQUALS expr COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## IDENT
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE IDENT EQUALS VAL
+##
+## Ends in an error in state: 154.
+##
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS . expr COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS . expr [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS . expr COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
+##
+## The known suffix of the stack is as follows:
+## IDENT EQUALS
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE IDENT EQUALS BOOL VAL
 ##
 ## Ends in an error in state: 155.
 ##
-## expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ DOT ]
-## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## non_semicolon_stmt -> STRUCT . IDENT LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> STRUCT . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> STRUCT . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## stmt_expr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
+## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA AT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN DOT COMMA AT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN DOT COMMA AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT
+## IDENT EQUALS expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
-just_stmt: STRUCT IDENT VAL
+just_stmt: ENUM LBRACE IDENT EQUALS BOOL COMMA VAL
 ##
 ## Ends in an error in state: 156.
 ##
-## non_semicolon_stmt -> STRUCT IDENT . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> STRUCT IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> STRUCT IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr COMMA . separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT
+## IDENT EQUALS expr COMMA
 ##
 
 Invalid syntax
 
-just_stmt: STRUCT IDENT LBRACKET VAL
-##
-## Ends in an error in state: 157.
-##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 158.
-##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+just_stmt: ENUM LBRACE IDENT COMMA VAL
 ##
 ## Ends in an error in state: 159.
 ##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN AT ]
+## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN AT ]
+## separated_nonempty_list(COMMA,enum_member) -> IDENT COMMA . separated_nonempty_list(COMMA,enum_member) [ RBRACE FN AT ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+## IDENT COMMA
 ##
 
 Invalid syntax
 
-just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE UNION
+just_stmt: UNION LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 160.
+## Ends in an error in state: 169.
 ##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 165.
-##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-just_stmt: STRUCT IDENT LBRACKET RBRACKET VAL
+just_stmt: LBRACE VAL
 ##
-## Ends in an error in state: 166.
+## Ends in an error in state: 170.
 ##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: STRUCT IDENT LBRACKET RBRACKET LBRACE UNION
-##
-## Ends in an error in state: 167.
-##
-## non_semicolon_stmt -> STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## code_block -> LBRACE . block_stmt RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL AT ]
+## code_block -> LBRACE . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: STRUCT IDENT LBRACE UNION
-##
-## Ends in an error in state: 172.
-##
-## non_semicolon_stmt -> STRUCT IDENT LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT IDENT LBRACE
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 177.
-##
-## expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ DOT ]
-## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params)
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE UNION
-##
-## Ends in an error in state: 178.
-##
-## expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ DOT ]
-## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE RBRACE VAL
-##
-## Ends in an error in state: 182.
-##
-## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ DOT ]
-## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
-## stmt_expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
+## LBRACE
 ##
 
 Invalid syntax
 
 just_stmt: STRING VAL
 ##
-## Ends in an error in state: 183.
+## Ends in an error in state: 171.
 ##
 ## expr -> STRING . [ DOT ]
 ## fexpr -> STRING . [ LPAREN LBRACKET ]
@@ -1693,7 +1758,7 @@ Invalid syntax
 
 just_stmt: RETURN VAL
 ##
-## Ends in an error in state: 184.
+## Ends in an error in state: 172.
 ##
 ## semicolon_stmt -> RETURN . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1705,7 +1770,7 @@ Invalid syntax
 
 just_stmt: RETURN BOOL VAL
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 173.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1719,14 +1784,14 @@ just_stmt: RETURN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: LET VAL
 ##
-## Ends in an error in state: 187.
+## Ends in an error in state: 175.
 ##
 ## semicolon_stmt -> LET . IDENT option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1742,7 +1807,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE VAL
 ##
-## Ends in an error in state: 188.
+## Ends in an error in state: 176.
 ##
 ## semicolon_stmt -> LET LBRACE . nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET LBRACE . loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1755,7 +1820,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT VAL
 ##
-## Ends in an error in state: 189.
+## Ends in an error in state: 177.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT . AS IDENT COMMA [ RBRACE DOUBLEDOT ]
@@ -1774,7 +1839,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT COMMA VAL
 ##
-## Ends in an error in state: 190.
+## Ends in an error in state: 178.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1788,7 +1853,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT AS VAL
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 181.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS . IDENT COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1803,7 +1868,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT AS IDENT VAL
 ##
-## Ends in an error in state: 194.
+## Ends in an error in state: 182.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT . COMMA nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1818,7 +1883,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT AS IDENT COMMA VAL
 ##
-## Ends in an error in state: 195.
+## Ends in an error in state: 183.
 ##
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . [ RBRACE DOUBLEDOT ]
 ## nonempty_list(terminated(destructuring_field,COMMA)) -> IDENT AS IDENT COMMA . nonempty_list(terminated(destructuring_field,COMMA)) [ RBRACE DOUBLEDOT ]
@@ -1832,7 +1897,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT COMMA DOUBLEDOT VAL
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 189.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1844,7 +1909,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT COMMA RBRACE VAL
 ##
-## Ends in an error in state: 202.
+## Ends in an error in state: 190.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1856,7 +1921,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT COMMA RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 203.
+## Ends in an error in state: 191.
 ##
 ## semicolon_stmt -> LET LBRACE nonempty_list(terminated(destructuring_field,COMMA)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1868,7 +1933,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE IDENT COMMA RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 192.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1882,14 +1947,14 @@ just_stmt: LET LBRACE IDENT COMMA RBRACE EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: LET LBRACE DOUBLEDOT VAL
 ##
-## Ends in an error in state: 206.
+## Ends in an error in state: 194.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) . RBRACE EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1901,7 +1966,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 207.
+## Ends in an error in state: 195.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1913,7 +1978,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE RBRACE EQUALS VAL
 ##
-## Ends in an error in state: 208.
+## Ends in an error in state: 196.
 ##
 ## semicolon_stmt -> LET LBRACE loption(separated_nonempty_list(COMMA,destructuring_field)) option(DOUBLEDOT) RBRACE EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1925,7 +1990,7 @@ Invalid syntax
 
 just_stmt: LET LBRACE RBRACE EQUALS BOOL VAL
 ##
-## Ends in an error in state: 209.
+## Ends in an error in state: 197.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -1939,14 +2004,14 @@ just_stmt: LET LBRACE RBRACE EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT VAL
 ##
-## Ends in an error in state: 210.
+## Ends in an error in state: 198.
 ##
 ## semicolon_stmt -> LET IDENT . option(__anonymous_0) EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1960,7 +2025,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN VAL
 ##
-## Ends in an error in state: 211.
+## Ends in an error in state: 199.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ## semicolon_stmt -> LET IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
@@ -1973,7 +2038,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 200.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -1984,14 +2049,14 @@ just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 213.
+## Ends in an error in state: 201.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2003,7 +2068,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 214.
+## Ends in an error in state: 202.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2015,7 +2080,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 215.
+## Ends in an error in state: 203.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2029,14 +2094,14 @@ just_stmt: LET IDENT LPAREN IDENT COLON BOOL COMMA RPAREN EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT LPAREN IDENT COLON BOOL RBRACKET
 ##
-## Ends in an error in state: 216.
+## Ends in an error in state: 204.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2047,16 +2112,16 @@ just_stmt: LET IDENT LPAREN IDENT COLON BOOL RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 217.
+## Ends in an error in state: 205.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2068,7 +2133,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN RPAREN EQUALS VAL
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 206.
 ##
 ## semicolon_stmt -> LET IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2080,7 +2145,7 @@ Invalid syntax
 
 just_stmt: LET IDENT LPAREN RPAREN EQUALS BOOL VAL
 ##
-## Ends in an error in state: 219.
+## Ends in an error in state: 207.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2094,14 +2159,14 @@ just_stmt: LET IDENT LPAREN RPAREN EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT COLON VAL
 ##
-## Ends in an error in state: 220.
+## Ends in an error in state: 208.
 ##
 ## option(__anonymous_0) -> COLON . type_expr [ EQUALS ]
 ##
@@ -2113,7 +2178,7 @@ Invalid syntax
 
 just_stmt: LET IDENT COLON IDENT LBRACE
 ##
-## Ends in an error in state: 222.
+## Ends in an error in state: 210.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) . EQUALS expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2124,15 +2189,15 @@ just_stmt: LET IDENT COLON IDENT LBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 139, spurious reduction of production type_expr -> IDENT
-## In state 221, spurious reduction of production option(__anonymous_0) -> COLON type_expr
+## In state 66, spurious reduction of production type_expr -> IDENT
+## In state 209, spurious reduction of production option(__anonymous_0) -> COLON type_expr
 ##
 
 Invalid syntax
 
 just_stmt: LET IDENT EQUALS VAL
 ##
-## Ends in an error in state: 223.
+## Ends in an error in state: 211.
 ##
 ## semicolon_stmt -> LET IDENT option(__anonymous_0) EQUALS . expr [ SEMICOLON RBRACE EOF ]
 ##
@@ -2144,7 +2209,7 @@ Invalid syntax
 
 just_stmt: LET IDENT EQUALS BOOL VAL
 ##
-## Ends in an error in state: 224.
+## Ends in an error in state: 212.
 ##
 ## expr -> expr . DOT IDENT [ SEMICOLON RBRACE EOF DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ SEMICOLON RBRACE EOF DOT ]
@@ -2158,184 +2223,14 @@ just_stmt: LET IDENT EQUALS BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE VAL
-##
-## Ends in an error in state: 225.
-##
-## expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-## non_semicolon_stmt -> INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> INTERFACE . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> INTERFACE . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## stmt_expr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE VAL
-##
-## Ends in an error in state: 226.
-##
-## expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ DOT ]
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE LBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE LBRACE RBRACE VAL
-##
-## Ends in an error in state: 228.
-##
-## expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ DOT ]
-## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
-## stmt_expr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT VAL
-##
-## Ends in an error in state: 229.
-##
-## non_semicolon_stmt -> INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> INTERFACE IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> INTERFACE IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET VAL
-##
-## Ends in an error in state: 230.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 231.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
-##
-## Ends in an error in state: 232.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
-##
-## Ends in an error in state: 233.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 236.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 237.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACKET RBRACKET LBRACE VAL
-##
-## Ends in an error in state: 238.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: INTERFACE IDENT LBRACE VAL
-##
-## Ends in an error in state: 241.
-##
-## non_semicolon_stmt -> INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## INTERFACE IDENT LBRACE
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: INT VAL
 ##
-## Ends in an error in state: 244.
+## Ends in an error in state: 213.
 ##
 ## expr -> INT . [ DOT ]
 ## fexpr -> INT . [ LPAREN LBRACKET ]
@@ -2349,9 +2244,9 @@ Invalid syntax
 
 just_stmt: IF VAL
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 214.
 ##
-## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## if_ -> IF . LPAREN expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF
@@ -2361,9 +2256,9 @@ Invalid syntax
 
 just_stmt: IF LPAREN VAL
 ##
-## Ends in an error in state: 246.
+## Ends in an error in state: 215.
 ##
-## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## if_ -> IF LPAREN . expr RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN
@@ -2373,12 +2268,12 @@ Invalid syntax
 
 just_stmt: IF LPAREN BOOL VAL
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 216.
 ##
 ## expr -> expr . DOT IDENT [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
 ## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT ]
-## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## if_ -> IF LPAREN expr . RPAREN code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr
@@ -2387,16 +2282,16 @@ just_stmt: IF LPAREN BOOL VAL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
 just_stmt: IF LPAREN BOOL RPAREN VAL
 ##
-## Ends in an error in state: 248.
+## Ends in an error in state: 217.
 ##
-## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## if_ -> IF LPAREN expr RPAREN . code_block option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr RPAREN
@@ -2406,9 +2301,9 @@ Invalid syntax
 
 just_stmt: IF LPAREN BOOL RPAREN LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 249.
+## Ends in an error in state: 218.
 ##
-## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## if_ -> IF LPAREN expr RPAREN code_block . option(located(else_)) [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## IF LPAREN expr RPAREN code_block
@@ -2418,10 +2313,10 @@ Invalid syntax
 
 just_stmt: IF LPAREN BOOL RPAREN LBRACE RBRACE ELSE VAL
 ##
-## Ends in an error in state: 250.
+## Ends in an error in state: 219.
 ##
-## else_ -> ELSE . if_ [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## else_ -> ELSE . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## else_ -> ELSE . if_ [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## else_ -> ELSE . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## ELSE
@@ -2431,7 +2326,7 @@ Invalid syntax
 
 just_stmt: IDENT VAL
 ##
-## Ends in an error in state: 255.
+## Ends in an error in state: 224.
 ##
 ## expr -> IDENT . [ DOT ]
 ## fexpr -> IDENT . [ LPAREN LBRACKET ]
@@ -2444,991 +2339,9 @@ just_stmt: IDENT VAL
 
 Invalid syntax
 
-just_stmt: FN VAL
-##
-## Ends in an error in state: 256.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located(ident),some(located(code_block))) -> FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(nothing,option(located(code_block))) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,option(located(code_block))) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-## function_definition(nothing,some(located(code_block))) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN VAL
-##
-## Ends in an error in state: 257.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 258.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 259.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 260.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE RBRACE VAL
-##
-## Ends in an error in state: 262.
-##
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
-## option(located(code_block)) -> code_block . [ DOT ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 263.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN RPAREN VAL
-##
-## Ends in an error in state: 264.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 265.
-##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ DOT ]
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN RPAREN LBRACE RBRACE VAL
-##
-## Ends in an error in state: 267.
-##
-## function_definition(nothing,some(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
-## option(located(code_block)) -> code_block . [ DOT ]
-##
-## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT VAL
-##
-## Ends in an error in state: 268.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN VAL
-##
-## Ends in an error in state: 269.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 270.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 271.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 272.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 274.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN RPAREN VAL
-##
-## Ends in an error in state: 275.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 276.
-##
-## function_definition(located(ident),some(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET VAL
-##
-## Ends in an error in state: 278.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 279.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
-##
-## Ends in an error in state: 280.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN VAL
-##
-## Ends in an error in state: 281.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 282.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 283.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 284.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 286.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN VAL
-##
-## Ends in an error in state: 287.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 288.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 290.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 291.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN VAL
-##
-## Ends in an error in state: 292.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 293.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 294.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 295.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 297.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN RPAREN VAL
-##
-## Ends in an error in state: 298.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: FN IDENT LBRACKET RBRACKET LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 299.
-##
-## function_definition(located_ident_with_params,some(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: ENUM VAL
-##
-## Ends in an error in state: 301.
-##
-## expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
-## expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
-## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## stmt_expr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
-## stmt_expr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE VAL
-##
-## Ends in an error in state: 302.
-##
-## expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
-## expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
-## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
-## stmt_expr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 304.
-##
-## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ DOT ]
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE IDENT COMMA RBRACE VAL
-##
-## Ends in an error in state: 305.
-##
-## expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ DOT ]
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
-## stmt_expr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 307.
-##
-## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ DOT ]
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
-## stmt_expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE RBRACE VAL
-##
-## Ends in an error in state: 308.
-##
-## expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ DOT ]
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
-## stmt_expr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ SEMICOLON RBRACE EOF ]
-##
-## The known suffix of the stack is as follows:
-## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT VAL
-##
-## Ends in an error in state: 309.
-##
-## non_semicolon_stmt -> ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET VAL
-##
-## Ends in an error in state: 310.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 311.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
-##
-## Ends in an error in state: 312.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
-##
-## Ends in an error in state: 313.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 315.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 318.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 320.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 321.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET RBRACKET LBRACE VAL
-##
-## Ends in an error in state: 322.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET RBRACKET LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 324.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACKET RBRACKET LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 327.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACE VAL
-##
-## Ends in an error in state: 329.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACE
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 331.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: ENUM IDENT LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 334.
-##
-## non_semicolon_stmt -> ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
 just_stmt: BOOL VAL
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 225.
 ##
 ## expr -> BOOL . [ DOT ]
 ## fexpr -> BOOL . [ LPAREN LBRACKET ]
@@ -3442,7 +2355,7 @@ Invalid syntax
 
 just_stmt: IDENT LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 227.
 ##
 ## expr -> struct_constructor . [ DOT ]
 ## stmt_expr -> struct_constructor . [ SEMICOLON RBRACE EOF ]
@@ -3455,7 +2368,7 @@ Invalid syntax
 
 program: BOOL SEMICOLON VAL
 ##
-## Ends in an error in state: 342.
+## Ends in an error in state: 231.
 ##
 ## block_stmt -> semicolon_stmt SEMICOLON . block_stmt [ RBRACE EOF ]
 ## block_stmt -> semicolon_stmt SEMICOLON . [ RBRACE EOF ]
@@ -3468,7 +2381,7 @@ Invalid syntax
 
 program: LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 232.
 ##
 ## block_stmt -> non_semicolon_stmt . block_stmt [ RBRACE EOF ]
 ## stmt -> non_semicolon_stmt . [ RBRACE EOF ]
@@ -3481,7 +2394,7 @@ Invalid syntax
 
 just_stmt: BOOL LBRACKET RBRACKET VAL
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 237.
 ##
 ## expr -> function_call . [ DOT ]
 ## fexpr -> function_call . [ LPAREN LBRACKET ]
@@ -3496,7 +2409,7 @@ Invalid syntax
 
 just_stmt: BOOL DOT VAL
 ##
-## Ends in an error in state: 350.
+## Ends in an error in state: 239.
 ##
 ## expr -> expr DOT . IDENT [ DOT ]
 ## expr -> expr DOT . IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3513,7 +2426,7 @@ Invalid syntax
 
 just_stmt: BOOL DOT IDENT VAL
 ##
-## Ends in an error in state: 351.
+## Ends in an error in state: 240.
 ##
 ## expr -> expr DOT IDENT . [ DOT ]
 ## expr -> expr DOT IDENT . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
@@ -3530,7 +2443,7 @@ Invalid syntax
 
 just_stmt: BOOL DOT IDENT LPAREN VAL
 ##
-## Ends in an error in state: 352.
+## Ends in an error in state: 241.
 ##
 ## expr -> expr DOT IDENT LPAREN . nonempty_list(terminated(located(expr),COMMA)) RPAREN [ DOT ]
 ## expr -> expr DOT IDENT LPAREN . loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ DOT ]
@@ -3545,7 +2458,7 @@ Invalid syntax
 
 just_stmt: BOOL DOT IDENT LPAREN BOOL COMMA RBRACKET
 ##
-## Ends in an error in state: 353.
+## Ends in an error in state: 242.
 ##
 ## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ SEMICOLON RBRACE EOF ]
@@ -3557,14 +2470,14 @@ just_stmt: BOOL DOT IDENT LPAREN BOOL COMMA RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 118, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+## In state 459, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
 ##
 
 Invalid syntax
 
 just_stmt: BOOL DOT IDENT LPAREN BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 354.
+## Ends in an error in state: 243.
 ##
 ## expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3577,7 +2490,7 @@ Invalid syntax
 
 just_stmt: BOOL DOT IDENT LPAREN BOOL RBRACKET
 ##
-## Ends in an error in state: 355.
+## Ends in an error in state: 244.
 ##
 ## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ SEMICOLON RBRACE EOF ]
@@ -3589,16 +2502,16 @@ just_stmt: BOOL DOT IDENT LPAREN BOOL RBRACKET
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 110, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
-## In state 105, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 41, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
+## In state 36, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
 ##
 
 Invalid syntax
 
 just_stmt: BOOL DOT IDENT LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 245.
 ##
 ## expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ DOT ]
 ## stmt_expr -> expr DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN . [ SEMICOLON RBRACE EOF ]
@@ -3609,11 +2522,1398 @@ just_stmt: BOOL DOT IDENT LPAREN RPAREN VAL
 
 Invalid syntax
 
-just_stmt: LBRACE BOOL EOF
+just_stmt: AT IDENT IMPL
+##
+## Ends in an error in state: 248.
+##
+## expr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ DOT ]
+## expr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
+## expr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## expr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## expr -> attributes . UNION LBRACE list(union_item) RBRACE [ DOT ]
+## fexpr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . UNION LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## function_definition(located(ident),some(located(code_block))) -> attributes . FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located(ident),some(located(code_block))) -> attributes . FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes . FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes . FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(nothing,option(located(code_block))) -> attributes . FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,option(located(code_block))) -> attributes . FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes . FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+## function_definition(nothing,some(located(code_block))) -> attributes . FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+## non_semicolon_stmt -> attributes . STRUCT IDENT LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . INTERFACE IDENT LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . UNION IDENT LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes . UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## stmt_expr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes . UNION LBRACE list(union_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
+##
+
+Invalid syntax
+
+just_stmt: UNION VAL
+##
+## Ends in an error in state: 249.
+##
+## expr -> attributes UNION . LBRACE list(union_item) RBRACE [ DOT ]
+## fexpr -> attributes UNION . LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## non_semicolon_stmt -> attributes UNION . IDENT LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes UNION . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes UNION . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## stmt_expr -> attributes UNION . LBRACE list(union_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE VAL
+##
+## Ends in an error in state: 250.
+##
+## expr -> attributes UNION LBRACE . list(union_item) RBRACE [ DOT ]
+## fexpr -> attributes UNION LBRACE . list(union_item) RBRACE [ LPAREN LBRACKET ]
+## stmt_expr -> attributes UNION LBRACE . list(union_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION LBRACE
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE RBRACE VAL
+##
+## Ends in an error in state: 252.
+##
+## expr -> attributes UNION LBRACE list(union_item) RBRACE . [ DOT ]
+## fexpr -> attributes UNION LBRACE list(union_item) RBRACE . [ LPAREN LBRACKET ]
+## stmt_expr -> attributes UNION LBRACE list(union_item) RBRACE . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION LBRACE list(union_item) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT VAL
+##
+## Ends in an error in state: 253.
+##
+## non_semicolon_stmt -> attributes UNION IDENT . LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes UNION IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes UNION IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET VAL
+##
+## Ends in an error in state: 254.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 255.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+##
+## Ends in an error in state: 256.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 257.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 260.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 261.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACKET RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 262.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: UNION IDENT LBRACE VAL
+##
+## Ends in an error in state: 265.
+##
+## non_semicolon_stmt -> attributes UNION IDENT LBRACE . list(union_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes UNION IDENT LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT VAL
+##
+## Ends in an error in state: 268.
+##
+## expr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ DOT ]
+## fexpr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## non_semicolon_stmt -> attributes STRUCT . IDENT LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes STRUCT . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes STRUCT . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## stmt_expr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT VAL
+##
+## Ends in an error in state: 269.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT . LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes STRUCT IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes STRUCT IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET VAL
+##
+## Ends in an error in state: 270.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 271.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+##
+## Ends in an error in state: 272.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE UNION
+##
+## Ends in an error in state: 273.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 276.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 277.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACKET RBRACKET LBRACE UNION
+##
+## Ends in an error in state: 278.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT IDENT LBRACE UNION
+##
+## Ends in an error in state: 281.
+##
+## non_semicolon_stmt -> attributes STRUCT IDENT LBRACE . list(struct_item) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT IDENT LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 284.
+##
+## expr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ DOT ]
+## fexpr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## stmt_expr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params)
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE UNION
+##
+## Ends in an error in state: 285.
+##
+## expr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ DOT ]
+## fexpr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## stmt_expr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params) LBRACE
+##
+
+Invalid syntax
+
+just_stmt: STRUCT LBRACE RBRACE VAL
+##
+## Ends in an error in state: 287.
+##
+## expr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ DOT ]
+## fexpr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ LPAREN LBRACKET ]
+## stmt_expr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params) LBRACE list(struct_item) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE VAL
+##
+## Ends in an error in state: 288.
+##
+## expr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ DOT ]
+## fexpr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## non_semicolon_stmt -> attributes INTERFACE . IDENT LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes INTERFACE . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes INTERFACE . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## stmt_expr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE VAL
+##
+## Ends in an error in state: 289.
+##
+## expr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ DOT ]
+## fexpr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## stmt_expr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE LBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE LBRACE RBRACE VAL
+##
+## Ends in an error in state: 291.
+##
+## expr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ DOT ]
+## fexpr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
+## stmt_expr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT VAL
+##
+## Ends in an error in state: 292.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes INTERFACE IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes INTERFACE IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET VAL
+##
+## Ends in an error in state: 293.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 294.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+##
+## Ends in an error in state: 295.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 296.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 299.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 300.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACKET RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 301.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: INTERFACE IDENT LBRACE VAL
+##
+## Ends in an error in state: 304.
+##
+## non_semicolon_stmt -> attributes INTERFACE IDENT LBRACE . list(located(function_signature_binding)) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE IDENT LBRACE
+##
+
+Invalid syntax
+
+just_stmt: FN VAL
+##
+## Ends in an error in state: 307.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN . IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located(ident),some(located(code_block))) -> attributes FN . IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN VAL
+##
+## Ends in an error in state: 308.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 309.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+##
+## Ends in an error in state: 310.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 311.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN IDENT COLON BOOL COMMA RPAREN LBRACE RBRACE VAL
+##
+## Ends in an error in state: 313.
+##
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
+## option(located(code_block)) -> code_block . [ DOT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 314.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN RPAREN VAL
+##
+## Ends in an error in state: 315.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 316.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ DOT ]
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN LPAREN RPAREN LBRACE RBRACE VAL
+##
+## Ends in an error in state: 318.
+##
+## function_definition(nothing,some(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block . [ SEMICOLON RBRACE EOF ]
+## option(located(code_block)) -> code_block . [ DOT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT VAL
+##
+## Ends in an error in state: 319.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN VAL
+##
+## Ends in an error in state: 320.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 321.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+##
+## Ends in an error in state: 322.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 323.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 325.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN RPAREN VAL
+##
+## Ends in an error in state: 326.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 327.
+##
+## function_definition(located(ident),some(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET VAL
+##
+## Ends in an error in state: 329.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 330.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+##
+## Ends in an error in state: 331.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN VAL
+##
+## Ends in an error in state: 332.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 333.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+##
+## Ends in an error in state: 334.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 335.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 337.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN VAL
+##
+## Ends in an error in state: 338.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 339.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 341.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 342.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN VAL
+##
+## Ends in an error in state: 343.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 344.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+##
+## Ends in an error in state: 345.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 346.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 348.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN RPAREN VAL
+##
+## Ends in an error in state: 349.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: FN IDENT LBRACKET RBRACKET LPAREN RPAREN RARROW IDENT VAL
+##
+## Ends in an error in state: 350.
+##
+## function_definition(located_ident_with_params,some(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . code_block [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: ENUM VAL
+##
+## Ends in an error in state: 352.
+##
+## expr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## expr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## fexpr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM . IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## stmt_expr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE VAL
+##
+## Ends in an error in state: 353.
+##
+## expr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## expr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ DOT ]
+## fexpr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## stmt_expr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+## stmt_expr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE IDENT COMMA RBRACE VAL
+##
+## Ends in an error in state: 356.
+##
+## expr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ DOT ]
+## fexpr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## stmt_expr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM LBRACE RBRACE VAL
+##
+## Ends in an error in state: 359.
+##
+## expr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ DOT ]
+## fexpr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## stmt_expr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ SEMICOLON RBRACE EOF ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT VAL
 ##
 ## Ends in an error in state: 360.
 ##
-## code_block -> LBRACE block_stmt . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET VAL
+##
+## Ends in an error in state: 361.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
+##
+## Ends in an error in state: 362.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
+##
+## Ends in an error in state: 363.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 364.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 371.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 372.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACKET RBRACKET LBRACE VAL
+##
+## Ends in an error in state: 373.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
+##
+
+Invalid syntax
+
+just_stmt: ENUM IDENT LBRACE VAL
+##
+## Ends in an error in state: 380.
+##
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+## non_semicolon_stmt -> attributes ENUM IDENT LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM IDENT LBRACE
+##
+
+Invalid syntax
+
+just_stmt: LBRACE BOOL EOF
+##
+## Ends in an error in state: 388.
+##
+## code_block -> LBRACE block_stmt . RBRACE [ VAL UNION TILDE SWITCH STRUCT STRING SEMICOLON RPAREN RETURN RBRACKET RBRACE LPAREN LET LBRACE INTERFACE INT IMPL IF IDENT FN EOF ENUM ELSE DOT COMMA CASE BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
 ## LBRACE block_stmt
@@ -3622,659 +3922,836 @@ just_stmt: LBRACE BOOL EOF
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 336, spurious reduction of production stmt_expr -> BOOL
-## In state 339, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 341, spurious reduction of production stmt -> semicolon_stmt
-## In state 340, spurious reduction of production block_stmt -> stmt
+## In state 225, spurious reduction of production stmt_expr -> BOOL
+## In state 228, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 230, spurious reduction of production stmt -> semicolon_stmt
+## In state 229, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax
 
-just_stmt: RETURN FN LPAREN IDENT COLON BOOL RBRACKET
+just_stmt: UNION LBRACE FN IDENT LPAREN IDENT COLON BOOL RBRACKET
 ##
-## Ends in an error in state: 363.
+## Ends in an error in state: 392.
 ##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
 ##
 
 Invalid syntax
 
-just_stmt: RETURN FN LPAREN RPAREN UNION
+just_stmt: UNION LBRACE FN IDENT LPAREN RPAREN UNION
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 393.
 ##
-## function_definition(nothing,option(located(code_block))) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE IDENT EQUALS BOOL VAL
+just_stmt: UNION LBRACE FN IDENT LPAREN RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 366.
+## Ends in an error in state: 394.
 ##
-## expr -> expr . DOT IDENT [ RBRACE FN DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE FN DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE FN DOT COMMA ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr . COMMA nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr . COMMA separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
+## function_definition(located(ident),option(located(code_block))) -> attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## IDENT EQUALS expr
+## attributes FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE IDENT EQUALS BOOL COMMA VAL
+just_stmt: UNION LBRACE FN IDENT LBRACKET VAL
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 396.
 ##
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT EQUALS expr COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT EQUALS expr COMMA . separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## IDENT EQUALS expr COMMA
+## attributes FN IDENT LBRACKET
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE IDENT COMMA VAL
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 397.
 ##
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . [ RBRACE FN ]
-## nonempty_list(terminated(enum_member,COMMA)) -> IDENT COMMA . nonempty_list(terminated(enum_member,COMMA)) [ RBRACE FN ]
-## separated_nonempty_list(COMMA,enum_member) -> IDENT COMMA . separated_nonempty_list(COMMA,enum_member) [ RBRACE FN ]
-##
-## The known suffix of the stack is as follows:
-## IDENT COMMA
-##
-
-Invalid syntax
-
-just_stmt: LET IDENT COLON ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 374.
-##
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
 ##
 
 Invalid syntax
 
-just_stmt: LET IDENT COLON ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 398.
 ##
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN VAL
+##
+## Ends in an error in state: 399.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 400.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
 ##
 
 Invalid syntax
 
-just_stmt: FN LPAREN RPAREN RARROW BOOL UNION
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN UNION
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 401.
 ##
-## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-## option(preceded(RARROW,located(fexpr))) -> RARROW fexpr . [ VAL SEMICOLON RPAREN RBRACKET RBRACE LBRACE IMPL FN EOF DOT COMMA CASE ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## RARROW fexpr
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN IDENT COLON BOOL RBRACKET
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT SEMICOLON
 ##
-## Ends in an error in state: 382.
+## Ends in an error in state: 402.
 ##
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
-just_stmt: INTERFACE LBRACE FN IDENT LPAREN RPAREN VAL
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL RBRACKET
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 404.
 ##
-## function_definition(located(ident),nothing) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RBRACE FN ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN UNION
+##
+## Ends in an error in state: 405.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN RARROW IDENT SEMICOLON
+##
+## Ends in an error in state: 406.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET IDENT COLON BOOL RPAREN
+##
+## Ends in an error in state: 408.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 409.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN VAL
+##
+## Ends in an error in state: 410.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 411.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN UNION
+##
+## Ends in an error in state: 412.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW IDENT SEMICOLON
+##
+## Ends in an error in state: 413.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL RBRACKET
+##
+## Ends in an error in state: 415.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN UNION
+##
+## Ends in an error in state: 416.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: UNION LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN RARROW IDENT SEMICOLON
+##
+## Ends in an error in state: 417.
+##
+## function_definition(located_ident_with_params,option(located(code_block))) -> attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ VAL RBRACE IMPL FN CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 133, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN VAL
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 419.
 ##
-## function_definition(nothing,nothing) -> FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-## function_definition(nothing,nothing) -> FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN
+## attributes FN
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN LPAREN VAL
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 420.
 ##
-## function_definition(nothing,nothing) -> FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
-## function_definition(nothing,nothing) -> FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN
+## attributes FN LPAREN
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN LPAREN IDENT COLON BOOL COMMA RBRACKET
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 421.
 ##
-## function_definition(nothing,nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA))
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN LPAREN IDENT COLON BOOL COMMA RPAREN VAL
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 422.
 ##
-## function_definition(nothing,nothing) -> FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN LPAREN IDENT COLON BOOL RBRACKET
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 424.
 ##
-## function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN FN LPAREN RPAREN VAL
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 425.
 ##
-## function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) [ RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
-## FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: LPAREN IDENT LBRACE RBRACE VAL
+just_stmt: UNION LBRACE IMPL IDENT VAL
 ##
-## Ends in an error in state: 395.
-##
-## fexpr -> LPAREN struct_constructor . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN struct_constructor
-##
-
-Invalid syntax
-
-just_stmt: LPAREN FN LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 397.
-##
-## fexpr -> LPAREN function_definition(nothing,nothing) . RPAREN [ VAL SEMICOLON RPAREN RBRACKET RBRACE LPAREN LBRACKET LBRACE IMPL FN EOF DOT COMMA CASE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN function_definition(nothing,nothing)
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-## In state 394, spurious reduction of production function_definition(nothing,nothing) -> FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE IMPL BOOL VAL
-##
-## Ends in an error in state: 399.
+## Ends in an error in state: 427.
 ##
 ## function_call -> fexpr . LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ LPAREN LBRACKET LBRACE ]
 ## function_call -> fexpr . LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ LPAREN LBRACKET LBRACE ]
 ## function_call -> fexpr . LBRACKET nonempty_list(terminated(located(expr),COMMA)) RBRACKET [ LPAREN LBRACKET LBRACE ]
 ## function_call -> fexpr . LBRACKET loption(separated_nonempty_list(COMMA,located(expr))) RBRACKET [ LPAREN LBRACKET LBRACE ]
-## list(impl) -> IMPL fexpr . LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(impl) [ RBRACE ]
+## list(union_item) -> attributes IMPL fexpr . LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE list(union_item) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPL fexpr
+## attributes IMPL fexpr
 ##
 
 Invalid syntax
 
-just_stmt: UNION LBRACE IMPL BOOL LBRACE VAL
+just_stmt: UNION LBRACE IMPL IDENT LBRACE VAL
 ##
-## Ends in an error in state: 400.
+## Ends in an error in state: 428.
 ##
-## list(impl) -> IMPL fexpr LBRACE . list(sugared_function_definition(option(located(code_block)))) RBRACE list(impl) [ RBRACE ]
+## list(union_item) -> attributes IMPL fexpr LBRACE . list(sugared_function_definition(option(located(code_block)))) RBRACE list(union_item) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE
+## attributes IMPL fexpr LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION LBRACE IMPL BOOL LBRACE FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 401.
-##
-## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) . RBRACE list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: UNION LBRACE IMPL BOOL LBRACE RBRACE VAL
-##
-## Ends in an error in state: 402.
-##
-## list(impl) -> IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE . list(impl) [ RBRACE ]
-##
-## The known suffix of the stack is as follows:
-## IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN UNION LBRACE RBRACE VAL
-##
-## Ends in an error in state: 405.
-##
-## fexpr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN TILDE VAL
-##
-## Ends in an error in state: 407.
-##
-## fexpr -> TILDE . IDENT [ LPAREN LBRACKET ]
-## type_expr -> LPAREN TILDE . IDENT RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN TILDE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN TILDE IDENT VAL
-##
-## Ends in an error in state: 408.
-##
-## fexpr -> TILDE IDENT . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN TILDE IDENT . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN TILDE IDENT
-##
-
-Invalid syntax
-
-just_stmt: LPAREN STRUCT VAL
-##
-## Ends in an error in state: 410.
-##
-## fexpr -> STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN STRUCT . option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRUCT
-##
-
-Invalid syntax
-
-just_stmt: LPAREN STRUCT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 411.
-##
-## fexpr -> STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN STRUCT option(params) . LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRUCT option(params)
-##
-
-Invalid syntax
-
-just_stmt: LPAREN STRUCT LBRACE UNION
-##
-## Ends in an error in state: 412.
-##
-## fexpr -> STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN STRUCT option(params) LBRACE . list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRUCT option(params) LBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN STRUCT LBRACE RBRACE VAL
-##
-## Ends in an error in state: 416.
-##
-## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN STRING VAL
-##
-## Ends in an error in state: 418.
-##
-## fexpr -> STRING . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN STRING . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN STRING
-##
-
-Invalid syntax
-
-just_stmt: LPAREN INTERFACE VAL
-##
-## Ends in an error in state: 420.
-##
-## fexpr -> INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INTERFACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN INTERFACE LBRACE VAL
-##
-## Ends in an error in state: 421.
-##
-## fexpr -> INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INTERFACE LBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN INTERFACE LBRACE RBRACE VAL
-##
-## Ends in an error in state: 423.
-##
-## fexpr -> INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: LPAREN INT VAL
-##
-## Ends in an error in state: 425.
-##
-## fexpr -> INT . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN INT . RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN INT
-##
-
-Invalid syntax
-
-just_stmt: LPAREN IDENT VAL
-##
-## Ends in an error in state: 427.
-##
-## fexpr -> IDENT . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN IDENT . RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> IDENT . [ LBRACE ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN IDENT
-##
-
-Invalid syntax
-
-just_stmt: LPAREN ENUM VAL
-##
-## Ends in an error in state: 429.
-##
-## fexpr -> ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN ENUM
-##
-
-Invalid syntax
-
-just_stmt: LPAREN ENUM LBRACE VAL
+just_stmt: UNION LBRACE IMPL IDENT LBRACE RBRACE VAL
 ##
 ## Ends in an error in state: 430.
 ##
-## fexpr -> ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## fexpr -> ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-## type_expr -> LPAREN ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## list(union_item) -> attributes IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE . list(union_item) [ RBRACE ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN ENUM LBRACE
+## attributes IMPL fexpr LBRACE list(sugared_function_definition(option(located(code_block)))) RBRACE
 ##
 
 Invalid syntax
 
-just_stmt: LPAREN ENUM LBRACE IDENT COMMA FN IDENT LPAREN RPAREN IMPL
-##
-## Ends in an error in state: 432.
-##
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
-##
-## The known suffix of the stack is as follows:
-## LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block))))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
-##
-
-Invalid syntax
-
-just_stmt: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
+just_stmt: RETURN UNION LBRACE RBRACE UNION
 ##
 ## Ends in an error in state: 433.
 ##
-## fexpr -> ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
+## expr -> attributes UNION LBRACE list(union_item) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes UNION LBRACE list(union_item) RBRACE . [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+## attributes UNION LBRACE list(union_item) RBRACE
 ##
 
 Invalid syntax
 
-just_stmt: LPAREN ENUM LBRACE FN IDENT LPAREN RPAREN IMPL
+just_stmt: RETURN STRUCT VAL
+##
+## Ends in an error in state: 434.
+##
+## expr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT
+##
+
+Invalid syntax
+
+just_stmt: RETURN STRUCT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 435.
+##
+## expr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params)
+##
+
+Invalid syntax
+
+just_stmt: RETURN STRUCT LBRACE UNION
 ##
 ## Ends in an error in state: 436.
 ##
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) . RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## expr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ LPAREN LBRACKET ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block))))
+## attributes STRUCT option(params) LBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN STRUCT LBRACE RBRACE UNION
+##
+## Ends in an error in state: 438.
+##
+## expr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes STRUCT option(params) LBRACE list(struct_item) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN INTERFACE VAL
+##
+## Ends in an error in state: 439.
+##
+## expr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN INTERFACE LBRACE VAL
+##
+## Ends in an error in state: 440.
+##
+## expr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE LBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN INTERFACE LBRACE RBRACE UNION
+##
+## Ends in an error in state: 442.
+##
+## expr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN FN VAL
+##
+## Ends in an error in state: 443.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN
+##
+
+Invalid syntax
+
+just_stmt: RETURN FN LPAREN VAL
+##
+## Ends in an error in state: 444.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN
+##
+
+Invalid syntax
+
+just_stmt: RETURN FN LPAREN IDENT COLON BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 445.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA))
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 460, spurious reduction of production option(preceded(RARROW,located(fexpr))) ->
-## In state 461, spurious reduction of production option(located(code_block)) ->
-## In state 462, spurious reduction of production function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block))
-## In state 41, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) ->
-## In state 42, spurious reduction of production list(sugared_function_definition(option(located(code_block)))) -> function_definition(located(ident),option(located(code_block))) list(sugared_function_definition(option(located(code_block))))
+## In state 85, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
 ##
 
 Invalid syntax
 
-just_stmt: LPAREN ENUM LBRACE RBRACE VAL
+just_stmt: RETURN FN LPAREN IDENT COLON BOOL COMMA RPAREN UNION
 ##
-## Ends in an error in state: 437.
+## Ends in an error in state: 446.
 ##
-## fexpr -> ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+## attributes FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: LPAREN BOOL VAL
+just_stmt: RETURN FN LPAREN IDENT COLON BOOL RBRACKET
 ##
-## Ends in an error in state: 439.
+## Ends in an error in state: 448.
 ##
-## fexpr -> BOOL . [ LPAREN LBRACKET ]
-## type_expr -> LPAREN BOOL . RPAREN [ LBRACE IDENT EQUALS ]
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
 ##
 ## The known suffix of the stack is as follows:
-## LPAREN BOOL
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 84, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
+## In state 88, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+##
+
+Invalid syntax
+
+just_stmt: RETURN FN LPAREN RPAREN UNION
+##
+## Ends in an error in state: 449.
+##
+## function_definition(nothing,option(located(code_block))) -> attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+##
+## The known suffix of the stack is as follows:
+## attributes FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
+##
+
+Invalid syntax
+
+just_stmt: RETURN ENUM VAL
+##
+## Ends in an error in state: 451.
+##
+## expr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM
+##
+
+Invalid syntax
+
+just_stmt: RETURN ENUM LBRACE VAL
+##
+## Ends in an error in state: 452.
+##
+## expr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## expr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN ENUM LBRACE IDENT COMMA RBRACE UNION
+##
+## Ends in an error in state: 455.
+##
+## expr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: RETURN ENUM LBRACE RBRACE UNION
+##
+## Ends in an error in state: 458.
+##
+## expr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE AT ]
+## fexpr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: BOOL LBRACKET BOOL COMMA VAL
+##
+## Ends in an error in state: 459.
+##
+## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . [ RPAREN RBRACKET ]
+## nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA . nonempty_list(terminated(located(expr),COMMA)) [ RPAREN RBRACKET ]
+## separated_nonempty_list(COMMA,located(expr)) -> expr COMMA . separated_nonempty_list(COMMA,located(expr)) [ RPAREN RBRACKET ]
+##
+## The known suffix of the stack is as follows:
+## expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: IDENT LBRACE IDENT COLON BOOL VAL
+##
+## Ends in an error in state: 462.
+##
+## expr -> expr . DOT IDENT [ RBRACE DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE DOT COMMA ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE DOT COMMA ]
+## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA [ RBRACE ]
+## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
+## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . [ RBRACE ]
+## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr . COMMA separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+##
+
+Invalid syntax
+
+just_stmt: IDENT LBRACE IDENT COLON BOOL COMMA VAL
+##
+## Ends in an error in state: 463.
+##
+## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . [ RBRACE ]
+## nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(separated_pair(located(ident),COLON,located(expr)),COMMA)) [ RBRACE ]
+## separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) -> IDENT COLON expr COMMA . separated_nonempty_list(COMMA,separated_pair(located(ident),COLON,located(expr))) [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## IDENT COLON expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: AT IDENT LPAREN BOOL COMMA RBRACKET
+##
+## Ends in an error in state: 471.
+##
+## option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) -> LPAREN nonempty_list(terminated(located(expr),COMMA)) . RPAREN [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN nonempty_list(terminated(located(expr),COMMA))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 459, spurious reduction of production nonempty_list(terminated(located(expr),COMMA)) -> expr COMMA
+##
+
+Invalid syntax
+
+just_stmt: AT IDENT LPAREN BOOL RBRACKET
+##
+## Ends in an error in state: 473.
+##
+## option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) -> LPAREN loption(separated_nonempty_list(COMMA,located(expr))) . RPAREN [ VAL UNION STRUCT INTERFACE IMPL FN ENUM AT ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN loption(separated_nonempty_list(COMMA,located(expr)))
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 25, spurious reduction of production expr -> BOOL
+## In state 41, spurious reduction of production separated_nonempty_list(COMMA,located(expr)) -> expr
+## In state 36, spurious reduction of production loption(separated_nonempty_list(COMMA,located(expr))) -> separated_nonempty_list(COMMA,located(expr))
 ##
 
 Invalid syntax
 
 just_stmt: LPAREN BOOL LBRACKET RBRACKET VAL
 ##
-## Ends in an error in state: 441.
+## Ends in an error in state: 476.
 ##
 ## fexpr -> function_call . [ LPAREN LBRACKET ]
 ## type_expr -> LPAREN function_call . RPAREN [ LBRACE IDENT EQUALS ]
@@ -4286,667 +4763,375 @@ just_stmt: LPAREN BOOL LBRACKET RBRACKET VAL
 
 Invalid syntax
 
-just_stmt: STRUCT LBRACE VAL IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 443.
-##
-## expr -> expr . DOT IDENT [ VAL SEMICOLON RBRACE IMPL FN DOT ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ VAL SEMICOLON RBRACE IMPL FN DOT ]
-## list(struct_field) -> VAL IDENT COLON expr . option(SEMICOLON) list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL IDENT COLON expr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-##
-
-Invalid syntax
-
-just_stmt: STRUCT LBRACE VAL IDENT COLON BOOL SEMICOLON UNION
-##
-## Ends in an error in state: 445.
-##
-## list(struct_field) -> VAL IDENT COLON expr option(SEMICOLON) . list(struct_field) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## VAL IDENT COLON expr option(SEMICOLON)
-##
-
-Invalid syntax
-
-just_stmt: RETURN STRUCT LBRACE RBRACE UNION
-##
-## Ends in an error in state: 450.
-##
-## expr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## STRUCT option(params) LBRACE list(struct_field) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL VAL
-##
-## Ends in an error in state: 451.
-##
-## expr -> expr . DOT IDENT [ RPAREN RBRACKET DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN RBRACKET DOT COMMA ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN RBRACKET DOT COMMA ]
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA [ RPAREN RBRACKET ]
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr . COMMA nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr . COMMA separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## IDENT COLON expr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-##
-
-Invalid syntax
-
-just_stmt: FN LPAREN IDENT COLON BOOL COMMA VAL
-##
-## Ends in an error in state: 452.
-##
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . [ RPAREN RBRACKET ]
-## nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA . nonempty_list(terminated(function_param,COMMA)) [ RPAREN RBRACKET ]
-## separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr COMMA . separated_nonempty_list(COMMA,function_param) [ RPAREN RBRACKET ]
-##
-## The known suffix of the stack is as follows:
-## IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 455.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 456.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 457.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 459.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN RPAREN VAL
-##
-## Ends in an error in state: 460.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 461.
-##
-## function_definition(located(ident),option(located(code_block))) -> FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET VAL
-##
-## Ends in an error in state: 463.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 464.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
-##
-## Ends in an error in state: 465.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN VAL
-##
-## Ends in an error in state: 466.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
-##
-## Ends in an error in state: 467.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
-##
-## Ends in an error in state: 468.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 469.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN IDENT COLON BOOL RBRACKET
-##
-## Ends in an error in state: 471.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN VAL
-##
-## Ends in an error in state: 472.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LPAREN RPAREN RARROW BOOL VAL
-##
-## Ends in an error in state: 473.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET IDENT COLON BOOL RPAREN
-##
-## Ends in an error in state: 475.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 476.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN VAL
-##
-## Ends in an error in state: 477.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN . loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RBRACKET
+just_stmt: LPAREN AT IDENT IMPL
 ##
 ## Ends in an error in state: 478.
 ##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
+## fexpr -> attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes . UNION LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## function_definition(nothing,nothing) -> attributes . FN LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## function_definition(nothing,nothing) -> attributes . FN LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) [ RPAREN ]
+## type_expr -> LPAREN attributes . STRUCT option(params) LBRACE list(struct_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes . INTERFACE LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes . ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes . ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes . UNION LBRACE list(union_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA))
+## LPAREN attributes
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
+## In state 21, spurious reduction of production option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN)) ->
+## In state 475, spurious reduction of production attribute -> AT IDENT option(delimited_separated_trailing_list(LPAREN,located(expr),COMMA,RPAREN))
+## In state 78, spurious reduction of production list(attribute) ->
+## In state 79, spurious reduction of production list(attribute) -> attribute list(attribute)
+## In state 31, spurious reduction of production attributes -> list(attribute)
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN VAL
+just_stmt: LPAREN UNION VAL
 ##
 ## Ends in an error in state: 479.
 ##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
+## fexpr -> attributes UNION . LBRACE list(union_item) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes UNION . LBRACE list(union_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN
+## LPAREN attributes UNION
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL COMMA RPAREN RARROW BOOL VAL
+just_stmt: LPAREN UNION LBRACE VAL
 ##
 ## Ends in an error in state: 480.
 ##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
+## fexpr -> attributes UNION LBRACE . list(union_item) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes UNION LBRACE . list(union_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN nonempty_list(terminated(function_param,COMMA)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## LPAREN attributes UNION LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN IDENT COLON BOOL RBRACKET
+just_stmt: LPAREN UNION LBRACE RBRACE VAL
 ##
 ## Ends in an error in state: 482.
 ##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) . RPAREN option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
+## fexpr -> attributes UNION LBRACE list(union_item) RBRACE . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes UNION LBRACE list(union_item) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## LPAREN attributes UNION LBRACE list(union_item) RBRACE
 ##
 
 Invalid syntax
 
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN VAL
-##
-## Ends in an error in state: 483.
-##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN . option(preceded(RARROW,located(fexpr))) option(located(code_block)) [ RBRACE IMPL FN ]
-##
-## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN
-##
-
-Invalid syntax
-
-just_stmt: ENUM LBRACE FN IDENT LBRACKET RBRACKET LPAREN RPAREN RARROW BOOL VAL
+just_stmt: LPAREN STRUCT VAL
 ##
 ## Ends in an error in state: 484.
 ##
-## function_definition(located_ident_with_params,option(located(code_block))) -> FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr))) . option(located(code_block)) [ RBRACE IMPL FN ]
+## fexpr -> attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes STRUCT . option(params) LBRACE list(struct_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## FN IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LPAREN loption(separated_nonempty_list(COMMA,function_param)) RPAREN option(preceded(RARROW,located(fexpr)))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 380, spurious reduction of production option(preceded(RARROW,located(fexpr))) -> RARROW fexpr
+## LPAREN attributes STRUCT
 ##
 
 Invalid syntax
 
-just_stmt: RETURN UNION LBRACE RBRACE UNION
+just_stmt: LPAREN STRUCT LBRACKET RBRACKET VAL
+##
+## Ends in an error in state: 485.
+##
+## fexpr -> attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes STRUCT option(params) . LBRACE list(struct_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN attributes STRUCT option(params)
+##
+
+Invalid syntax
+
+just_stmt: LPAREN STRUCT LBRACE UNION
+##
+## Ends in an error in state: 486.
+##
+## fexpr -> attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes STRUCT option(params) LBRACE . list(struct_item) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN attributes STRUCT option(params) LBRACE
+##
+
+Invalid syntax
+
+just_stmt: LPAREN STRUCT LBRACE RBRACE VAL
 ##
 ## Ends in an error in state: 488.
 ##
-## expr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ VAL SEMICOLON RPAREN RBRACKET RBRACE IMPL FN EOF DOT COMMA CASE ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
+## fexpr -> attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes STRUCT option(params) LBRACE list(struct_item) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
+## LPAREN attributes STRUCT option(params) LBRACE list(struct_item) RBRACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION LBRACE CASE BOOL VAL
+just_stmt: LPAREN INTERFACE VAL
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 490.
 ##
-## expr -> expr . DOT IDENT [ RBRACE IMPL FN DOT CASE ]
-## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RBRACE IMPL FN DOT CASE ]
-## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RBRACE IMPL FN DOT CASE ]
-## list(preceded(CASE,located(expr))) -> CASE expr . list(preceded(CASE,located(expr))) [ RBRACE IMPL FN ]
+## fexpr -> attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes INTERFACE . LBRACE list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## CASE expr
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
+## LPAREN attributes INTERFACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION LBRACE RBRACE VAL
+just_stmt: LPAREN INTERFACE LBRACE VAL
 ##
-## Ends in an error in state: 494.
+## Ends in an error in state: 491.
 ##
-## expr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ DOT ]
-## fexpr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ LPAREN LBRACKET ]
-## stmt_expr -> UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE . [ SEMICOLON RBRACE EOF ]
+## fexpr -> attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes INTERFACE LBRACE . list(located(function_signature_binding)) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE
+## LPAREN attributes INTERFACE LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT VAL
+just_stmt: LPAREN INTERFACE LBRACE RBRACE VAL
+##
+## Ends in an error in state: 493.
+##
+## fexpr -> attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
+##
+## The known suffix of the stack is as follows:
+## LPAREN attributes INTERFACE LBRACE list(located(function_signature_binding)) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: LPAREN ENUM VAL
 ##
 ## Ends in an error in state: 495.
 ##
-## non_semicolon_stmt -> UNION IDENT . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT . LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT . LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## fexpr -> attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes ENUM . LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes ENUM . LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT
+## LPAREN attributes ENUM
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT LBRACKET VAL
+just_stmt: LPAREN ENUM LBRACE VAL
 ##
 ## Ends in an error in state: 496.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACKET . nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-## non_semicolon_stmt -> UNION IDENT LBRACKET . loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## fexpr -> attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## fexpr -> attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes ENUM LBRACE . nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
+## type_expr -> LPAREN attributes ENUM LBRACE . loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET
+## LPAREN attributes ENUM LBRACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RPAREN
-##
-## Ends in an error in state: 497.
-##
-## non_semicolon_stmt -> UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) . RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA))
-##
-## WARNING: This example involves spurious reductions.
-## This implies that, although the LR(1) items shown above provide an
-## accurate view of the past (what has been recognized so far), they
-## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 452, spurious reduction of production nonempty_list(terminated(function_param,COMMA)) -> IDENT COLON expr COMMA
-##
-
-Invalid syntax
-
-just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET VAL
-##
-## Ends in an error in state: 498.
-##
-## non_semicolon_stmt -> UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL COMMA RBRACKET LBRACE VAL
+just_stmt: LPAREN ENUM LBRACE IDENT COMMA RBRACE VAL
 ##
 ## Ends in an error in state: 499.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## fexpr -> attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET nonempty_list(terminated(function_param,COMMA)) RBRACKET LBRACE
+## LPAREN attributes ENUM LBRACE nonempty_list(terminated(enum_member,COMMA)) list(sugared_function_definition(option(located(code_block)))) RBRACE
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT LBRACKET IDENT COLON BOOL RPAREN
+just_stmt: LPAREN ENUM LBRACE RBRACE VAL
 ##
-## Ends in an error in state: 504.
+## Ends in an error in state: 503.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) . RBRACKET LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## fexpr -> attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . [ LPAREN LBRACKET ]
+## type_expr -> LPAREN attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE . RPAREN [ LBRACE IDENT EQUALS ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param))
+## LPAREN attributes ENUM LBRACE loption(separated_nonempty_list(COMMA,enum_member)) list(sugared_function_definition(option(located(code_block)))) RBRACE
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL VAL
+##
+## Ends in an error in state: 505.
+##
+## expr -> expr . DOT IDENT [ RPAREN DOT ]
+## expr -> expr . DOT IDENT LPAREN nonempty_list(terminated(located(expr),COMMA)) RPAREN [ RPAREN DOT ]
+## expr -> expr . DOT IDENT LPAREN loption(separated_nonempty_list(COMMA,located(expr))) RPAREN [ RPAREN DOT ]
+## switch -> SWITCH LPAREN expr . RPAREN LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## SWITCH LPAREN expr
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 95, spurious reduction of production expr -> BOOL
-## In state 451, spurious reduction of production separated_nonempty_list(COMMA,function_param) -> IDENT COLON expr
-## In state 16, spurious reduction of production loption(separated_nonempty_list(COMMA,function_param)) -> separated_nonempty_list(COMMA,function_param)
+## In state 25, spurious reduction of production expr -> BOOL
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT LBRACKET RBRACKET VAL
-##
-## Ends in an error in state: 505.
-##
-## non_semicolon_stmt -> UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET . LBRACE list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
-##
-## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET
-##
-
-Invalid syntax
-
-just_stmt: UNION IDENT LBRACKET RBRACKET LBRACE VAL
+just_stmt: SWITCH LPAREN BOOL RPAREN VAL
 ##
 ## Ends in an error in state: 506.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch -> SWITCH LPAREN expr RPAREN . LBRACE list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT LBRACKET loption(separated_nonempty_list(COMMA,function_param)) RBRACKET LBRACE
+## SWITCH LPAREN expr RPAREN
 ##
 
 Invalid syntax
 
-just_stmt: UNION IDENT LBRACE VAL
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE VAL
+##
+## Ends in an error in state: 507.
+##
+## switch -> SWITCH LPAREN expr RPAREN LBRACE . list(located(switch_branch)) option(default_branch) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## SWITCH LPAREN expr RPAREN LBRACE
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE VAL
+##
+## Ends in an error in state: 508.
+##
+## switch_branch -> CASE . type_expr IDENT REARROW code_block [ RBRACE ELSE CASE ]
+##
+## The known suffix of the stack is as follows:
+## CASE
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT LBRACE
+##
+## Ends in an error in state: 509.
+##
+## switch_branch -> CASE type_expr . IDENT REARROW code_block [ RBRACE ELSE CASE ]
+##
+## The known suffix of the stack is as follows:
+## CASE type_expr
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 66, spurious reduction of production type_expr -> IDENT
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT VAL
+##
+## Ends in an error in state: 510.
+##
+## switch_branch -> CASE type_expr IDENT . REARROW code_block [ RBRACE ELSE CASE ]
+##
+## The known suffix of the stack is as follows:
+## CASE type_expr IDENT
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW VAL
 ##
 ## Ends in an error in state: 511.
 ##
-## non_semicolon_stmt -> UNION IDENT LBRACE . list(preceded(CASE,located(expr))) list(sugared_function_definition(option(located(code_block)))) list(impl) RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL ]
+## switch_branch -> CASE type_expr IDENT REARROW . code_block [ RBRACE ELSE CASE ]
 ##
 ## The known suffix of the stack is as follows:
-## UNION IDENT LBRACE
+## CASE type_expr IDENT REARROW
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE CASE IDENT IDENT REARROW LBRACE RBRACE VAL
+##
+## Ends in an error in state: 513.
+##
+## list(located(switch_branch)) -> switch_branch . list(located(switch_branch)) [ RBRACE ELSE ]
+##
+## The known suffix of the stack is as follows:
+## switch_branch
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE VAL
+##
+## Ends in an error in state: 516.
+##
+## default_branch -> ELSE . REARROW code_block [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## ELSE
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW VAL
+##
+## Ends in an error in state: 517.
+##
+## default_branch -> ELSE REARROW . code_block [ RBRACE ]
+##
+## The known suffix of the stack is as follows:
+## ELSE REARROW
+##
+
+Invalid syntax
+
+just_stmt: SWITCH LPAREN BOOL RPAREN LBRACE ELSE REARROW LBRACE RBRACE VAL
+##
+## Ends in an error in state: 519.
+##
+## switch -> SWITCH LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch) . RBRACE [ UNION TILDE SWITCH STRUCT STRING RETURN RBRACE LPAREN LET LBRACE INTERFACE INT IF IDENT FN EOF ENUM BOOL AT ]
+##
+## The known suffix of the stack is as follows:
+## SWITCH LPAREN expr RPAREN LBRACE list(located(switch_branch)) option(default_branch)
 ##
 
 Invalid syntax
 
 just_stmt: BOOL SEMICOLON
 ##
-## Ends in an error in state: 516.
+## Ends in an error in state: 522.
 ##
 ## just_stmt -> stmt . EOF [ # ]
 ##
@@ -4957,16 +5142,16 @@ just_stmt: BOOL SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 336, spurious reduction of production stmt_expr -> BOOL
-## In state 339, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 518, spurious reduction of production stmt -> semicolon_stmt
+## In state 225, spurious reduction of production stmt_expr -> BOOL
+## In state 228, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 524, spurious reduction of production stmt -> semicolon_stmt
 ##
 
 Invalid syntax
 
 program: VAL
 ##
-## Ends in an error in state: 521.
+## Ends in an error in state: 527.
 ##
 ## program' -> . program [ # ]
 ##
@@ -4978,7 +5163,7 @@ Invalid syntax
 
 program: BOOL RBRACE
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 530.
 ##
 ## program -> block_stmt . EOF [ # ]
 ##
@@ -4989,10 +5174,10 @@ program: BOOL RBRACE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 336, spurious reduction of production stmt_expr -> BOOL
-## In state 339, spurious reduction of production semicolon_stmt -> stmt_expr
-## In state 341, spurious reduction of production stmt -> semicolon_stmt
-## In state 340, spurious reduction of production block_stmt -> stmt
+## In state 225, spurious reduction of production stmt_expr -> BOOL
+## In state 228, spurious reduction of production semicolon_stmt -> stmt_expr
+## In state 230, spurious reduction of production stmt -> semicolon_stmt
+## In state 229, spurious reduction of production block_stmt -> stmt
 ##
 
 Invalid syntax

--- a/lib/partial_evaluator.ml
+++ b/lib/partial_evaluator.ml
@@ -123,7 +123,8 @@ functor
           {switch_condition = cond; branches}
 
         method! visit_function_signature env
-            {value = {function_params; function_returns}; span} =
+            { value = {function_attributes; function_params; function_returns};
+              span } =
           let function_params =
             self#visit_list
               (fun env (n, e) -> (n, self#visit_type_ env e))
@@ -133,7 +134,8 @@ functor
           let function_returns =
             self#with_vars vars (fun _ -> self#visit_type_ env function_returns)
           in
-          {value = {function_params; function_returns}; span}
+          { value = {function_attributes; function_params; function_returns};
+            span }
 
         method! visit_function_ env f =
           let sign =

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -24,15 +24,20 @@ functor
     type ident = Ident of string
 
     and struct_definition =
-      { fields : struct_field located list; [@sexp.list]
+      { struct_attributes : attribute list; [@sexp.list]
+        fields : struct_field located list; [@sexp.list]
         struct_bindings : binding located list; [@sexp.list]
         impls : impl list; [@sexp.list]
         struct_span : (span[@sexp.opaque]) }
 
-    and impl = {interface : expr located; methods : binding located list}
+    and impl =
+      { impl_attributes : attribute list; [@sexp.list]
+        interface : expr located;
+        methods : binding located list }
 
     and interface_definition =
-      {interface_members : binding located list [@sexp.list]}
+      { interface_attributes : attribute list; [@sexp.list]
+        interface_members : binding located list [@sexp.list] }
 
     and function_call =
       {fn : expr located; arguments : expr located list [@sexp.list]}
@@ -43,7 +48,8 @@ functor
         receiver_arguments : expr located list }
 
     and enum_definition =
-      { enum_members : enum_member located list; [@sexp.list]
+      { enum_attributes : attribute list; [@sexp.list]
+        enum_members : enum_member located list; [@sexp.list]
         enum_bindings : binding located list [@sexp.list] }
 
     and enum_member =
@@ -52,10 +58,15 @@ functor
 
     (* TODO: union impls *)
     and union_definition =
-      { union_members : expr located list; [@sexpa.list]
+      { union_attributes : attribute list; [@sexp.list]
+        union_members : expr located list; [@sexpa.list]
         union_bindings : binding located list; [@sexp.list]
         union_impls : impl list; [@sexp.list]
         union_span : (span[@sexp.opaque]) }
+
+    and attribute =
+      { attribute_ident : ident located;
+        attribute_exprs : expr located list [@sexp.list] }
 
     and expr =
       | Struct of struct_definition
@@ -96,12 +107,16 @@ functor
         fields_construction : (ident located * expr located) list [@sexp.list]
       }
 
-    and struct_field = {field_name : ident located; field_type : expr located}
+    and struct_field =
+      { field_attributes : attribute list; [@sexp.list]
+        field_name : ident located;
+        field_type : expr located }
 
     and function_param = ident located * expr located
 
     and function_definition =
-      { name : ident located option; [@sexp.option]
+      { function_attributes : attribute list; [@sexp.list]
+        name : ident located option; [@sexp.option]
         params : function_param located list; [@sexp.list]
         returns : expr located option; [@sexp.option]
         function_body : function_body option; [@sexp.option]

--- a/lib/tokens.mly
+++ b/lib/tokens.mly
@@ -3,6 +3,7 @@
 %token <string> IDENT
 %token <string> STRING
 %token EOF
+%token AT
 %token DOUBLEDOT 
 %token LBRACE LPAREN LBRACKET
 %token RBRACE RPAREN RBRACKET

--- a/test/errors.ml
+++ b/test/errors.ml
@@ -130,13 +130,14 @@ let%expect_test "duplicate variant" =
     |}
   in
   pp source ;
+  (* FIXME: wrong positioning of the highlight *)
   [%expect
     {|
     Error[1]: Duplicate variant with type Integer
     File: <unknown>
 
     Error[1]: Duplicate variant with type Integer
-    File: "":7:6
+    File: "":5:7
       |
-    7 |       union Test2[T: Type] {...
-      |       ^^^^^^^^^^^^^^^^^^^^^^^^^ Duplicated variant in this union |}]
+    5 |       }...
+      |        ^^^ Duplicated variant in this union |}]

--- a/test/immediacy_check.ml
+++ b/test/immediacy_check.ml
@@ -103,7 +103,10 @@ let%expect_test "Immediacy Checks Empty Function" =
          (Function
             ( bl
             @@ { function_signature =
-                   bl @@ {function_params = []; function_returns = VoidType};
+                   bl
+                   @@ { function_attributes = [];
+                        function_params = [];
+                        function_returns = VoidType };
                  function_impl = Fn (bl @@ Block []) } ) )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
@@ -118,7 +121,8 @@ let%expect_test "Immediacy Checks Function Argument" =
             ( bl
             @@ { function_signature =
                    bl
-                   @@ { function_params = [(bl "arg", VoidType)];
+                   @@ { function_attributes = [];
+                        function_params = [(bl "arg", VoidType)];
                         function_returns = VoidType };
                  function_impl =
                    Fn
@@ -137,7 +141,10 @@ let%expect_test "Immediacy Checks Let Argument" =
          (Function
             ( bl
             @@ { function_signature =
-                   bl @@ {function_params = []; function_returns = VoidType};
+                   bl
+                   @@ { function_attributes = [];
+                        function_params = [];
+                        function_returns = VoidType };
                  function_impl =
                    Fn
                      ( bl
@@ -157,7 +164,10 @@ let%expect_test "Immediacy Checks Destructuring Let" =
          (Function
             ( bl
             @@ { function_signature =
-                   bl @@ {function_params = []; function_returns = VoidType};
+                   bl
+                   @@ { function_attributes = [];
+                        function_params = [];
+                        function_returns = VoidType };
                  function_impl =
                    Fn
                      ( bl
@@ -186,7 +196,9 @@ let%expect_test "Immediacy Checks Function Call WITHOUT Primitive" =
                    ( bl
                    @@ { function_signature =
                           bl
-                          @@ {function_params = []; function_returns = VoidType};
+                          @@ { function_attributes = [];
+                               function_params = [];
+                               function_returns = VoidType };
                         function_impl =
                           Fn
                             ( bl
@@ -211,7 +223,9 @@ let%expect_test "Immediacy Checks Function Call WITH Primitive" =
                    ( bl
                    @@ { function_signature =
                           bl
-                          @@ {function_params = []; function_returns = VoidType};
+                          @@ { function_attributes = [];
+                               function_params = [];
+                               function_returns = VoidType };
                         function_impl =
                           Fn
                             ( bl
@@ -233,7 +247,10 @@ let f_with_primitive =
        (Function
           ( bl
           @@ { function_signature =
-                 bl @@ {function_params = []; function_returns = VoidType};
+                 bl
+                 @@ { function_attributes = [];
+                      function_params = [];
+                      function_returns = VoidType };
                function_impl =
                  Fn
                    ( bl
@@ -255,7 +272,9 @@ let%expect_test "Immediacy Checks Function Call that contains function with \
                    ( bl
                    @@ { function_signature =
                           bl
-                          @@ {function_params = []; function_returns = VoidType};
+                          @@ { function_attributes = [];
+                               function_params = [];
+                               function_returns = VoidType };
                         function_impl =
                           Fn
                             ( bl
@@ -278,7 +297,9 @@ let%expect_test "Immediacy Checks Function Call that Call function with \
                    ( bl
                    @@ { function_signature =
                           bl
-                          @@ {function_params = []; function_returns = VoidType};
+                          @@ { function_attributes = [];
+                               function_params = [];
+                               function_returns = VoidType };
                         function_impl =
                           Fn
                             ( bl
@@ -301,7 +322,10 @@ let%expect_test "Immediacy Checks Top Level Fn With Sign" =
          (Function
             ( bl
             @@ { function_signature =
-                   bl @@ {function_params = []; function_returns = StructSig 0};
+                   bl
+                   @@ { function_attributes = [];
+                        function_params = [];
+                        function_returns = StructSig 0 };
                  function_impl = Fn (bl @@ Block []) } ) )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;

--- a/test/lang_types.ml
+++ b/test/lang_types.ml
@@ -66,10 +66,18 @@ let%test "parameterized structure equality" =
 let%test "builtin function equality" =
   let bl = Config.builtin_located in
   let f1 =
-    { function_signature = bl {function_params = []; function_returns = VoidType};
+    { function_signature =
+        bl
+          { function_attributes = [];
+            function_params = [];
+            function_returns = VoidType };
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Void)) }
   and f2 =
-    { function_signature = bl {function_params = []; function_returns = VoidType};
+    { function_signature =
+        bl
+          { function_attributes = [];
+            function_params = [];
+            function_returns = VoidType };
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Void)) }
   in
   Alcotest.(check bool)

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -1106,3 +1106,168 @@ let%expect_test "program returns" =
   let sources = [{| 1 |}; {| return 1|}] in
   List.iter ~f:pp sources ;
   [%expect {| ((stmts ((Expr (Int 1)))))((stmts ((Return (Int 1))))) |}]
+
+let%expect_test "attributes" =
+  let source =
+    {|
+    @attr
+    @attr(1)
+    @attr(1,2)
+    struct T {
+      @attr val a: Integer
+      @attr fn x() { true }
+    }
+
+    @attr
+    struct Ta[X: Integer] {}
+
+    let T1 = @attr struct { };
+
+    @attr
+    fn x() { }
+
+    let x1 = @attr fn () { };
+
+    @attr
+    interface I {
+      @attr
+      fn x() -> Bool
+    }
+
+    @attr
+    union U { case Void }
+
+    let U1 = @attr union { case Void };
+
+    struct Ti {
+      @attr
+      impl I {
+        @attr
+        fn x() -> Bool { true } 
+      }
+    }
+
+    @attr
+    enum E {
+      @attr fn x() { true }
+    }
+
+    let E1 = @attr enum { }
+
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    ((stmts
+      ((Let
+        ((binding_name (Ident T))
+         (binding_expr
+          (Struct
+           ((struct_attributes
+             (((attribute_ident (Ident attr)))
+              ((attribute_ident (Ident attr)) (attribute_exprs ((Int 1))))
+              ((attribute_ident (Ident attr))
+               (attribute_exprs ((Int 1) (Int 2))))))
+            (fields
+             (((field_attributes (((attribute_ident (Ident attr)))))
+               (field_name (Ident a)) (field_type (Reference (Ident Integer))))))
+            (struct_bindings
+             (((binding_name (Ident x))
+               (binding_expr
+                (Function
+                 ((function_attributes (((attribute_ident (Ident attr)))))
+                  (function_body
+                   ((function_stmt (CodeBlock ((Break (Expr (Bool true))))))))
+                  (function_def_span <opaque>)))))))
+            (struct_span <opaque>))))))
+       (Let
+        ((binding_name (Ident Ta))
+         (binding_expr
+          (Function
+           ((params (((Ident X) (Reference (Ident Integer)))))
+            (function_body
+             ((function_stmt
+               (Expr
+                (Struct
+                 ((struct_attributes (((attribute_ident (Ident attr)))))
+                  (struct_span <opaque>)))))))
+            (function_def_span <opaque>))))))
+       (Let
+        ((binding_name (Ident T1))
+         (binding_expr
+          (Struct
+           ((struct_attributes (((attribute_ident (Ident attr)))))
+            (struct_span <opaque>))))))
+       (Let
+        ((binding_name (Ident x))
+         (binding_expr
+          (Function
+           ((function_attributes (((attribute_ident (Ident attr)))))
+            (function_body ((function_stmt (CodeBlock ()))))
+            (function_def_span <opaque>))))))
+       (Let
+        ((binding_name (Ident x1))
+         (binding_expr
+          (Function
+           ((function_attributes (((attribute_ident (Ident attr)))))
+            (function_body ((function_stmt (CodeBlock ()))))
+            (function_def_span <opaque>))))))
+       (Let
+        ((binding_name (Ident I))
+         (binding_expr
+          (Interface
+           ((interface_attributes (((attribute_ident (Ident attr)))))
+            (interface_members
+             (((binding_name (Ident x))
+               (binding_expr
+                (Function
+                 ((function_attributes (((attribute_ident (Ident attr)))))
+                  (returns (Reference (Ident Bool)))
+                  (function_def_span <opaque>))))))))))))
+       (Let
+        ((binding_name (Ident U))
+         (binding_expr
+          (Union
+           ((union_attributes (((attribute_ident (Ident attr)))))
+            (union_members ((Reference (Ident Void)))) (union_span <opaque>))))))
+       (Let
+        ((binding_name (Ident U1))
+         (binding_expr
+          (Union
+           ((union_attributes (((attribute_ident (Ident attr)))))
+            (union_members ((Reference (Ident Void)))) (union_span <opaque>))))))
+       (Let
+        ((binding_name (Ident Ti))
+         (binding_expr
+          (Struct
+           ((impls
+             (((impl_attributes (((attribute_ident (Ident attr)))))
+               (interface (Reference (Ident I)))
+               (methods
+                (((binding_name (Ident x))
+                  (binding_expr
+                   (Function
+                    ((function_attributes (((attribute_ident (Ident attr)))))
+                     (returns (Reference (Ident Bool)))
+                     (function_body
+                      ((function_stmt (CodeBlock ((Break (Expr (Bool true))))))))
+                     (function_def_span <opaque>))))))))))
+            (struct_span <opaque>))))))
+       (Let
+        ((binding_name (Ident E))
+         (binding_expr
+          (Enum
+           ((enum_attributes (((attribute_ident (Ident attr)))))
+            (enum_bindings
+             (((binding_name (Ident x))
+               (binding_expr
+                (Function
+                 ((function_attributes (((attribute_ident (Ident attr)))))
+                  (function_body
+                   ((function_stmt (CodeBlock ((Break (Expr (Bool true))))))))
+                  (function_def_span <opaque>))))))))))))
+       (Let
+        ((binding_name (Ident E1))
+         (binding_expr
+          (Enum ((enum_attributes (((attribute_ident (Ident attr))))))))))))) |}]


### PR DESCRIPTION
At this point, the support is enabled for types (structs, unions,
interfaces, enums [limited to parser only as enums are not compiled
yet], struct fields [`val`] and `impl`s). I've considered adding
attributes to union cases but wasn't able to determine whether that is
necessary at this point.

An intersting byproduct of this change is that now struct and union
contents (items) can be arranged in any order. Before, it had to be in a
sequence:

For structs: fields, followed by functions, followed by impls
For unions: cases, followed by functions, followed by impls

However, the addition of attributes created shift/reduce conflicts in
the parser as it wasn't able to make a determination if the following
item is still of the same type or the follow-up type.

Therefore I rewrote that piece of the parser to handle them in any order
and that allowed it to handle attributes correctly.

Please note that this change has introduced a minor regression in some
of the error printing. I've put a FIXME there as I am unable to handle
it right now.