### PR TITLE
Add attribute executors

### DIFF
--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -7,54 +7,59 @@ functor
   struct
     open Lang_types.Make (Config)
 
-    let bl = Config.builtin_located
+    open struct
+      let bl = Config.builtin_located
 
-    let derive_executor p _exprs = function
-      | ImplInput {impl; self_ty} -> (
-        match impl.mk_impl_interface with
-        (* Serialize intf *)
-        | {value = Value (Type (InterfaceType -1)); _} ->
-            let builder_ty =
-              List.find_map_exn p.bindings ~f:(fun (n, e) ->
-                  if String.equal n.value "Builder" then Some e else None )
-              |> expr_to_type p
-            in
-            let self_serializer =
-              FunctionCall
-                ( bl @@ Reference (bl "serializer", HoleType),
-                  [bl @@ Value (Type self_ty)] )
-            in
-            let fun_body =
-              bl
-              @@ Return
-                   ( bl
-                   @@ FunctionCall
-                        ( bl @@ self_serializer,
-                          [ bl @@ Reference (bl "self", self_ty);
-                            bl @@ Reference (bl "b", builder_ty) ] ) )
-            in
-            let function_signature =
-              bl
-              @@ { function_params = [(bl "self", self_ty); (bl "b", builder_ty)];
-                   function_returns = builder_ty;
-                   function_attributes = [] }
-            in
-            let method_ =
-              bl
-              @@ MkFunction
-                   (bl {function_signature; function_impl = Fn fun_body})
-            in
-            let impl =
-              { mk_impl_interface = impl.mk_impl_interface;
-                mk_impl_attributes = [];
-                mk_impl_methods = [(bl "serialize", method_)] }
-            in
-            ImplInput {impl; self_ty}
-        (* Deserialize intf *)
-        | {value = Value (Type (InterfaceType -2)); _} ->
-            ImplInput {impl; self_ty}
-        | _ ->
-            raise Errors.InternalCompilerError )
+      let derive_executor p binds _exprs = function
+        | ImplInput {impl; self_ty} -> (
+          match impl.mk_impl_interface.value with
+          (* Serialize intf *)
+          | ResolvedReference (_, {value = Value (Type (InterfaceType -1)); _})
+          | Value (Type (InterfaceType -1)) ->
+              let builder_ty =
+                find_comptime "Builder" binds
+                |> Option.value_exn |> Result.ok |> Option.value_exn
+                |> expr_to_type p
+              in
+              let self_serializer =
+                FunctionCall
+                  ( bl @@ Reference (bl "serializer", HoleType),
+                    [bl @@ Value (Type self_ty)] )
+              in
+              let fun_body =
+                bl
+                @@ Return
+                     ( bl
+                     @@ FunctionCall
+                          ( bl @@ self_serializer,
+                            [ bl @@ Reference (bl "self", self_ty);
+                              bl @@ Reference (bl "b", builder_ty) ] ) )
+              in
+              let function_signature =
+                bl
+                @@ { function_params =
+                       [(bl "self", self_ty); (bl "b", builder_ty)];
+                     function_returns = builder_ty;
+                     function_attributes = [] }
+              in
+              let method_ =
+                bl
+                @@ MkFunction
+                     (bl {function_signature; function_impl = Fn fun_body})
+              in
+              let impl =
+                { mk_impl_interface = impl.mk_impl_interface;
+                  mk_impl_attributes = [];
+                  mk_impl_methods = [(bl "serialize", method_)] }
+              in
+              ImplInput {impl; self_ty}
+          (* Deserialize intf *)
+          | ResolvedReference (_, {value = Value (Type (InterfaceType -2)); _})
+          | Value (Type (InterfaceType -2)) ->
+              ImplInput {impl; self_ty}
+          | _ ->
+              raise Errors.InternalCompilerError )
+    end
 
     let attr_executors = [("derive", derive_executor)]
   end

--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -1,0 +1,60 @@
+open Base
+
+module Make =
+functor
+  (Config : Config.T)
+  ->
+  struct
+    open Lang_types.Make (Config)
+
+    let bl = Config.builtin_located
+
+    let derive_executor p _exprs = function
+      | ImplInput {impl; self_ty} -> (
+        match impl.mk_impl_interface with
+        (* Serialize intf *)
+        | {value = Value (Type (InterfaceType -1)); _} ->
+            let builder_ty =
+              List.find_map_exn p.bindings ~f:(fun (n, e) ->
+                  if String.equal n.value "Builder" then Some e else None )
+              |> expr_to_type p
+            in
+            let self_serializer =
+              FunctionCall
+                ( bl @@ Reference (bl "serializer", HoleType),
+                  [bl @@ Value (Type self_ty)] )
+            in
+            let fun_body =
+              bl
+              @@ Return
+                   ( bl
+                   @@ FunctionCall
+                        ( bl @@ self_serializer,
+                          [ bl @@ Reference (bl "self", self_ty);
+                            bl @@ Reference (bl "b", builder_ty) ] ) )
+            in
+            let function_signature =
+              bl
+              @@ { function_params = [(bl "self", self_ty); (bl "b", builder_ty)];
+                   function_returns = builder_ty;
+                   function_attributes = [] }
+            in
+            let method_ =
+              bl
+              @@ MkFunction
+                   (bl {function_signature; function_impl = Fn fun_body})
+            in
+            let impl =
+              { mk_impl_interface = impl.mk_impl_interface;
+                mk_impl_attributes = [];
+                mk_impl_methods = [(bl "serialize", method_)] }
+            in
+            ImplInput {impl; self_ty}
+        (* Deserialize intf *)
+        | {value = Value (Type (InterfaceType -2)); _} ->
+            ImplInput {impl; self_ty}
+        | _ ->
+            raise Errors.InternalCompilerError )
+
+    let attr_executors = [("derive", derive_executor)]
+  end

--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -11,7 +11,7 @@ functor
       let bl = Config.builtin_located
 
       let derive_executor p binds _exprs = function
-        | ImplInput {impl; self_ty} -> (
+        | ImplAttrTarget {impl; self_ty} -> (
           match impl.mk_impl_interface.value with
           (* Serialize intf *)
           | ResolvedReference (_, {value = Value (Type (InterfaceType -1)); _})
@@ -52,7 +52,7 @@ functor
                   mk_impl_attributes = [];
                   mk_impl_methods = [(bl "serialize", method_)] }
               in
-              ImplInput {impl; self_ty}
+              ImplAttrTarget {impl; self_ty}
           (* Deserialize intf *)
           | ResolvedReference (_, {value = Value (Type (InterfaceType -2)); _})
           | Value (Type (InterfaceType -2)) ->
@@ -100,7 +100,7 @@ functor
                   mk_impl_attributes = [];
                   mk_impl_methods = [(bl "deserialize", method_)] }
               in
-              ImplInput {impl; self_ty}
+              ImplAttrTarget {impl; self_ty}
           | _ ->
               raise Errors.InternalCompilerError )
     end

--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -56,6 +56,50 @@ functor
           (* Deserialize intf *)
           | ResolvedReference (_, {value = Value (Type (InterfaceType -2)); _})
           | Value (Type (InterfaceType -2)) ->
+              let slice_ty =
+                find_comptime "Slice" binds
+                |> Option.value_exn |> Result.ok |> Option.value_exn
+                |> expr_to_type p
+              in
+              let load_result_f =
+                find_comptime "LoadResult" binds
+                |> Option.value_exn |> Result.ok |> Option.value_exn
+              in
+              let self_deserializer =
+                FunctionCall
+                  ( bl @@ Reference (bl "deserializer", HoleType),
+                    [bl @@ Value (Type self_ty)] )
+              in
+              let fun_body =
+                bl
+                @@ Return
+                     ( bl
+                     @@ FunctionCall
+                          ( bl @@ self_deserializer,
+                            [bl @@ Reference (bl "s", slice_ty)] ) )
+              in
+              let ret_ty =
+                ExprType
+                  ( bl
+                  @@ FunctionCall (load_result_f, [bl @@ Value (Type self_ty)])
+                  )
+              in
+              let function_signature =
+                bl
+                @@ { function_params = [(bl "s", slice_ty)];
+                     function_returns = ret_ty;
+                     function_attributes = [] }
+              in
+              let method_ =
+                bl
+                @@ MkFunction
+                     (bl {function_signature; function_impl = Fn fun_body})
+              in
+              let impl =
+                { mk_impl_interface = impl.mk_impl_interface;
+                  mk_impl_attributes = [];
+                  mk_impl_methods = [(bl "deserialize", method_)] }
+              in
               ImplInput {impl; self_ty}
           | _ ->
               raise Errors.InternalCompilerError )

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -8,6 +8,7 @@ functor
     open Lang_types.Make (Config)
 
     open Config
+    module Attributes = Attributes.Make (Config)
 
     let builder = BuiltinType "Builder"
 
@@ -485,7 +486,8 @@ functor
         memoized_fcalls = [];
         interfaces = [];
         struct_signs = Arena.default ();
-        union_signs = Arena.default () }
+        union_signs = Arena.default ();
+        attr_executors = Attributes.attr_executors }
 
     let make_bindings = List.map ~f:(fun (x, y) -> (bl x, bl y))
 

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -932,10 +932,10 @@ functor
                 | Some executor -> (
                     let x =
                       executor program !current_bindings attr.attribute_exprs
-                        (ImplInput {impl; self_ty})
+                        (ImplAttrTarget {impl; self_ty})
                     in
                     match x with
-                    | ImplInput {impl; _} ->
+                    | ImplAttrTarget {impl; _} ->
                         impl |> remove_attr attr )
                 | None ->
                     impl

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -338,10 +338,11 @@ functor
 
     and primitive = Prim of {name : string; exprs : expr list}
 
-    and attr_input = ImplInput of {impl : mk_impl; self_ty : type_}
+    (* This type will be extended in the future *)
+    and attr_target = ImplAttrTarget of {impl : mk_impl; self_ty : type_}
 
     and attr_executor =
-      (program -> tbinding list list -> expr list -> attr_input -> attr_input
+      (program -> tbinding list list -> expr list -> attr_target -> attr_target
       [@visitors.opaque] [@equal.ignore] [@compare.ignore] )
     [@@deriving
       equal,

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -341,7 +341,7 @@ functor
     and attr_input = ImplInput of {impl : mk_impl; self_ty : type_}
 
     and attr_executor =
-      (program -> expr list -> attr_input -> attr_input
+      (program -> tbinding list list -> expr list -> attr_input -> attr_input
       [@visitors.opaque] [@equal.ignore] [@compare.ignore] )
     [@@deriving
       equal,

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -141,8 +141,10 @@ functor
             [@hash.ignore]
         mutable struct_signs : struct_sig Arena.t;
             [@hash.ignore] [@visitors.name "arena"]
-        mutable union_signs : union_sig Arena.t
-            [@hash.ignore] [@visitors.name "arena"] }
+        mutable union_signs : union_sig Arena.t;
+            [@hash.ignore] [@visitors.name "arena"]
+        attr_executors : ((string * attr_executor) list[@sexp.opaque])
+            [@visitors.opaque] [@equal.ignore] [@compare.ignore] }
 
     and expr = expr_kind located
 
@@ -335,6 +337,12 @@ functor
       {branch_ty : type_; branch_var : string located; branch_stmt : stmt}
 
     and primitive = Prim of {name : string; exprs : expr list}
+
+    and attr_input = ImplInput of {impl : mk_impl; self_ty : type_}
+
+    and attr_executor =
+      (program -> expr list -> attr_input -> attr_input
+      [@visitors.opaque] [@equal.ignore] [@compare.ignore] )
     [@@deriving
       equal,
         compare,

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -337,11 +337,8 @@ struct Timestamps {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct IntMsgInfoFlags {
@@ -352,22 +349,16 @@ struct IntMsgInfoFlags {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct IntMsgInfoAddresses {
   val src: MsgAddressInt
   val dst: MsgAddressInt
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct IntMsgInfoCoins {
@@ -377,11 +368,8 @@ struct IntMsgInfoCoins {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct IntMsgInfo {
@@ -406,11 +394,8 @@ struct IntMsgInfo {
     }
   }
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct ExtInMsgInfo {
@@ -418,11 +403,8 @@ struct ExtInMsgInfo {
   val dest: MsgAddressInt
   val import_fee: Coins
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      deserializer[Self](s)
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 union CommonMsgInfo {

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -191,11 +191,8 @@ union MsgAddressExt {
   case AddrNone
   case AddrExtern
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -279,11 +276,8 @@ union MsgAddressInt {
   case AddressStd
   case AddressVar
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -302,11 +296,8 @@ union MsgAddress {
   case MsgAddressExt
   case MsgAddressInt
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -328,11 +319,8 @@ struct ExtOutMsgInfoRelaxed {
   val created_lt: Uint[64]
   val created_at: Uint[32]
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      return serializer[Self](self, b);
-    }
-  }
+  @derive
+  impl Serialize {}
 }
 
 struct Timestamps {
@@ -346,11 +334,8 @@ struct Timestamps {
     }
   }
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -364,11 +349,8 @@ struct IntMsgInfoFlags {
   val bounce: Int[1]
   val bounced: Int[1]
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -392,11 +374,8 @@ struct IntMsgInfoCoins {
   val ihr_fee: Coins
   val fwd_fee: Coins
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 
   impl Deserialize {
     fn deserialize(s: Slice) -> LoadResult[Self] {
@@ -473,11 +452,8 @@ struct IntMsgInfoRelaxedAddresses {
   val src: MsgAddress
   val dst: MsgAddressInt
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 }
 
 struct IntMsgInfoRelaxed {
@@ -502,11 +478,8 @@ struct IntMsgInfoRelaxed {
     }
   }
 
-  impl Serialize {
-    fn serialize(self: Self, b: Builder) -> Builder {
-      serializer[Self](self, b)
-    }
-  }
+  @derive
+  impl Serialize {}
 }
 
 union CommonMsgInfoRelaxed {

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -169,7 +169,7 @@ let%expect_test "Int[bits] constructor" =
                            ((value (Reference (i IntegerType)))))))))))))))))
               (uty_id 102) (uty_base_id 12)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-        (union_signs (0 ())))) |}]
+        (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Int[bits] serializer" =
   let source =
@@ -351,7 +351,7 @@ let%expect_test "Int[bits] serializer" =
                            ((value (Reference (i IntegerType)))))))))))))))))
               (uty_id 102) (uty_base_id 12)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-        (union_signs (0 ())))) |}]
+        (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "demo struct serializer" =
   let source =
@@ -759,7 +759,7 @@ let%expect_test "demo struct serializer" =
              ((a (Value (Type (StructType 102))))
               (b (Value (Type (StructType 104))))))
             (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 136)))))
-        (union_signs (0 ())))) |}]
+        (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "from interface" =
   let source =
@@ -833,7 +833,7 @@ let%expect_test "from interface" =
                ((function_params ((x IntegerType)))
                 (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
             (st_sig_base_id 102) (st_sig_id 136)))))
-        (union_signs (0 ())))) |}]
+        (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "tensor2" =
   let source =
@@ -861,7 +861,7 @@ let%expect_test "tensor2" =
                     ((ResolvedReference (builtin_divmod <opaque>))
                      ((Value (Integer 10)) (Value (Integer 2))))))))))))))))
         (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-        (struct_signs (0 ())) (union_signs (0 ())))) |}]
+        (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "slice api" =
   let source =
@@ -929,7 +929,7 @@ let%expect_test "slice api" =
                        ((StructField
                          ((Reference (result (StructType 5))) value IntegerType))))))))))))))))))
         (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-        (struct_signs (0 ())) (union_signs (0 ())))) |}]
+        (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "deserializer" =
   let source =
@@ -1070,4 +1070,4 @@ let%expect_test "deserializer" =
            ((value1 (Value (Type (StructType 17))))
             (value2 (Value (Type (StructType 30))))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -1071,3 +1071,132 @@ let%expect_test "deserializer" =
             (value2 (Value (Type (StructType 30))))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "derive Serialize" =
+  let source =
+    {|
+      struct Something {
+        val value1: Int[9]
+        
+        @derive
+        impl Serialize {}
+      }
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((Something (Value (Type (StructType 103))))))
+      (structs
+       ((103
+         ((struct_fields ((value1 ((field_type (StructType 17))))))
+          (struct_details
+           ((uty_methods
+             ((serialize
+               ((function_signature
+                 ((function_params ((self (StructType 103)) (b (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((Value
+                      (Function
+                       ((function_signature
+                         ((function_params
+                           ((self (StructType 103)) (b (StructType 3))))
+                          (function_returns (StructType 3))))
+                        (function_impl
+                         (Fn
+                          (Block
+                           ((Let
+                             ((b
+                               (FunctionCall
+                                ((Value
+                                  (Function
+                                   ((function_signature
+                                     ((function_params
+                                       ((self (StructType 17))
+                                        (builder (StructType 3))))
+                                      (function_returns (StructType 3))))
+                                    (function_impl
+                                     (Fn
+                                      (Return
+                                       (FunctionCall
+                                        ((ResolvedReference
+                                          (serialize_int <opaque>))
+                                         ((Reference (builder (StructType 3)))
+                                          (StructField
+                                           ((Reference (self (StructType 17)))
+                                            value IntegerType))
+                                          (Value (Integer 9)))))))))))
+                                 ((StructField
+                                   ((Reference (self (StructType 103))) value1
+                                    (StructType 17)))
+                                  (Reference (b (StructType 3)))))))))
+                            (Return (Reference (b (StructType 3)))))))))))
+                     ((Reference (self (StructType 103)))
+                      (Reference (b (StructType 3)))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 103)) (b (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((self (StructType 103)) (b (StructType 3))))
+                             (function_returns (StructType 3))))
+                           (function_impl
+                            (Fn
+                             (Block
+                              ((Let
+                                ((b
+                                  (FunctionCall
+                                   ((Value
+                                     (Function
+                                      ((function_signature
+                                        ((function_params
+                                          ((self (StructType 17))
+                                           (builder (StructType 3))))
+                                         (function_returns (StructType 3))))
+                                       (function_impl
+                                        (Fn
+                                         (Return
+                                          (FunctionCall
+                                           ((ResolvedReference
+                                             (serialize_int <opaque>))
+                                            ((Reference (builder (StructType 3)))
+                                             (StructField
+                                              ((Reference (self (StructType 17)))
+                                               value IntegerType))
+                                             (Value (Integer 9)))))))))))
+                                    ((StructField
+                                      ((Reference (self (StructType 103))) value1
+                                       (StructType 17)))
+                                     (Reference (b (StructType 3)))))))))
+                               (Return (Reference (b (StructType 3)))))))))))
+                        ((Reference (self (StructType 103)))
+                         (Reference (b (StructType 3))))))))))))))))
+            (uty_id 103) (uty_base_id 102)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ((value1 (Value (Type (StructType 17))))))
+          (st_sig_methods
+           ((serialize
+             ((function_params
+               ((self (ExprType (Reference (Self (StructSig 136)))))
+                (b (StructType 3))))
+              (function_returns (StructType 3))))))
+          (st_sig_base_id 102) (st_sig_id 136)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -758,7 +758,7 @@ let%expect_test "demo struct serializer" =
           (((st_sig_fields
              ((a (Value (Type (StructType 102))))
               (b (Value (Type (StructType 104))))))
-            (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 136)))))
+            (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 94)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -831,8 +831,8 @@ let%expect_test "from interface" =
             (st_sig_methods
              ((from
                ((function_params ((x IntegerType)))
-                (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
-            (st_sig_base_id 102) (st_sig_id 136)))))
+                (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
+            (st_sig_base_id 102) (st_sig_id 94)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "tensor2" =
@@ -1069,7 +1069,7 @@ let%expect_test "deserializer" =
         (((st_sig_fields
            ((value1 (Value (Type (StructType 17))))
             (value2 (Value (Type (StructType 30))))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "derive Serialize" =
@@ -1195,8 +1195,8 @@ let%expect_test "derive Serialize" =
           (st_sig_methods
            ((serialize
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 136)))))
+               ((self (ExprType (Reference (Self (StructSig 94)))))
                 (b (StructType 3))))
               (function_returns (StructType 3))))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -74,7 +74,7 @@ let%expect_test "program returns" =
       (struct_signs
        (1
         (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 102)
-          (st_sig_id 136)))))
+          (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scope resolution" =
@@ -732,7 +732,7 @@ let%expect_test "basic struct definition" =
       (struct_signs
        (1
         (((st_sig_fields ((t (Value (Type (StructType 102))))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Tact function evaluation" =
@@ -1082,7 +1082,7 @@ let%expect_test "struct definition" =
         (((st_sig_fields
            ((a (Value (Type (StructType 102))))
             (b (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -1103,7 +1103,7 @@ let%expect_test "duplicate type field" =
           ((a (Value (Type (StructType 102))))
            (a (ResolvedReference (Bool <opaque>)))))
          (mk_struct_details
-          ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 136)
+          ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 94)
            (mk_span <opaque>)))))))
      ((bindings ((MyType (Value (Type (StructType 105))))))
       (structs
@@ -1264,7 +1264,7 @@ let%expect_test "duplicate type field" =
         (((st_sig_fields
            ((a (Value (Type (StructType 102))))
             (a (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -1285,14 +1285,14 @@ let%expect_test "parametric struct instantiation" =
           (Function
            ((function_signature
              ((function_params ((A (TypeN 0))))
-              (function_returns (StructSig 136))))
+              (function_returns (StructSig 94))))
             (function_impl
              (Fn
               (Return
                (MkStructDef
                 ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
                  (mk_struct_details
-                  ((mk_methods ()) (mk_impls ()) (mk_id 102) (mk_sig 136)
+                  ((mk_methods ()) (mk_impls ()) (mk_id 102) (mk_sig 94)
                    (mk_span <opaque>))))))))))))))
       (structs
        ((105
@@ -1449,7 +1449,7 @@ let%expect_test "parametric struct instantiation" =
       (struct_signs
        (1
         (((st_sig_fields ((a (Reference (A (TypeN 0)))))) (st_sig_methods ())
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -1912,10 +1912,10 @@ let%expect_test "struct method access" =
           (st_sig_methods
            ((bar
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 136)))))
+               ((self (ExprType (Reference (Self (StructSig 94)))))
                 (i IntegerType)))
               (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -1953,7 +1953,7 @@ let%expect_test "struct type method access" =
           (st_sig_methods
            ((bar
              ((function_params ((i IntegerType))) (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -1989,9 +1989,9 @@ let%expect_test "Self type resolution in methods" =
           (st_sig_methods
            ((bar
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 136)))))))
-              (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+               ((self (ExprType (Reference (Self (StructSig 94)))))))
+              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -2151,7 +2151,7 @@ let%expect_test "struct instantiation" =
         (((st_sig_fields
            ((a (ResolvedReference (Integer <opaque>)))
             (b (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -2942,7 +2942,7 @@ let%expect_test "implement interface op" =
            ((op
              ((function_params ((left IntegerType) (right IntegerType)))
               (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -3000,8 +3000,8 @@ let%expect_test "implement interface op" =
           (st_sig_methods
            ((new
              ((function_params ())
-              (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
-          (st_sig_base_id 103) (st_sig_id 136)))))
+              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
+          (st_sig_base_id 103) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
@@ -3213,9 +3213,9 @@ let%expect_test "serializer inner struct" =
         (((st_sig_fields
            ((y (Value (Type (StructType 102))))
             (z (ResolvedReference (Inner <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 137))
+          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 95))
          ((st_sig_fields ((x (Value (Type (StructType 102))))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -4098,7 +4098,7 @@ let%expect_test "methods monomorphization" =
           (Function
            ((function_signature
              ((function_params ((X (TypeN 0))))
-              (function_returns (StructSig 136))))
+              (function_returns (StructSig 94))))
             (function_impl
              (Fn
               (Return
@@ -4110,14 +4110,14 @@ let%expect_test "methods monomorphization" =
                       (MkFunction
                        ((function_signature
                          ((function_params
-                           ((self (ExprType (Reference (Self (StructSig 136)))))
+                           ((self (ExprType (Reference (Self (StructSig 94)))))
                             (x (ExprType (Reference (X (TypeN 0)))))))
                           (function_returns (ExprType (Reference (X (TypeN 0)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))
-                   (mk_impls ()) (mk_id 102) (mk_sig 136) (mk_span <opaque>))))))))))))))
+                   (mk_impls ()) (mk_id 102) (mk_sig 94) (mk_span <opaque>))))))))))))))
       (structs
        ((106
          ((struct_fields ())
@@ -4148,15 +4148,15 @@ let%expect_test "methods monomorphization" =
       (struct_signs
        (2
         (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 104)
-          (st_sig_id 137))
+          (st_sig_id 95))
          ((st_sig_fields ())
           (st_sig_methods
            ((id
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 136)))))
+               ((self (ExprType (Reference (Self (StructSig 94)))))
                 (x (ExprType (Reference (X (TypeN 0)))))))
               (function_returns (ExprType (Reference (X (TypeN 0)))))))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -5031,9 +5031,9 @@ let%expect_test "interface constraints" =
           (st_sig_methods
            ((beep
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 136)))))))
+               ((self (ExprType (Reference (Self (StructSig 94)))))))
               (function_returns IntegerType)))))
-          (st_sig_base_id 103) (st_sig_id 136)))))
+          (st_sig_base_id 103) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let" =
@@ -5087,7 +5087,7 @@ let%expect_test "destructuring let" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields" =
@@ -5138,7 +5138,7 @@ let%expect_test "destructuring let with missing fields" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields ignored" =
@@ -5189,7 +5189,7 @@ let%expect_test "destructuring let with missing fields ignored" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
+          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type that does not implement interface passed to the \
@@ -5226,7 +5226,7 @@ let%expect_test "type that does not implement interface passed to the \
       (struct_signs
        (1
         (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 103)
-          (st_sig_id 136)))))
+          (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct signatures" =
@@ -5293,7 +5293,7 @@ let%expect_test "struct signatures" =
           (Function
            ((function_signature
              ((function_params ((bits IntegerType)))
-              (function_returns (StructSig 136))))
+              (function_returns (StructSig 94))))
             (function_impl
              (Fn
               (Return
@@ -5307,15 +5307,15 @@ let%expect_test "struct signatures" =
                        ((function_signature
                          ((function_params ((i IntegerType)))
                           (function_returns
-                           (ExprType (Reference (Self (StructSig 136)))))))
+                           (ExprType (Reference (Self (StructSig 94)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Value
                             (Struct
-                             ((Reference (Self (StructSig 136)))
+                             ((Reference (Self (StructSig 94)))
                               ((value (Reference (i IntegerType)))))))))))))))
-                   (mk_impls ()) (mk_id 102) (mk_sig 136) (mk_span <opaque>))))))))))))))
+                   (mk_impls ()) (mk_id 102) (mk_sig 94) (mk_span <opaque>))))))))))))))
       (structs
        ((104
          ((struct_fields ((value ((field_type IntegerType)))))
@@ -5356,8 +5356,8 @@ let%expect_test "struct signatures" =
           (st_sig_methods
            ((new
              ((function_params ((i IntegerType)))
-              (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
-          (st_sig_base_id 102) (st_sig_id 136)))))
+              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
+          (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserilize intf with constraints" =
@@ -5855,7 +5855,7 @@ let%expect_test "attributes" =
             (Function
              ((function_signature
                ((function_params ((X IntegerType)))
-                (function_returns (StructSig 137))))
+                (function_returns (StructSig 95))))
               (function_impl
                (Fn
                 (Return
@@ -5864,7 +5864,7 @@ let%expect_test "attributes" =
                     (((attribute_ident attr) (attribute_exprs ()))))
                    (mk_struct_fields ())
                    (mk_struct_details
-                    ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 137)
+                    ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 95)
                      (mk_span <opaque>))))))))))))
           (T (Value (Type (StructType 103))))))
         (structs
@@ -5964,13 +5964,13 @@ let%expect_test "attributes" =
                ((function_attributes
                  (((attribute_ident attr) (attribute_exprs ()))))
                 (function_params ()) (function_returns BoolType)))))
-            (st_sig_base_id 113) (st_sig_id 139))
+            (st_sig_base_id 113) (st_sig_id 97))
            ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 105)
-            (st_sig_id 138))
+            (st_sig_id 96))
            ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 104)
-            (st_sig_id 137))
+            (st_sig_id 95))
            ((st_sig_attributes
              (((attribute_ident attr) (attribute_exprs ()))
               ((attribute_ident attr) (attribute_exprs ((Value (Integer 1)))))
@@ -5982,7 +5982,7 @@ let%expect_test "attributes" =
                ((function_attributes
                  (((attribute_ident attr) (attribute_exprs ()))))
                 (function_params ()) (function_returns BoolType)))))
-            (st_sig_base_id 102) (st_sig_id 136)))))
+            (st_sig_base_id 102) (st_sig_id 94)))))
         (union_signs
          (2
           (((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -27,44 +27,55 @@ let%expect_test "program returns" =
     {|
     (Ok
      ((bindings ()) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))))
+      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
+      (attr_executors <opaque>)))
+    (Ok
+                                  ((bindings ()) (structs ())
+                                   (type_counter <opaque>)
+                                   (memoized_fcalls <opaque>)
+                                   (struct_signs (0 ())) (union_signs (0 ()))
+                                   (attr_executors <opaque>)))
+    (Ok
+                                                               ((bindings
+                                                                 ((x
+                                                                   (Value
+                                                                    (Function
+                                                                     ((function_signature
+                                                                       ((function_params
+                                                                        ())
+                                                                        (function_returns
+                                                                        IntegerType)))
+                                                                      (function_impl
+                                                                       (Fn
+                                                                        (Return
+                                                                        (Value
+                                                                        (Integer
+                                                                        1)))))))))))
+                                                                (structs ())
+                                                                (type_counter
+                                                                 <opaque>)
+                                                                (memoized_fcalls
+                                                                 <opaque>)
+                                                                (struct_signs
+                                                                 (0 ()))
+                                                                (union_signs
+                                                                 (0 ()))
+                                                                (attr_executors
+                                                                 <opaque>)))
 
     (Ok
-     ((bindings ()) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))))
-
-    (Ok
-     ((bindings
-       ((x
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ()) (function_returns IntegerType)))
-            (function_impl (Fn (Return (Value (Integer 1)))))))))))
-      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ()))))
-    (Ok
-                                                   ((bindings
-                                                     ((T
-                                                       (Value
-                                                        (Type (StructType 103))))))
-                                                    (structs
-                                                     ((103
-                                                       ((struct_fields ())
-                                                        (struct_details
-                                                         ((uty_methods ())
-                                                          (uty_impls ())
-                                                          (uty_id 103)
-                                                          (uty_base_id 102)))))))
-                                                    (type_counter <opaque>)
-                                                    (memoized_fcalls <opaque>)
-                                                    (struct_signs
-                                                     (1
-                                                      (((st_sig_fields ())
-                                                        (st_sig_methods ())
-                                                        (st_sig_base_id 102)
-                                                        (st_sig_id 136)))))
-                                                    (union_signs (0 ())))) |}]
+     ((bindings ((T (Value (Type (StructType 103))))))
+      (structs
+       ((103
+         ((struct_fields ())
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 102)
+          (st_sig_id 136)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scope resolution" =
   let source = {|
@@ -223,7 +234,7 @@ let%expect_test "scope resolution" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "binding resolution" =
   let source = {|
@@ -382,7 +393,7 @@ let%expect_test "binding resolution" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "failed scope resolution" =
   let source = {|
@@ -393,7 +404,8 @@ let%expect_test "failed scope resolution" =
     {|
     (((UnresolvedIdentifier Int256))
      ((bindings ((T (Value Void)))) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "scope resolution after let binding" =
   let source = {|
@@ -554,7 +566,7 @@ let%expect_test "scope resolution after let binding" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "basic struct definition" =
   let source = {|
@@ -721,7 +733,7 @@ let%expect_test "basic struct definition" =
        (1
         (((st_sig_fields ((t (Value (Type (StructType 102))))))
           (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Tact function evaluation" =
   let source =
@@ -896,7 +908,7 @@ let%expect_test "Tact function evaluation" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct definition" =
   let source =
@@ -1071,7 +1083,7 @@ let%expect_test "struct definition" =
            ((a (Value (Type (StructType 102))))
             (b (ResolvedReference (Bool <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
   let source =
@@ -1253,7 +1265,7 @@ let%expect_test "duplicate type field" =
            ((a (Value (Type (StructType 102))))
             (a (ResolvedReference (Bool <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "parametric struct instantiation" =
   let source =
@@ -1438,7 +1450,7 @@ let%expect_test "parametric struct instantiation" =
        (1
         (((st_sig_fields ((a (Reference (A (TypeN 0)))))) (st_sig_methods ())
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "function without a return type" =
   let source = {|
@@ -1458,7 +1470,7 @@ let%expect_test "function without a return type" =
              ((function_params ()) (function_returns IntegerType)))
             (function_impl (Fn (Return (Value (Integer 1)))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scoping that `let` introduces in code" =
   let source =
@@ -1638,7 +1650,7 @@ let%expect_test "scoping that `let` introduces in code" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "reference in function bodies" =
   let source =
@@ -1834,7 +1846,7 @@ let%expect_test "reference in function bodies" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "resolving a reference from inside a function" =
   let source =
@@ -1860,7 +1872,7 @@ let%expect_test "resolving a reference from inside a function" =
             (function_impl (Fn (Return (ResolvedReference (i <opaque>)))))))))
         (i (Value (Integer 1)))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct method access" =
   let source =
@@ -1904,7 +1916,7 @@ let%expect_test "struct method access" =
                 (i IntegerType)))
               (function_returns IntegerType)))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct type method access" =
   let source =
@@ -1942,7 +1954,7 @@ let%expect_test "struct type method access" =
            ((bar
              ((function_params ((i IntegerType))) (function_returns IntegerType)))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
   let source =
@@ -1980,7 +1992,7 @@ let%expect_test "Self type resolution in methods" =
                ((self (ExprType (Reference (Self (StructSig 136)))))))
               (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "union method access" =
   let source =
@@ -2041,7 +2053,8 @@ let%expect_test "union method access" =
              ((function_params ((from BoolType))) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
-       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102))))))) |}]
+       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "union type method access" =
   let source =
@@ -2101,7 +2114,8 @@ let%expect_test "union type method access" =
              ((function_params ((from BoolType))) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
-       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102))))))) |}]
+       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "struct instantiation" =
   let source =
@@ -2138,7 +2152,7 @@ let%expect_test "struct instantiation" =
            ((a (ResolvedReference (Integer <opaque>)))
             (b (ResolvedReference (Integer <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type check error" =
   let source = {|
@@ -2454,7 +2468,7 @@ let%expect_test "type check error" =
              ((function_params ((from (StructType 102))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type inference" =
   let source = {|
@@ -2472,7 +2486,7 @@ let%expect_test "type inference" =
              ((function_params ((i IntegerType))) (function_returns IntegerType)))
             (function_impl (Fn (Return (Reference (i IntegerType)))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scope doesn't leak bindings" =
   let source = {|
@@ -2485,7 +2499,8 @@ let%expect_test "scope doesn't leak bindings" =
     {|
     (Ok
      ((bindings ()) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "compile-time if/then/else continues interpretation after \
                  condition check (bug fix)" =
@@ -2520,7 +2535,7 @@ let%expect_test "compile-time if/then/else continues interpretation after \
                   (if_then (Block ((Return (Value (Integer 1)))))) (if_else ())))
                 (Return (Value (Integer 2)))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ()))))
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>)))
 |}]
 
 let%expect_test "compile-time if/then/else" =
@@ -2566,7 +2581,7 @@ let%expect_test "compile-time if/then/else" =
              ((function_params ()) (function_returns BoolType)))
             (function_impl (Fn (Return (Value (Bool true)))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type check error" =
   let source =
@@ -2881,7 +2896,7 @@ let%expect_test "type check error" =
              ((function_params ((from (StructType 104))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -2928,7 +2943,7 @@ let%expect_test "implement interface op" =
              ((function_params ((left IntegerType) (right IntegerType)))
               (function_returns IntegerType)))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "implement interface op" =
   let source =
@@ -2987,7 +3002,7 @@ let%expect_test "implement interface op" =
              ((function_params ())
               (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
           (st_sig_base_id 103) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
   let source =
@@ -3201,7 +3216,7 @@ let%expect_test "serializer inner struct" =
           (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 137))
          ((st_sig_fields ((x (Value (Type (StructType 102))))))
           (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
   let source =
@@ -3238,7 +3253,7 @@ let%expect_test "reference resolving in inner functions" =
                   (Fn
                    (Return (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "dependent types" =
   let source =
@@ -3302,7 +3317,7 @@ let%expect_test "dependent types" =
                     ((function_params ((x (ExprType (Reference (X (TypeN 0)))))))
                      (function_returns (ExprType (Reference (X (TypeN 0))))))))))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "TypeN" =
   let source =
@@ -3324,7 +3339,7 @@ let%expect_test "TypeN" =
              ((function_params ((X (TypeN 0)))) (function_returns (TypeN 0))))
             (function_impl (Fn (Return (Reference (X (TypeN 0))))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "union variants constructing" =
   let source =
@@ -3545,7 +3560,8 @@ let%expect_test "union variants constructing" =
       (union_signs
        (1
         (((un_sig_cases (IntegerType (StructType 102))) (un_sig_methods ())
-          (un_sig_base_id 104))))))) |}]
+          (un_sig_base_id 104)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "unions duplicate variant" =
   let source =
@@ -3687,7 +3703,8 @@ let%expect_test "unions duplicate variant" =
       (union_signs
        (1
         (((un_sig_cases (IntegerType (ExprType (Reference (T (TypeN 0))))))
-          (un_sig_methods ()) (un_sig_base_id 102))))))) |}]
+          (un_sig_methods ()) (un_sig_base_id 102)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "unions" =
   let source =
@@ -4048,7 +4065,8 @@ let%expect_test "unions" =
       (union_signs
        (1
         (((un_sig_cases ((StructType 102) (StructType 104))) (un_sig_methods ())
-          (un_sig_base_id 106))))))) |}]
+          (un_sig_base_id 106)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =
   let source =
@@ -4139,7 +4157,7 @@ let%expect_test "methods monomorphization" =
                 (x (ExprType (Reference (X (TypeN 0)))))))
               (function_returns (ExprType (Reference (X (TypeN 0)))))))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "switch statement" =
   let source =
@@ -4517,7 +4535,8 @@ let%expect_test "switch statement" =
       (union_signs
        (1
         (((un_sig_cases ((StructType 102) (StructType 104))) (un_sig_methods ())
-          (un_sig_base_id 106))))))) |}]
+          (un_sig_base_id 106)))))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "partial evaluation of a function" =
   let source =
@@ -4581,7 +4600,7 @@ let%expect_test "partial evaluation of a function" =
               (function_returns IntegerType)))
             (function_impl (Fn (Return (Reference (x IntegerType)))))))))))
       (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "let binding with type" =
   let source = {|
@@ -4894,7 +4913,7 @@ let%expect_test "let binding with type" =
                          ((value (Reference (i IntegerType)))))))))))))))))
             (uty_id 102) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "let binding with a non-matching type" =
   let source = {|
@@ -4905,7 +4924,8 @@ let%expect_test "let binding with a non-matching type" =
     {|
     (((TypeError (BoolType IntegerType)) (TypeError (BoolType IntegerType)))
      ((bindings ((a (Value Void)))) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ())))) |}]
+      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
+      (attr_executors <opaque>))) |}]
 
 let%expect_test "interface constraints" =
   let source =
@@ -5014,7 +5034,7 @@ let%expect_test "interface constraints" =
                ((self (ExprType (Reference (Self (StructSig 136)))))))
               (function_returns IntegerType)))))
           (st_sig_base_id 103) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let" =
   let source =
@@ -5068,7 +5088,7 @@ let%expect_test "destructuring let" =
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields" =
   let source =
@@ -5119,7 +5139,7 @@ let%expect_test "destructuring let with missing fields" =
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields ignored" =
   let source =
@@ -5170,7 +5190,7 @@ let%expect_test "destructuring let with missing fields ignored" =
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type that does not implement interface passed to the \
                  constrained argument" =
@@ -5207,7 +5227,7 @@ let%expect_test "type that does not implement interface passed to the \
        (1
         (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 103)
           (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct signatures" =
   let source =
@@ -5338,7 +5358,7 @@ let%expect_test "struct signatures" =
              ((function_params ((i IntegerType)))
               (function_returns (ExprType (Reference (Self (StructSig 136)))))))))
           (st_sig_base_id 102) (st_sig_id 136)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserilize intf with constraints" =
   let source =
@@ -5515,7 +5535,7 @@ let%expect_test "Deserilize intf with constraints" =
           (st_sig_methods ()) (st_sig_base_id 0) (st_sig_id 2))
          ((st_sig_fields ((x (Reference (X (TypeN 0)))))) (st_sig_methods ())
           (st_sig_base_id 0) (st_sig_id 1)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Interface inner constraints" =
   let source =
@@ -5752,7 +5772,7 @@ let%expect_test "Interface inner constraints" =
                ((self (ExprType (Reference (Self (StructSig 1)))))))
               (function_returns HoleType)))))
           (st_sig_base_id 1) (st_sig_id 1)))))
-      (union_signs (0 ())))) |}]
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "attributes" =
   let source =
@@ -5970,4 +5990,5 @@ let%expect_test "attributes" =
             (un_sig_base_id 111))
            ((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (un_sig_cases ((ExprType (Value Void)))) (un_sig_methods ())
-            (un_sig_base_id 108))))))) |}]
+            (un_sig_base_id 108)))))
+        (attr_executors <opaque>))) |}]


### PR DESCRIPTION
This PR adds attribute executors for the `derive` attribute for the `Serialize` and `Deserialize` interfaces.