### PR TITLE
Add deserializer for unions

### DIFF
--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -218,7 +218,9 @@ functor
             match expr.value with
             | Value (Function f) -> (
               try Some (F.Function (self#add_function f ~name:(Some name)))
-              with ex -> if equal_string name "test" then raise ex else None )
+              with ex ->
+                if equal_string name "deserialize_union" then raise ex else None
+              )
             | _ ->
                 None
 

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -897,5 +897,14 @@ functor
         |> Option.bind ~f:(fun dets ->
                List.find dets.uty_impls ~f:(fun {impl_interface; _} ->
                    equal_int impl_interface impl ) )
+
+      let find_method p ty m =
+        List.Assoc.find (methods_of p ty)
+          ~equal:(fun v1 v2 -> equal_string v1.value v2.value)
+          (builtin_located m)
+
+      let find_binding p name =
+        List.Assoc.find p.bindings (builtin_located name)
+          ~equal:(equal_located equal_string)
     end
   end

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -154,6 +154,12 @@ struct AddrNone {
       return b;
     }
   }
+
+  impl Deserialize {
+    fn deserialize(s: Slice) -> LoadResult[Self] {
+      return LoadResult[Self].new(s, Self{});
+    }
+  }
 }
 
 // Interesting situation with this declaration: `bits` field should have count of bits
@@ -194,19 +200,8 @@ union MsgAddressExt {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      let res_discr = s.load_int(1);
-      if (builtin_equal(res_discr.value, 0)) {
-        return LoadResult[Self].new(res_discr.slice, AddrNone{});
-      } else if (builtin_equal(res_discr.value, 1)) {
-        let res_addr = AddrExtern.deserialize(res_discr.slice);
-        return LoadResult[Self].new(res_addr.slice, res_addr.value);
-      } else {
-        throw(0);
-      }
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct AddressStd {
@@ -279,18 +274,8 @@ union MsgAddressInt {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      let res_discr = s.load_int(1);
-      if (builtin_equal(res_discr.value, 0)) {
-        let res_addr = AddressStd.deserialize(res_discr.slice);
-        return LoadResult[Self].new(res_addr.slice, res_addr.value);
-      } else {
-        let res_addr = AddressVar.deserialize(res_discr.slice);
-        return LoadResult[Self].new(res_addr.slice, res_addr.value);
-      }
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 union MsgAddress {
   case MsgAddressExt
@@ -299,18 +284,8 @@ union MsgAddress {
   @derive
   impl Serialize {}
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      let res_discr = s.load_int(1);
-      if (builtin_equal(res_discr.value, 0)) {
-        let res_addr = MsgAddressExt.deserialize(res_discr.slice);
-        return LoadResult[Self].new(res_addr.slice, res_addr.value);
-      } else {
-        let res_addr = MsgAddressInt.deserialize(res_discr.slice);
-        return LoadResult[Self].new(res_addr.slice, res_addr.value);
-      }
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct ExtOutMsgInfoRelaxed {
@@ -411,23 +386,8 @@ union CommonMsgInfo {
   case IntMsgInfo
   case ExtInMsgInfo
 
-  impl Deserialize {
-    fn deserialize(s: Slice) -> LoadResult[Self] {
-      let res_discr1 = s.load_int(1);
-      if (builtin_equal(res_discr1.value, 0)) {
-        let res_info = IntMsgInfo.deserialize(res_discr1.slice);
-        return LoadResult[Self].new(res_info.slice, res_info.value);
-      } else {
-        let res_discr2 = res_discr1.slice.load_int(1);
-        if (builtin_equal(res_discr2.value, 0)) {
-          let res_info = ExtInMsgInfo.deserialize(res_discr2.slice);
-          return LoadResult[Self].new(res_info.slice, res_info.value);
-        } else {
-          throw(0); // unreachable
-        }
-      }
-    }
-  }
+  @derive
+  impl Deserialize {}
 }
 
 struct IntMsgInfoRelaxedAddresses {

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -1200,3 +1200,352 @@ let%expect_test "derive Serialize" =
               (function_returns (StructType 3))))))
           (st_sig_base_id 102) (st_sig_id 94)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "Deserialize Unions" =
+  let source =
+    {|
+      union TestUnion {
+        case Int[8]
+        case Int[9]
+      }
+      let deserialize_union = deserializer[TestUnion];
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((deserialize_union
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((slice (StructType 6))))
+              (function_returns (StructType 106))))
+            (function_impl
+             (Fn
+              (Block
+               ((Let
+                 ((res_discr
+                   (FunctionCall
+                    ((Value
+                      (Function
+                       ((function_signature
+                         ((function_params
+                           ((self (StructType 6)) (bits IntegerType)))
+                          (function_returns (StructType 5))))
+                        (function_impl
+                         (Fn
+                          (Block
+                           ((Let
+                             ((output
+                               (FunctionCall
+                                ((ResolvedReference (builtin_load_uint <opaque>))
+                                 ((StructField
+                                   ((Reference (self (StructType 6))) s
+                                    (BuiltinType Slice)))
+                                  (Reference (bits IntegerType))))))))
+                            (Let
+                             ((slice
+                               (Value
+                                (Struct
+                                 ((Value (Type (StructType 6)))
+                                  ((s
+                                    (StructField
+                                     ((Reference (output (StructType -4))) value1
+                                      (BuiltinType Slice)))))))))))
+                            (Let
+                             ((int
+                               (StructField
+                                ((Reference (output (StructType -4))) value2
+                                 IntegerType)))))
+                            (Return
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 5)))
+                                ((slice (Reference (slice (StructType 6))))
+                                 (value (Reference (int IntegerType)))))))))))))))
+                     ((Reference (slice (StructType 6))) (Value (Integer 1))))))))
+                (If
+                 ((if_condition
+                   (FunctionCall
+                    ((Value
+                      (Function
+                       ((function_signature
+                         ((function_params ((i1 IntegerType) (i2 IntegerType)))
+                          (function_returns IntegerType)))
+                        (function_impl
+                         (Fn
+                          (Return
+                           (Primitive
+                            (Prim (name __==__)
+                             (exprs
+                              ((Reference (i1 IntegerType))
+                               (Reference (i2 IntegerType))))))))))))
+                     ((StructField
+                       ((Reference (res_discr (StructType 5))) value IntegerType))
+                      (Value (Integer 0))))))
+                  (if_then
+                   (Block
+                    ((Let
+                      ((res
+                        (FunctionCall
+                         ((Value
+                           (Function
+                            ((function_signature
+                              ((function_params ((s (StructType 6))))
+                               (function_returns (StructType 29))))
+                             (function_impl
+                              (Fn
+                               (Block
+                                ((Let
+                                  ((res
+                                    (FunctionCall
+                                     ((ResolvedReference (load_int <opaque>))
+                                      ((Reference (s (StructType 6)))
+                                       (Value (Integer 8))))))))
+                                 (DestructuringLet
+                                  ((destructuring_let
+                                    ((slice slice) (value value)))
+                                   (destructuring_let_expr
+                                    (Reference (res (StructType 5))))
+                                   (destructuring_let_rest false)))
+                                 (Return
+                                  (Value
+                                   (Struct
+                                    ((Value (Type (StructType 29)))
+                                     ((slice (Reference (slice (StructType 6))))
+                                      (value
+                                       (Value
+                                        (Struct
+                                         ((Value (Type (StructType 28)))
+                                          ((value
+                                            (Reference (value IntegerType))))))))))))))))))))
+                          ((StructField
+                            ((Reference (res_discr (StructType 5))) slice
+                             (StructType 6)))))))))
+                     (Return
+                      (FunctionCall
+                       ((Value
+                         (Function
+                          ((function_signature
+                            ((function_params
+                              ((s (StructType 6)) (v (UnionType 103))))
+                             (function_returns (StructType 106))))
+                           (function_impl
+                            (Fn
+                             (Return
+                              (Value
+                               (Struct
+                                ((Value (Type (StructType 106)))
+                                 ((slice (Reference (s (StructType 6))))
+                                  (value (Reference (v (UnionType 103))))))))))))))
+                        ((StructField
+                          ((Reference (res (StructType 106))) slice
+                           (StructType 6)))
+                         (StructField
+                          ((Reference (res (StructType 106))) value
+                           (StructType 28))))))))))
+                  (if_else
+                   ((Block
+                     ((Let
+                       ((res_discr
+                         (FunctionCall
+                          ((Value
+                            (Function
+                             ((function_signature
+                               ((function_params
+                                 ((self (StructType 6)) (bits IntegerType)))
+                                (function_returns (StructType 5))))
+                              (function_impl
+                               (Fn
+                                (Block
+                                 ((Let
+                                   ((output
+                                     (FunctionCall
+                                      ((ResolvedReference
+                                        (builtin_load_uint <opaque>))
+                                       ((StructField
+                                         ((Reference (self (StructType 6))) s
+                                          (BuiltinType Slice)))
+                                        (Reference (bits IntegerType))))))))
+                                  (Let
+                                   ((slice
+                                     (Value
+                                      (Struct
+                                       ((Value (Type (StructType 6)))
+                                        ((s
+                                          (StructField
+                                           ((Reference (output (StructType -4)))
+                                            value1 (BuiltinType Slice)))))))))))
+                                  (Let
+                                   ((int
+                                     (StructField
+                                      ((Reference (output (StructType -4)))
+                                       value2 IntegerType)))))
+                                  (Return
+                                   (Value
+                                    (Struct
+                                     ((Value (Type (StructType 5)))
+                                      ((slice (Reference (slice (StructType 6))))
+                                       (value (Reference (int IntegerType)))))))))))))))
+                           ((StructField
+                             ((Reference (res_discr (StructType 5))) slice
+                              (StructType 6)))
+                            (Value (Integer 1))))))))
+                      (If
+                       ((if_condition
+                         (FunctionCall
+                          ((Value
+                            (Function
+                             ((function_signature
+                               ((function_params
+                                 ((i1 IntegerType) (i2 IntegerType)))
+                                (function_returns IntegerType)))
+                              (function_impl
+                               (Fn
+                                (Return
+                                 (Primitive
+                                  (Prim (name __==__)
+                                   (exprs
+                                    ((Reference (i1 IntegerType))
+                                     (Reference (i2 IntegerType))))))))))))
+                           ((StructField
+                             ((Reference (res_discr (StructType 5))) value
+                              IntegerType))
+                            (Value (Integer 1))))))
+                        (if_then
+                         (Block
+                          ((Let
+                            ((res
+                              (FunctionCall
+                               ((Value
+                                 (Function
+                                  ((function_signature
+                                    ((function_params ((s (StructType 6))))
+                                     (function_returns (StructType 18))))
+                                   (function_impl
+                                    (Fn
+                                     (Block
+                                      ((Let
+                                        ((res
+                                          (FunctionCall
+                                           ((ResolvedReference
+                                             (load_int <opaque>))
+                                            ((Reference (s (StructType 6)))
+                                             (Value (Integer 9))))))))
+                                       (DestructuringLet
+                                        ((destructuring_let
+                                          ((slice slice) (value value)))
+                                         (destructuring_let_expr
+                                          (Reference (res (StructType 5))))
+                                         (destructuring_let_rest false)))
+                                       (Return
+                                        (Value
+                                         (Struct
+                                          ((Value (Type (StructType 18)))
+                                           ((slice
+                                             (Reference (slice (StructType 6))))
+                                            (value
+                                             (Value
+                                              (Struct
+                                               ((Value (Type (StructType 17)))
+                                                ((value
+                                                  (Reference (value IntegerType))))))))))))))))))))
+                                ((StructField
+                                  ((Reference (res_discr (StructType 5))) slice
+                                   (StructType 6)))))))))
+                           (Return
+                            (FunctionCall
+                             ((Value
+                               (Function
+                                ((function_signature
+                                  ((function_params
+                                    ((s (StructType 6)) (v (UnionType 103))))
+                                   (function_returns (StructType 106))))
+                                 (function_impl
+                                  (Fn
+                                   (Return
+                                    (Value
+                                     (Struct
+                                      ((Value (Type (StructType 106)))
+                                       ((slice (Reference (s (StructType 6))))
+                                        (value (Reference (v (UnionType 103))))))))))))))
+                              ((StructField
+                                ((Reference (res (StructType 106))) slice
+                                 (StructType 6)))
+                               (StructField
+                                ((Reference (res (StructType 106))) value
+                                 (StructType 17))))))))))
+                        (if_else
+                         ((Expr
+                           (Primitive
+                            (Prim (name throw) (exprs ((Value (Integer 0)))))))))))))))))))))))))
+        (TestUnion (Value (Type (UnionType 103))))))
+      (structs
+       ((106
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (UnionType 103))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (UnionType 103))))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (UnionType 103)))))))))))))))
+            (uty_impls ()) (uty_id 106) (uty_base_id -500)))))))
+      (unions
+       ((103
+         ((union_attributes ())
+          (cases
+           (((StructType 17) (Discriminator 1))
+            ((StructType 28) (Discriminator 0))))
+          (union_details
+           ((uty_methods ())
+            (uty_impls
+             (((impl_interface 104)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (StructType 28))))
+                     (function_returns (UnionType 102))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v (StructType 28))) 103))))))))))
+              ((impl_interface 105)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (StructType 17))))
+                     (function_returns (UnionType 102))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v (StructType 17))) 103))))))))))))
+            (uty_id 103) (uty_base_id 102)))))))
+      (interfaces
+       ((105
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 17))))
+              (function_returns SelfType)))))))
+        (104
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 28))))
+              (function_returns SelfType)))))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (1
+        (((un_sig_cases ((StructType 28) (StructType 17))) (un_sig_methods ())
+          (un_sig_base_id 102)))))
+      (attr_executors <opaque>))) |}]

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -16,50 +16,50 @@ let%expect_test "Int[bits] constructor" =
          ((overflow
            (Value
             (Struct
-             ((Value (Type (StructType 28))) ((value (Value (Integer 513))))))))
+             ((Value (Type (StructType 30))) ((value (Value (Integer 513))))))))
           (i
            (Value
             (Struct
-             ((Value (Type (StructType 102))) ((value (Value (Integer 100))))))))))
+             ((Value (Type (StructType 104))) ((value (Value (Integer 100))))))))))
         (structs
-         ((103
+         ((105
            ((struct_fields
              ((slice ((field_type (StructType 6))))
-              (value ((field_type (StructType 102))))))
+              (value ((field_type (StructType 104))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 6)) (v (StructType 102))))
-                    (function_returns (StructType 103))))
+                   ((function_params ((s (StructType 6)) (v (StructType 104))))
+                    (function_returns (StructType 105))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((slice (Reference (s (StructType 6))))
-                         (value (Reference (v (StructType 102)))))))))))))))
-              (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-          (102
+                         (value (Reference (v (StructType 104)))))))))))))))
+              (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+          (104
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
+                    (function_returns (StructType 104))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 102)))
+                       ((Value (Type (StructType 104)))
                         ((value (Reference (i IntegerType))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 102)) (builder (StructType 3))))
+                     ((self (StructType 104)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -68,12 +68,12 @@ let%expect_test "Int[bits] constructor" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 102))) value IntegerType))
+                         ((Reference (self (StructType 104))) value IntegerType))
                         (Value (Integer 257))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 6))))
-                    (function_returns (StructType 103))))
+                    (function_returns (StructType 105))))
                   (function_impl
                    (Fn
                     (Block
@@ -89,23 +89,23 @@ let%expect_test "Int[bits] constructor" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 103)))
+                         ((Value (Type (StructType 105)))
                           ((slice (Reference (slice (StructType 6))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 102)))
+                              ((Value (Type (StructType 104)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
+                    (function_returns (StructType 104))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 102)))
+                       ((Value (Type (StructType 104)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -113,7 +113,7 @@ let%expect_test "Int[bits] constructor" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 102)) (builder (StructType 3))))
+                        ((self (StructType 104)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -122,14 +122,14 @@ let%expect_test "Int[bits] constructor" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 102))) value IntegerType))
+                            ((Reference (self (StructType 104))) value IntegerType))
                            (Value (Integer 257)))))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 6))))
-                       (function_returns (StructType 103))))
+                       (function_returns (StructType 105))))
                      (function_impl
                       (Fn
                        (Block
@@ -147,27 +147,27 @@ let%expect_test "Int[bits] constructor" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 103)))
+                            ((Value (Type (StructType 105)))
                              ((slice (Reference (slice (StructType 6))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 102)))
+                                 ((Value (Type (StructType 104)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
                 ((impl_interface 13)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 102))))
+                       (function_returns (StructType 104))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 102)))
+                          ((Value (Type (StructType 104)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 102) (uty_base_id 12)))))))
+              (uty_id 104) (uty_base_id 12)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -197,7 +197,7 @@ let%expect_test "Int[bits] serializer" =
                    ((i
                      (Value
                       (Struct
-                       ((Value (Type (StructType 102)))
+                       ((Value (Type (StructType 104)))
                         ((value (Value (Integer 100))))))))))
                   (Return
                    (FunctionCall
@@ -205,44 +205,44 @@ let%expect_test "Int[bits] serializer" =
                      ((ResolvedReference (i <opaque>))
                       (Reference (b (StructType 3)))))))))))))))))
         (structs
-         ((103
+         ((105
            ((struct_fields
              ((slice ((field_type (StructType 6))))
-              (value ((field_type (StructType 102))))))
+              (value ((field_type (StructType 104))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 6)) (v (StructType 102))))
-                    (function_returns (StructType 103))))
+                   ((function_params ((s (StructType 6)) (v (StructType 104))))
+                    (function_returns (StructType 105))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((slice (Reference (s (StructType 6))))
-                         (value (Reference (v (StructType 102)))))))))))))))
-              (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-          (102
+                         (value (Reference (v (StructType 104)))))))))))))))
+              (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+          (104
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
+                    (function_returns (StructType 104))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 102)))
+                       ((Value (Type (StructType 104)))
                         ((value (Reference (i IntegerType))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 102)) (builder (StructType 3))))
+                     ((self (StructType 104)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -251,12 +251,12 @@ let%expect_test "Int[bits] serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 102))) value IntegerType))
+                         ((Reference (self (StructType 104))) value IntegerType))
                         (Value (Integer 32))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 6))))
-                    (function_returns (StructType 103))))
+                    (function_returns (StructType 105))))
                   (function_impl
                    (Fn
                     (Block
@@ -272,23 +272,23 @@ let%expect_test "Int[bits] serializer" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 103)))
+                         ((Value (Type (StructType 105)))
                           ((slice (Reference (slice (StructType 6))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 102)))
+                              ((Value (Type (StructType 104)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
+                    (function_returns (StructType 104))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 102)))
+                       ((Value (Type (StructType 104)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -296,7 +296,7 @@ let%expect_test "Int[bits] serializer" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 102)) (builder (StructType 3))))
+                        ((self (StructType 104)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -305,14 +305,14 @@ let%expect_test "Int[bits] serializer" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 102))) value IntegerType))
+                            ((Reference (self (StructType 104))) value IntegerType))
                            (Value (Integer 32)))))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 6))))
-                       (function_returns (StructType 103))))
+                       (function_returns (StructType 105))))
                      (function_impl
                       (Fn
                        (Block
@@ -329,27 +329,27 @@ let%expect_test "Int[bits] serializer" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 103)))
+                            ((Value (Type (StructType 105)))
                              ((slice (Reference (slice (StructType 6))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 102)))
+                                 ((Value (Type (StructType 104)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
                 ((impl_interface 13)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 102))))
+                       (function_returns (StructType 104))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 102)))
+                          ((Value (Type (StructType 104)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 102) (uty_base_id 12)))))))
+              (uty_id 104) (uty_base_id 12)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -388,50 +388,28 @@ let%expect_test "demo struct serializer" =
                     ((ResolvedReference (T_serializer <opaque>))
                      ((Value
                        (Struct
-                        ((Value (Type (StructType 107)))
+                        ((Value (Type (StructType 109)))
                          ((a
                            (Value
                             (Struct
-                             ((Value (Type (StructType 102)))
+                             ((Value (Type (StructType 104)))
                               ((value (Value (Integer 0))))))))
                           (b
                            (Value
                             (Struct
-                             ((Value (Type (StructType 104)))
+                             ((Value (Type (StructType 106)))
                               ((value (Value (Integer 1))))))))))))
                       (Reference (b (StructType 3)))))))))))))))
           (T_serializer
            (Value
             (Function
              ((function_signature
-               ((function_params ((self (StructType 107)) (b (StructType 3))))
+               ((function_params ((self (StructType 109)) (b (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
                 (Block
                  ((Let
-                   ((b
-                     (FunctionCall
-                      ((Value
-                        (Function
-                         ((function_signature
-                           ((function_params
-                             ((self (StructType 102)) (builder (StructType 3))))
-                            (function_returns (StructType 3))))
-                          (function_impl
-                           (Fn
-                            (Return
-                             (FunctionCall
-                              ((ResolvedReference (serialize_int <opaque>))
-                               ((Reference (builder (StructType 3)))
-                                (StructField
-                                 ((Reference (self (StructType 102))) value
-                                  IntegerType))
-                                (Value (Integer 32)))))))))))
-                       ((StructField
-                         ((Reference (self (StructType 107))) a (StructType 102)))
-                        (Reference (b (StructType 3)))))))))
-                  (Let
                    ((b
                      (FunctionCall
                       ((Value
@@ -449,19 +427,186 @@ let%expect_test "demo struct serializer" =
                                 (StructField
                                  ((Reference (self (StructType 104))) value
                                   IntegerType))
+                                (Value (Integer 32)))))))))))
+                       ((StructField
+                         ((Reference (self (StructType 109))) a (StructType 104)))
+                        (Reference (b (StructType 3)))))))))
+                  (Let
+                   ((b
+                     (FunctionCall
+                      ((Value
+                        (Function
+                         ((function_signature
+                           ((function_params
+                             ((self (StructType 106)) (builder (StructType 3))))
+                            (function_returns (StructType 3))))
+                          (function_impl
+                           (Fn
+                            (Return
+                             (FunctionCall
+                              ((ResolvedReference (serialize_int <opaque>))
+                               ((Reference (builder (StructType 3)))
+                                (StructField
+                                 ((Reference (self (StructType 106))) value
+                                  IntegerType))
                                 (Value (Integer 16)))))))))))
                        ((StructField
-                         ((Reference (self (StructType 107))) b (StructType 104)))
+                         ((Reference (self (StructType 109))) b (StructType 106)))
                         (Reference (b (StructType 3)))))))))
                   (Return (Reference (b (StructType 3))))))))))))
-          (T (Value (Type (StructType 107))))))
+          (T (Value (Type (StructType 109))))))
         (structs
-         ((107
+         ((109
            ((struct_fields
-             ((a ((field_type (StructType 102))))
-              (b ((field_type (StructType 104))))))
+             ((a ((field_type (StructType 104))))
+              (b ((field_type (StructType 106))))))
             (struct_details
-             ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
+             ((uty_methods ()) (uty_impls ()) (uty_id 109) (uty_base_id 108)))))
+          (107
+           ((struct_fields
+             ((slice ((field_type (StructType 6))))
+              (value ((field_type (StructType 106))))))
+            (struct_details
+             ((uty_methods
+               ((new
+                 ((function_signature
+                   ((function_params ((s (StructType 6)) (v (StructType 106))))
+                    (function_returns (StructType 107))))
+                  (function_impl
+                   (Fn
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (s (StructType 6))))
+                         (value (Reference (v (StructType 106)))))))))))))))
+              (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+          (106
+           ((struct_fields ((value ((field_type IntegerType)))))
+            (struct_details
+             ((uty_methods
+               ((new
+                 ((function_signature
+                   ((function_params ((i IntegerType)))
+                    (function_returns (StructType 106))))
+                  (function_impl
+                   (Fn
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 106)))
+                        ((value (Reference (i IntegerType))))))))))))
+                (serialize
+                 ((function_signature
+                   ((function_params
+                     ((self (StructType 106)) (builder (StructType 3))))
+                    (function_returns (StructType 3))))
+                  (function_impl
+                   (Fn
+                    (Return
+                     (FunctionCall
+                      ((ResolvedReference (serialize_int <opaque>))
+                       ((Reference (builder (StructType 3)))
+                        (StructField
+                         ((Reference (self (StructType 106))) value IntegerType))
+                        (Value (Integer 16))))))))))
+                (deserialize
+                 ((function_signature
+                   ((function_params ((s (StructType 6))))
+                    (function_returns (StructType 107))))
+                  (function_impl
+                   (Fn
+                    (Block
+                     ((Let
+                       ((res
+                         (FunctionCall
+                          ((ResolvedReference (load_int <opaque>))
+                           ((Reference (s (StructType 6))) (Value (Integer 16))))))))
+                      (DestructuringLet
+                       ((destructuring_let ((slice slice) (value value)))
+                        (destructuring_let_expr (Reference (res (StructType 5))))
+                        (destructuring_let_rest false)))
+                      (Return
+                       (Value
+                        (Struct
+                         ((Value (Type (StructType 107)))
+                          ((slice (Reference (slice (StructType 6))))
+                           (value
+                            (Value
+                             (Struct
+                              ((Value (Type (StructType 106)))
+                               ((value (Reference (value IntegerType)))))))))))))))))))
+                (from
+                 ((function_signature
+                   ((function_params ((i IntegerType)))
+                    (function_returns (StructType 106))))
+                  (function_impl
+                   (Fn
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 106)))
+                        ((value (Reference (i IntegerType))))))))))))))
+              (uty_impls
+               (((impl_interface -1)
+                 (impl_methods
+                  ((serialize
+                    ((function_signature
+                      ((function_params
+                        ((self (StructType 106)) (builder (StructType 3))))
+                       (function_returns (StructType 3))))
+                     (function_impl
+                      (Fn
+                       (Return
+                        (FunctionCall
+                         ((ResolvedReference (serialize_int <opaque>))
+                          ((Reference (builder (StructType 3)))
+                           (StructField
+                            ((Reference (self (StructType 106))) value IntegerType))
+                           (Value (Integer 16)))))))))))))
+                ((impl_interface -2)
+                 (impl_methods
+                  ((deserialize
+                    ((function_signature
+                      ((function_params ((s (StructType 6))))
+                       (function_returns (StructType 107))))
+                     (function_impl
+                      (Fn
+                       (Block
+                        ((Let
+                          ((res
+                            (FunctionCall
+                             ((ResolvedReference (load_int <opaque>))
+                              ((Reference (s (StructType 6))) (Value (Integer 16))))))))
+                         (DestructuringLet
+                          ((destructuring_let ((slice slice) (value value)))
+                           (destructuring_let_expr
+                            (Reference (res (StructType 5))))
+                           (destructuring_let_rest false)))
+                         (Return
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 107)))
+                             ((slice (Reference (slice (StructType 6))))
+                              (value
+                               (Value
+                                (Struct
+                                 ((Value (Type (StructType 106)))
+                                  ((value (Reference (value IntegerType))))))))))))))))))))))
+                ((impl_interface 13)
+                 (impl_methods
+                  ((from
+                    ((function_signature
+                      ((function_params ((i IntegerType)))
+                       (function_returns (StructType 106))))
+                     (function_impl
+                      (Fn
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 106)))
+                           ((value (Reference (i IntegerType)))))))))))))))))
+              (uty_id 106) (uty_base_id 12)))))
           (105
            ((struct_fields
              ((slice ((field_type (StructType 6))))
@@ -509,7 +654,7 @@ let%expect_test "demo struct serializer" =
                        ((Reference (builder (StructType 3)))
                         (StructField
                          ((Reference (self (StructType 104))) value IntegerType))
-                        (Value (Integer 16))))))))))
+                        (Value (Integer 32))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 6))))
@@ -521,7 +666,7 @@ let%expect_test "demo struct serializer" =
                        ((res
                          (FunctionCall
                           ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 6))) (Value (Integer 16))))))))
+                           ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                       (DestructuringLet
                        ((destructuring_let ((slice slice) (value value)))
                         (destructuring_let_expr (Reference (res (StructType 5))))
@@ -563,7 +708,7 @@ let%expect_test "demo struct serializer" =
                           ((Reference (builder (StructType 3)))
                            (StructField
                             ((Reference (self (StructType 104))) value IntegerType))
-                           (Value (Integer 16)))))))))))))
+                           (Value (Integer 32)))))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
@@ -577,7 +722,7 @@ let%expect_test "demo struct serializer" =
                           ((res
                             (FunctionCall
                              ((ResolvedReference (load_int <opaque>))
-                              ((Reference (s (StructType 6))) (Value (Integer 16))))))))
+                              ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                          (DestructuringLet
                           ((destructuring_let ((slice slice) (value value)))
                            (destructuring_let_expr
@@ -606,159 +751,14 @@ let%expect_test "demo struct serializer" =
                          (Struct
                           ((Value (Type (StructType 104)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 104) (uty_base_id 12)))))
-          (103
-           ((struct_fields
-             ((slice ((field_type (StructType 6))))
-              (value ((field_type (StructType 102))))))
-            (struct_details
-             ((uty_methods
-               ((new
-                 ((function_signature
-                   ((function_params ((s (StructType 6)) (v (StructType 102))))
-                    (function_returns (StructType 103))))
-                  (function_impl
-                   (Fn
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (s (StructType 6))))
-                         (value (Reference (v (StructType 102)))))))))))))))
-              (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-          (102
-           ((struct_fields ((value ((field_type IntegerType)))))
-            (struct_details
-             ((uty_methods
-               ((new
-                 ((function_signature
-                   ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
-                  (function_impl
-                   (Fn
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 102)))
-                        ((value (Reference (i IntegerType))))))))))))
-                (serialize
-                 ((function_signature
-                   ((function_params
-                     ((self (StructType 102)) (builder (StructType 3))))
-                    (function_returns (StructType 3))))
-                  (function_impl
-                   (Fn
-                    (Return
-                     (FunctionCall
-                      ((ResolvedReference (serialize_int <opaque>))
-                       ((Reference (builder (StructType 3)))
-                        (StructField
-                         ((Reference (self (StructType 102))) value IntegerType))
-                        (Value (Integer 32))))))))))
-                (deserialize
-                 ((function_signature
-                   ((function_params ((s (StructType 6))))
-                    (function_returns (StructType 103))))
-                  (function_impl
-                   (Fn
-                    (Block
-                     ((Let
-                       ((res
-                         (FunctionCall
-                          ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                      (DestructuringLet
-                       ((destructuring_let ((slice slice) (value value)))
-                        (destructuring_let_expr (Reference (res (StructType 5))))
-                        (destructuring_let_rest false)))
-                      (Return
-                       (Value
-                        (Struct
-                         ((Value (Type (StructType 103)))
-                          ((slice (Reference (slice (StructType 6))))
-                           (value
-                            (Value
-                             (Struct
-                              ((Value (Type (StructType 102)))
-                               ((value (Reference (value IntegerType)))))))))))))))))))
-                (from
-                 ((function_signature
-                   ((function_params ((i IntegerType)))
-                    (function_returns (StructType 102))))
-                  (function_impl
-                   (Fn
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 102)))
-                        ((value (Reference (i IntegerType))))))))))))))
-              (uty_impls
-               (((impl_interface -1)
-                 (impl_methods
-                  ((serialize
-                    ((function_signature
-                      ((function_params
-                        ((self (StructType 102)) (builder (StructType 3))))
-                       (function_returns (StructType 3))))
-                     (function_impl
-                      (Fn
-                       (Return
-                        (FunctionCall
-                         ((ResolvedReference (serialize_int <opaque>))
-                          ((Reference (builder (StructType 3)))
-                           (StructField
-                            ((Reference (self (StructType 102))) value IntegerType))
-                           (Value (Integer 32)))))))))))))
-                ((impl_interface -2)
-                 (impl_methods
-                  ((deserialize
-                    ((function_signature
-                      ((function_params ((s (StructType 6))))
-                       (function_returns (StructType 103))))
-                     (function_impl
-                      (Fn
-                       (Block
-                        ((Let
-                          ((res
-                            (FunctionCall
-                             ((ResolvedReference (load_int <opaque>))
-                              ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                         (DestructuringLet
-                          ((destructuring_let ((slice slice) (value value)))
-                           (destructuring_let_expr
-                            (Reference (res (StructType 5))))
-                           (destructuring_let_rest false)))
-                         (Return
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 103)))
-                             ((slice (Reference (slice (StructType 6))))
-                              (value
-                               (Value
-                                (Struct
-                                 ((Value (Type (StructType 102)))
-                                  ((value (Reference (value IntegerType))))))))))))))))))))))
-                ((impl_interface 13)
-                 (impl_methods
-                  ((from
-                    ((function_signature
-                      ((function_params ((i IntegerType)))
-                       (function_returns (StructType 102))))
-                     (function_impl
-                      (Fn
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 102)))
-                           ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 102) (uty_base_id 12)))))))
+              (uty_id 104) (uty_base_id 12)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs
          (1
           (((st_sig_fields
-             ((a (Value (Type (StructType 102))))
-              (b (Value (Type (StructType 104))))))
-            (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 94)))))
+             ((a (Value (Type (StructType 104))))
+              (b (Value (Type (StructType 106))))))
+            (st_sig_methods ()) (st_sig_base_id 108) (st_sig_id 59)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -784,30 +784,30 @@ let%expect_test "from interface" =
        ((bindings
          ((var
            (Value
-            (Struct ((Value (Type (StructType 103))) ((a (Value (Integer 10))))))))
+            (Struct ((Value (Type (StructType 105))) ((a (Value (Integer 10))))))))
           (check
            (Value
             (Function
              ((function_signature
-               ((function_params ((y (StructType 103))))
-                (function_returns (StructType 103))))
-              (function_impl (Fn (Return (Reference (y (StructType 103))))))))))
-          (Value (Value (Type (StructType 103))))))
+               ((function_params ((y (StructType 105))))
+                (function_returns (StructType 105))))
+              (function_impl (Fn (Return (Reference (y (StructType 105))))))))))
+          (Value (Value (Type (StructType 105))))))
         (structs
-         ((103
+         ((105
            ((struct_fields ((a ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((x IntegerType)))
-                    (function_returns (StructType 103))))
+                    (function_returns (StructType 105))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((a (Reference (x IntegerType))))))))))))))
               (uty_impls
                (((impl_interface 13)
@@ -815,15 +815,15 @@ let%expect_test "from interface" =
                   ((from
                     ((function_signature
                       ((function_params ((x IntegerType)))
-                       (function_returns (StructType 103))))
+                       (function_returns (StructType 105))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 103)))
+                          ((Value (Type (StructType 105)))
                            ((a (Reference (x IntegerType)))))))))))))))))
-              (uty_id 103) (uty_base_id 102)))))))
+              (uty_id 105) (uty_base_id 104)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs
          (1
@@ -831,8 +831,8 @@ let%expect_test "from interface" =
             (st_sig_methods
              ((from
                ((function_params ((x IntegerType)))
-                (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
-            (st_sig_base_id 102) (st_sig_id 94)))))
+                (function_returns (ExprType (Reference (Self (StructSig 59)))))))))
+            (st_sig_base_id 104) (st_sig_id 59)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "tensor2" =
@@ -951,7 +951,7 @@ let%expect_test "deserializer" =
           (Function
            ((function_signature
              ((function_params ((slice (StructType 6))))
-              (function_returns (StructType 104))))
+              (function_returns (StructType 106))))
             (function_impl
              (Fn
               (Block
@@ -963,7 +963,7 @@ let%expect_test "deserializer" =
                       (Function
                        ((function_signature
                          ((function_params ((s (StructType 6))))
-                          (function_returns (StructType 18))))
+                          (function_returns (StructType 20))))
                         (function_impl
                          (Fn
                           (Block
@@ -981,12 +981,12 @@ let%expect_test "deserializer" =
                             (Return
                              (Value
                               (Struct
-                               ((Value (Type (StructType 18)))
+                               ((Value (Type (StructType 20)))
                                 ((slice (Reference (slice (StructType 6))))
                                  (value
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 17)))
+                                    ((Value (Type (StructType 19)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
                      ((Reference (slice (StructType 6)))))))
                   (destructuring_let_rest false)))
@@ -998,7 +998,7 @@ let%expect_test "deserializer" =
                       (Function
                        ((function_signature
                          ((function_params ((s (StructType 6))))
-                          (function_returns (StructType 31))))
+                          (function_returns (StructType 33))))
                         (function_impl
                          (Fn
                           (Block
@@ -1016,60 +1016,60 @@ let%expect_test "deserializer" =
                             (Return
                              (Value
                               (Struct
-                               ((Value (Type (StructType 31)))
+                               ((Value (Type (StructType 33)))
                                 ((slice (Reference (slice (StructType 6))))
                                  (value
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 30)))
+                                    ((Value (Type (StructType 32)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
                      ((Reference (slice (StructType 6)))))))
                   (destructuring_let_rest false)))
                 (Return
                  (Value
                   (Struct
-                   ((Value (Type (StructType 104)))
+                   ((Value (Type (StructType 106)))
                     ((value
                       (Value
                        (Struct
-                        ((Value (Type (StructType 103)))
-                         ((value1 (Reference (value1 (StructType 17))))
-                          (value2 (Reference (value2 (StructType 30)))))))))
+                        ((Value (Type (StructType 105)))
+                         ((value1 (Reference (value1 (StructType 19))))
+                          (value2 (Reference (value2 (StructType 32)))))))))
                      (slice (Reference (slice (StructType 6)))))))))))))))))
-        (Something (Value (Type (StructType 103))))))
+        (Something (Value (Type (StructType 105))))))
       (structs
-       ((104
+       ((106
          ((struct_fields
            ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 103))))))
+            (value ((field_type (StructType 105))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 103))))
-                  (function_returns (StructType 104))))
+                 ((function_params ((s (StructType 6)) (v (StructType 105))))
+                  (function_returns (StructType 106))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 104)))
+                     ((Value (Type (StructType 106)))
                       ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 103)))))))))))))))
-            (uty_impls ()) (uty_id 104) (uty_base_id -500)))))
-        (103
+                       (value (Reference (v (StructType 105)))))))))))))))
+            (uty_impls ()) (uty_id 106) (uty_base_id -500)))))
+        (105
          ((struct_fields
-           ((value1 ((field_type (StructType 17))))
-            (value2 ((field_type (StructType 30))))))
+           ((value1 ((field_type (StructType 19))))
+            (value2 ((field_type (StructType 32))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields
-           ((value1 (Value (Type (StructType 17))))
-            (value2 (Value (Type (StructType 30))))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
+           ((value1 (Value (Type (StructType 19))))
+            (value2 (Value (Type (StructType 32))))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "derive Serialize" =
@@ -1087,15 +1087,15 @@ let%expect_test "derive Serialize" =
   [%expect
     {|
     (Ok
-     ((bindings ((Something (Value (Type (StructType 103))))))
+     ((bindings ((Something (Value (Type (StructType 105))))))
       (structs
-       ((103
-         ((struct_fields ((value1 ((field_type (StructType 17))))))
+       ((105
+         ((struct_fields ((value1 ((field_type (StructType 19))))))
           (struct_details
            ((uty_methods
              ((serialize
                ((function_signature
-                 ((function_params ((self (StructType 103)) (b (StructType 3))))
+                 ((function_params ((self (StructType 105)) (b (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1105,7 +1105,7 @@ let%expect_test "derive Serialize" =
                       (Function
                        ((function_signature
                          ((function_params
-                           ((self (StructType 103)) (b (StructType 3))))
+                           ((self (StructType 105)) (b (StructType 3))))
                           (function_returns (StructType 3))))
                         (function_impl
                          (Fn
@@ -1117,7 +1117,7 @@ let%expect_test "derive Serialize" =
                                   (Function
                                    ((function_signature
                                      ((function_params
-                                       ((self (StructType 17))
+                                       ((self (StructType 19))
                                         (builder (StructType 3))))
                                       (function_returns (StructType 3))))
                                     (function_impl
@@ -1128,15 +1128,15 @@ let%expect_test "derive Serialize" =
                                           (serialize_int <opaque>))
                                          ((Reference (builder (StructType 3)))
                                           (StructField
-                                           ((Reference (self (StructType 17)))
+                                           ((Reference (self (StructType 19)))
                                             value IntegerType))
                                           (Value (Integer 9)))))))))))
                                  ((StructField
-                                   ((Reference (self (StructType 103))) value1
-                                    (StructType 17)))
+                                   ((Reference (self (StructType 105))) value1
+                                    (StructType 19)))
                                   (Reference (b (StructType 3)))))))))
                             (Return (Reference (b (StructType 3)))))))))))
-                     ((Reference (self (StructType 103)))
+                     ((Reference (self (StructType 105)))
                       (Reference (b (StructType 3)))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1144,7 +1144,7 @@ let%expect_test "derive Serialize" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 103)) (b (StructType 3))))
+                      ((self (StructType 105)) (b (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1154,7 +1154,7 @@ let%expect_test "derive Serialize" =
                          (Function
                           ((function_signature
                             ((function_params
-                              ((self (StructType 103)) (b (StructType 3))))
+                              ((self (StructType 105)) (b (StructType 3))))
                              (function_returns (StructType 3))))
                            (function_impl
                             (Fn
@@ -1166,7 +1166,7 @@ let%expect_test "derive Serialize" =
                                      (Function
                                       ((function_signature
                                         ((function_params
-                                          ((self (StructType 17))
+                                          ((self (StructType 19))
                                            (builder (StructType 3))))
                                          (function_returns (StructType 3))))
                                        (function_impl
@@ -1177,28 +1177,28 @@ let%expect_test "derive Serialize" =
                                              (serialize_int <opaque>))
                                             ((Reference (builder (StructType 3)))
                                              (StructField
-                                              ((Reference (self (StructType 17)))
+                                              ((Reference (self (StructType 19)))
                                                value IntegerType))
                                              (Value (Integer 9)))))))))))
                                     ((StructField
-                                      ((Reference (self (StructType 103))) value1
-                                       (StructType 17)))
+                                      ((Reference (self (StructType 105))) value1
+                                       (StructType 19)))
                                      (Reference (b (StructType 3)))))))))
                                (Return (Reference (b (StructType 3)))))))))))
-                        ((Reference (self (StructType 103)))
+                        ((Reference (self (StructType 105)))
                          (Reference (b (StructType 3))))))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
+            (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ((value1 (Value (Type (StructType 17))))))
+        (((st_sig_fields ((value1 (Value (Type (StructType 19))))))
           (st_sig_methods
            ((serialize
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 94)))))
+               ((self (ExprType (Reference (Self (StructSig 59)))))
                 (b (StructType 3))))
               (function_returns (StructType 3))))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserialize Unions" =
@@ -1221,7 +1221,7 @@ let%expect_test "Deserialize Unions" =
           (Function
            ((function_signature
              ((function_params ((slice (StructType 6))))
-              (function_returns (StructType 106))))
+              (function_returns (StructType 108))))
             (function_impl
              (Fn
               (Block
@@ -1294,7 +1294,7 @@ let%expect_test "Deserialize Unions" =
                            (Function
                             ((function_signature
                               ((function_params ((s (StructType 6))))
-                               (function_returns (StructType 29))))
+                               (function_returns (StructType 31))))
                              (function_impl
                               (Fn
                                (Block
@@ -1313,12 +1313,12 @@ let%expect_test "Deserialize Unions" =
                                  (Return
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 29)))
+                                    ((Value (Type (StructType 31)))
                                      ((slice (Reference (slice (StructType 6))))
                                       (value
                                        (Value
                                         (Struct
-                                         ((Value (Type (StructType 28)))
+                                         ((Value (Type (StructType 30)))
                                           ((value
                                             (Reference (value IntegerType))))))))))))))))))))
                           ((StructField
@@ -1330,22 +1330,22 @@ let%expect_test "Deserialize Unions" =
                          (Function
                           ((function_signature
                             ((function_params
-                              ((s (StructType 6)) (v (UnionType 103))))
-                             (function_returns (StructType 106))))
+                              ((s (StructType 6)) (v (UnionType 105))))
+                             (function_returns (StructType 108))))
                            (function_impl
                             (Fn
                              (Return
                               (Value
                                (Struct
-                                ((Value (Type (StructType 106)))
+                                ((Value (Type (StructType 108)))
                                  ((slice (Reference (s (StructType 6))))
-                                  (value (Reference (v (UnionType 103))))))))))))))
+                                  (value (Reference (v (UnionType 105))))))))))))))
                         ((StructField
-                          ((Reference (res (StructType 106))) slice
+                          ((Reference (res (StructType 108))) slice
                            (StructType 6)))
                          (StructField
-                          ((Reference (res (StructType 106))) value
-                           (StructType 28))))))))))
+                          ((Reference (res (StructType 108))) value
+                           (StructType 30))))))))))
                   (if_else
                    ((Block
                      ((Let
@@ -1423,7 +1423,7 @@ let%expect_test "Deserialize Unions" =
                                  (Function
                                   ((function_signature
                                     ((function_params ((s (StructType 6))))
-                                     (function_returns (StructType 18))))
+                                     (function_returns (StructType 20))))
                                    (function_impl
                                     (Fn
                                      (Block
@@ -1443,13 +1443,13 @@ let%expect_test "Deserialize Unions" =
                                        (Return
                                         (Value
                                          (Struct
-                                          ((Value (Type (StructType 18)))
+                                          ((Value (Type (StructType 20)))
                                            ((slice
                                              (Reference (slice (StructType 6))))
                                             (value
                                              (Value
                                               (Struct
-                                               ((Value (Type (StructType 17)))
+                                               ((Value (Type (StructType 19)))
                                                 ((value
                                                   (Reference (value IntegerType))))))))))))))))))))
                                 ((StructField
@@ -1461,91 +1461,91 @@ let%expect_test "Deserialize Unions" =
                                (Function
                                 ((function_signature
                                   ((function_params
-                                    ((s (StructType 6)) (v (UnionType 103))))
-                                   (function_returns (StructType 106))))
+                                    ((s (StructType 6)) (v (UnionType 105))))
+                                   (function_returns (StructType 108))))
                                  (function_impl
                                   (Fn
                                    (Return
                                     (Value
                                      (Struct
-                                      ((Value (Type (StructType 106)))
+                                      ((Value (Type (StructType 108)))
                                        ((slice (Reference (s (StructType 6))))
-                                        (value (Reference (v (UnionType 103))))))))))))))
+                                        (value (Reference (v (UnionType 105))))))))))))))
                               ((StructField
-                                ((Reference (res (StructType 106))) slice
+                                ((Reference (res (StructType 108))) slice
                                  (StructType 6)))
                                (StructField
-                                ((Reference (res (StructType 106))) value
-                                 (StructType 17))))))))))
+                                ((Reference (res (StructType 108))) value
+                                 (StructType 19))))))))))
                         (if_else
                          ((Expr
                            (Primitive
                             (Prim (name throw) (exprs ((Value (Integer 0)))))))))))))))))))))))))
-        (TestUnion (Value (Type (UnionType 103))))))
+        (TestUnion (Value (Type (UnionType 105))))))
       (structs
-       ((106
+       ((108
          ((struct_fields
            ((slice ((field_type (StructType 6))))
-            (value ((field_type (UnionType 103))))))
+            (value ((field_type (UnionType 105))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 6)) (v (UnionType 103))))
-                  (function_returns (StructType 106))))
+                 ((function_params ((s (StructType 6)) (v (UnionType 105))))
+                  (function_returns (StructType 108))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 106)))
+                     ((Value (Type (StructType 108)))
                       ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (UnionType 103)))))))))))))))
-            (uty_impls ()) (uty_id 106) (uty_base_id -500)))))))
+                       (value (Reference (v (UnionType 105)))))))))))))))
+            (uty_impls ()) (uty_id 108) (uty_base_id -500)))))))
       (unions
-       ((103
+       ((105
          ((union_attributes ())
           (cases
-           (((StructType 17) (Discriminator 1))
-            ((StructType 28) (Discriminator 0))))
+           (((StructType 19) (Discriminator 1))
+            ((StructType 30) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 104)
+             (((impl_interface 106)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 28))))
-                     (function_returns (UnionType 102))))
+                    ((function_params ((v (StructType 30))))
+                     (function_returns (UnionType 104))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 28))) 103))))))))))
-              ((impl_interface 105)
+                      (MakeUnionVariant ((Reference (v (StructType 30))) 105))))))))))
+              ((impl_interface 107)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 17))))
-                     (function_returns (UnionType 102))))
+                    ((function_params ((v (StructType 19))))
+                     (function_returns (UnionType 104))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 17))) 103))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 19))) 105))))))))))))
+            (uty_id 105) (uty_base_id 104)))))))
       (interfaces
-       ((105
+       ((107
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 17))))
+             ((function_params ((from (StructType 19))))
               (function_returns SelfType)))))))
-        (104
+        (106
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 28))))
+             ((function_params ((from (StructType 30))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 28) (StructType 17))) (un_sig_methods ())
-          (un_sig_base_id 102)))))
+        (((un_sig_cases ((StructType 30) (StructType 19))) (un_sig_methods ())
+          (un_sig_base_id 104)))))
       (attr_executors <opaque>))) |}]

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -1095,222 +1095,245 @@ let%expect_test "deserialization api" =
        slice f0(cell cell_) {
          return builtin_begin_parse(cell_);
        }
-       [slice, int] f3(slice self, int bits) {
-         (slice, int) output = builtin_load_int(self, bits);
-         slice slice_ = tensor2_value1(output);
-         int int_ = tensor2_value2(output);
-         return [slice_, int_];
-       }
-       [slice, int] f8(slice s) {
-         [slice, int] res = f3(s, 9);
-         [slice slice_, int value] = res;
-         return [slice_, value];
-       }
-       [slice, [int, int]] f7(slice slice_) {
-         [slice slice_, int len] = f8(slice_);
-         [slice slice_, int bits] = f3(slice_, len);
-         return [slice_, [len, bits]];
-       }
-       [slice, tuple] f9(slice s, tuple v) {
-         return [s, v];
-       }
-       [slice, tuple] f6(slice s) {
-         [slice, int] res_discr = f3(s, 1);
-         if (builtin_equal(second(res_discr), 0)) {
-         return f9(first(res_discr), []);
-       } else if (builtin_equal(second(res_discr), 1))
-       {
-         [slice, [int, int]] res_addr = f7(first(res_discr));
-       return
-       f9(first(res_addr), second(res_addr));
-       } else
-       {
-         throw(0);
-       }}
-       [slice, int] f12(slice s) {
-         [slice, int] res = f3(s, 8);
-         [slice slice_, int value] = res;
-         return [slice_, value];
-       }
-       [slice, [int, int, int]] f13(slice s, [int, int, int] v) {
-         return [s, v];
-       }
-       [slice, [int, int, int]] f11(slice s) {
-         [slice, int] res_anycast = f3(s, 1);
-         if (builtin_equal(second(res_anycast), 0)) {
-         [slice, int] res_len = f8(first(res_anycast));
-       [slice, int] res_workchain =
-       f12(first(res_len));
-       [slice, int] res_address =
-       f3(first(res_workchain), res_len);
-       return
-       f13(first(res_address), [second(res_len), second(res_workchain), second(res_address)]);
-       } else
-       {
-         throw(0);
-       }}
-       [slice, tuple] f14(slice s, tuple v) {
-         return [s, v];
-       }
-       [slice, int] f17(slice s) {
-         [slice, int] res = f3(s, 256);
-         [slice slice_, int value] = res;
-         return [slice_, value];
-       }
-       [slice, [int, int]] f16(slice slice_) {
-         [slice slice_, int workchain_id] = f12(slice_);
-         [slice slice_, int address] = f17(slice_);
-         return [[workchain_id, address], slice_];
-       }
-       [slice, [int, int]] f15(slice s) {
-         [slice, int] res_anycast = f3(s, 1);
-         if (builtin_equal(second(res_anycast), 0)) {
-         return f16(s);
-       } else
-       {
-         throw(0);
-       }}
-       [slice, tuple] f10(slice s) {
-         [slice, int] res_discr = f3(s, 1);
-         if (builtin_equal(second(res_discr), 0)) {
-         [slice, [int, int]] res_addr = f15(first(res_discr));
-       return
-       f14(first(res_addr), second(res_addr));
-       } else
-       {
-         [slice, [int, int, int]] res_addr = f11(first(res_discr));
-       return
-       f14(first(res_addr), second(res_addr));
-       }}
-       [slice, int] f19(slice self) {
-         (slice, int) output = builtin_load_coins(self);
-         slice slice_ = tensor2_value1(output);
-         int coins = tensor2_value2(output);
-         return [slice_, coins];
-       }
-       [slice, int] f20(slice s, int v) {
-         return [s, v];
-       }
-       [slice, int] f18(slice s) {
-         [slice slice_, int value] = f19(s);
-         return f20(value, slice_);
-       }
-       [slice, [tuple, tuple, int]] f5(slice slice_) {
-         [slice slice_, tuple src] = f6(slice_);
-         [slice slice_, tuple dest] = f10(slice_);
-         [slice slice_, int import_fee] = f18(slice_);
-         return [[src, dest, import_fee], slice_];
-       }
-       [slice, [tuple, tuple, int]] f4(slice s) {
-         return f5(s);
-       }
-       [slice, tuple] f21(slice s, tuple v) {
-         return [s, v];
-       }
-       [slice, int] f26(slice s) {
-         [slice, int] res = f3(s, 1);
-         [slice slice_, int value] = res;
-         return [slice_, value];
-       }
-       [slice, [int, int, int]] f25(slice slice_) {
-         [slice slice_, int ihr_disabled] = f26(slice_);
-         [slice slice_, int bounce] = f26(slice_);
-         [slice slice_, int bounced] = f26(slice_);
-         return [[ihr_disabled, bounce, bounced], slice_];
-       }
-       [slice, [int, int, int]] f24(slice s) {
-         return f25(s);
-       }
-       [slice, [tuple, tuple]] f28(slice slice_) {
-         [slice slice_, tuple src] = f10(slice_);
-         [slice slice_, tuple dst] = f10(slice_);
-         return [[src, dst], slice_];
-       }
-       [slice, [tuple, tuple]] f27(slice s) {
-         return f28(s);
-       }
-       [slice, [int, int]] f30(slice slice_) {
-         [slice slice_, int ihr_fee] = f18(slice_);
-         [slice slice_, int fwd_fee] = f18(slice_);
-         return [[ihr_fee, fwd_fee], slice_];
-       }
-       [slice, [int, int]] f29(slice s) {
-         return f30(s);
-       }
-       [slice, int] f34(slice self, int bits) {
+       [slice, int] f4(slice self, int bits) {
          (slice, int) output = builtin_load_uint(self, bits);
          slice slice_ = tensor2_value1(output);
          int int_ = tensor2_value2(output);
          return [slice_, int_];
        }
-       [slice, int] f33(slice s) {
-         [slice, int] res = f34(s, 64);
-         return [first(res), second(res)];
+       [slice, int] f11(slice self, int bits) {
+         (slice, int) output = builtin_load_int(self, bits);
+         slice slice_ = tensor2_value1(output);
+         int int_ = tensor2_value2(output);
+         return [slice_, int_];
        }
-       [slice, int] f35(slice s) {
-         [slice, int] res = f34(s, 32);
-         return [first(res), second(res)];
+       [slice, int] f10(slice s) {
+         [slice, int] res = f11(s, 9);
+         [slice slice_, int value] = res;
+         return [slice_, value];
        }
-       [slice, [int, int]] f32(slice slice_) {
-         [slice slice_, int created_lt] = f33(slice_);
-         [slice slice_, int created_at] = f35(slice_);
-         return [[created_lt, created_at], slice_];
+       [slice, [int, int]] f9(slice slice_) {
+         [slice slice_, int len] = f10(slice_);
+         [slice slice_, int bits] = f11(slice_, len);
+         return [slice_, [len, bits]];
        }
-       [slice, [int, int]] f31(slice s) {
-         return f32(s);
+       [slice, tuple] f12(slice s, tuple v) {
+         return [s, v];
        }
-       [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] f23(slice
-           slice_) {
-         [slice slice_, [int, int, int] flags] = f24(slice_);
-         [slice slice_, [tuple, tuple] addresses] = f27(slice_);
-         [slice slice_, [int, int] coins] = f29(slice_);
-         [slice slice_, [int, int] timestamps] = f31(slice_);
-         return [[flags, addresses, coins, timestamps], slice_];
+       [slice, []] f14(slice s, [] v) {
+         return [s, v];
        }
-       [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] f22(slice s)
-           {
-         return f23(s);
+       [slice, []] f13(slice s) {
+         return f14(s, []);
        }
-       [slice, tuple] f2(slice s) {
-         [slice, int] res_discr1 = f3(s, 1);
-         if (builtin_equal(second(res_discr1), 0)) {
-         [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] res_info =
-           f22(first(res_discr1));
+       [slice, tuple] f8(slice slice_) {
+         [slice, int] res_discr = f4(slice_, 1);
+         if (builtin_equal(second(res_discr), 0)) {
+         [slice, []] res = f13(first(res_discr));
        return
-       f21(first(res_info), second(res_info));
+       f12(first(res), second(res));
        } else
        {
-         [slice, int] res_discr2 = f3(first(res_discr1), 1);
-       if (builtin_equal(second(res_discr2), 0))
+         [slice, int] res_discr = f4(first(res_discr), 1);
+       if (builtin_equal(second(res_discr), 1))
        {
-         [slice, [tuple, tuple, int]] res_info = f4(first(res_discr2));
+         [slice, [int, int]] res = f9(first(res_discr));
        return
-       f21(first(res_info), second(res_info));
+       f12(first(res), second(res));
+       } else
+       throw(0);
+       }}
+       [slice, tuple] f7(slice s) {
+         return f8(s);
+       }
+       [slice, int] f18(slice s) {
+         [slice, int] res = f11(s, 8);
+         [slice slice_, int value] = res;
+         return [slice_, value];
+       }
+       [slice, [int, int, int]] f19(slice s, [int, int, int] v) {
+         return [s, v];
+       }
+       [slice, [int, int, int]] f17(slice s) {
+         [slice, int] res_anycast = f11(s, 1);
+         if (builtin_equal(second(res_anycast), 0)) {
+         [slice, int] res_len = f10(first(res_anycast));
+       [slice, int] res_workchain =
+       f18(first(res_len));
+       [slice, int] res_address =
+       f11(first(res_workchain), res_len);
+       return
+       f19(first(res_address), [second(res_len), second(res_workchain), second(res_address)]);
        } else
        {
          throw(0);
-       }}}
-       [slice, []] f37(slice s, [] v) {
+       }}
+       [slice, tuple] f20(slice s, tuple v) {
          return [s, v];
        }
-       [slice, []] f36(slice s) {
-         return f37(s, []);
+       [slice, int] f23(slice s) {
+         [slice, int] res = f11(s, 256);
+         [slice slice_, int value] = res;
+         return [slice_, value];
        }
-       [slice, [tuple, []]] f38(slice s, [tuple, []] v) {
+       [slice, [int, int]] f22(slice slice_) {
+         [slice slice_, int workchain_id] = f18(slice_);
+         [slice slice_, int address] = f23(slice_);
+         return [[workchain_id, address], slice_];
+       }
+       [slice, [int, int]] f21(slice s) {
+         [slice, int] res_anycast = f11(s, 1);
+         if (builtin_equal(second(res_anycast), 0)) {
+         return f22(s);
+       } else
+       {
+         throw(0);
+       }}
+       [slice, tuple] f16(slice slice_) {
+         [slice, int] res_discr = f4(slice_, 1);
+         if (builtin_equal(second(res_discr), 0)) {
+         [slice, [int, int]] res = f21(first(res_discr));
+       return
+       f20(first(res), second(res));
+       } else
+       {
+         [slice, int] res_discr = f4(first(res_discr), 1);
+       if (builtin_equal(second(res_discr), 1))
+       {
+         [slice, [int, int, int]] res = f17(first(res_discr));
+       return
+       f20(first(res), second(res));
+       } else
+       throw(0);
+       }}
+       [slice, tuple] f15(slice s) {
+         return f16(s);
+       }
+       [slice, int] f25(slice self) {
+         (slice, int) output = builtin_load_coins(self);
+         slice slice_ = tensor2_value1(output);
+         int coins = tensor2_value2(output);
+         return [slice_, coins];
+       }
+       [slice, int] f26(slice s, int v) {
+         return [s, v];
+       }
+       [slice, int] f24(slice s) {
+         [slice slice_, int value] = f25(s);
+         return f26(value, slice_);
+       }
+       [slice, [tuple, tuple, int]] f6(slice slice_) {
+         [slice slice_, tuple src] = f7(slice_);
+         [slice slice_, tuple dest] = f15(slice_);
+         [slice slice_, int import_fee] = f24(slice_);
+         return [[src, dest, import_fee], slice_];
+       }
+       [slice, [tuple, tuple, int]] f5(slice s) {
+         return f6(s);
+       }
+       [slice, tuple] f27(slice s, tuple v) {
+         return [s, v];
+       }
+       [slice, int] f32(slice s) {
+         [slice, int] res = f11(s, 1);
+         [slice slice_, int value] = res;
+         return [slice_, value];
+       }
+       [slice, [int, int, int]] f31(slice slice_) {
+         [slice slice_, int ihr_disabled] = f32(slice_);
+         [slice slice_, int bounce] = f32(slice_);
+         [slice slice_, int bounced] = f32(slice_);
+         return [[ihr_disabled, bounce, bounced], slice_];
+       }
+       [slice, [int, int, int]] f30(slice s) {
+         return f31(s);
+       }
+       [slice, [tuple, tuple]] f34(slice slice_) {
+         [slice slice_, tuple src] = f15(slice_);
+         [slice slice_, tuple dst] = f15(slice_);
+         return [[src, dst], slice_];
+       }
+       [slice, [tuple, tuple]] f33(slice s) {
+         return f34(s);
+       }
+       [slice, [int, int]] f36(slice slice_) {
+         [slice slice_, int ihr_fee] = f24(slice_);
+         [slice slice_, int fwd_fee] = f24(slice_);
+         return [[ihr_fee, fwd_fee], slice_];
+       }
+       [slice, [int, int]] f35(slice s) {
+         return f36(s);
+       }
+       [slice, int] f39(slice s) {
+         [slice, int] res = f4(s, 64);
+         return [first(res), second(res)];
+       }
+       [slice, int] f40(slice s) {
+         [slice, int] res = f4(s, 32);
+         return [first(res), second(res)];
+       }
+       [slice, [int, int]] f38(slice slice_) {
+         [slice slice_, int created_lt] = f39(slice_);
+         [slice slice_, int created_at] = f40(slice_);
+         return [[created_lt, created_at], slice_];
+       }
+       [slice, [int, int]] f37(slice s) {
+         return f38(s);
+       }
+       [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] f29(slice
+           slice_) {
+         [slice slice_, [int, int, int] flags] = f30(slice_);
+         [slice slice_, [tuple, tuple] addresses] = f33(slice_);
+         [slice slice_, [int, int] coins] = f35(slice_);
+         [slice slice_, [int, int] timestamps] = f37(slice_);
+         return [[flags, addresses, coins, timestamps], slice_];
+       }
+       [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] f28(slice s)
+           {
+         return f29(s);
+       }
+       [slice, tuple] f3(slice slice_) {
+         [slice, int] res_discr = f4(slice_, 1);
+         if (builtin_equal(second(res_discr), 0)) {
+         [slice, [[int, int, int], [tuple, tuple], [int, int], [int, int]]] res =
+           f28(first(res_discr));
+       return
+       f27(first(res), second(res));
+       } else
+       {
+         [slice, int] res_discr = f4(first(res_discr), 1);
+       if (builtin_equal(second(res_discr), 1))
+       {
+         [slice, [tuple, tuple, int]] res = f5(first(res_discr));
+       return
+       f27(first(res), second(res));
+       } else
+       throw(0);
+       }}
+       [slice, tuple] f2(slice s) {
+         return f3(s);
+       }
+       [slice, []] f42(slice s, [] v) {
+         return [s, v];
+       }
+       [slice, []] f41(slice s) {
+         return f42(s, []);
+       }
+       [slice, [tuple, []]] f43(slice s, [tuple, []] v) {
          return [s, v];
        }
        [slice, [tuple, []]] f1(slice s) {
          [slice, tuple] res_info = f2(s);
-         [slice, int] res_init = f3(first(res_info), 1);
+         [slice, int] res_init = f11(first(res_info), 1);
          if (builtin_equal(second(res_init), 0)) {
-         [slice, int] res_body_discr = f3(first(res_init), 1);
+         [slice, int] res_body_discr = f11(first(res_init), 1);
        if (builtin_equal(second(res_body_discr), 0))
        {
-         [slice, []] body = f36(first(res_body_discr));
+         [slice, []] body = f41(first(res_body_discr));
        [tuple, [tuple, []]] mes =
        [second(res_info), second(body)];
        return
-       f38(first(body), mes);
+       f43(first(body), mes);
        } else
        {
          }} else
@@ -1488,7 +1511,9 @@ let%expect_test "deserializer unions" =
       let deserialize_union = deserializer[TestUnion];
     |}
   in
-  pp_codegen source ; [%expect{|
+  pp_codegen source ;
+  [%expect
+    {|
     forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
       (Value1 value, _) = tensor;
       return value;

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -64,17 +64,17 @@ let%expect_test "program returns" =
                                                                  <opaque>)))
 
     (Ok
-     ((bindings ((T (Value (Type (StructType 103))))))
+     ((bindings ((T (Value (Type (StructType 105))))))
       (structs
-       ((103
+       ((105
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 102)
-          (st_sig_id 94)))))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 104)
+          (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scope resolution" =
@@ -85,2091 +85,7 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 102))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "binding resolution" =
-  let source = {|
-    let T = Int[257];
-  |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings ((T (Value (Type (StructType 102))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "failed scope resolution" =
-  let source = {|
-    let T = Int256;
-  |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (((UnresolvedIdentifier Int256))
-     ((bindings ((T (Value Void)))) (structs ()) (type_counter <opaque>)
-      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
-      (attr_executors <opaque>))) |}]
-
-let%expect_test "scope resolution after let binding" =
-  let source = {|
-    let A = Int[257];
-    let B = A;
-  |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((B (Value (Type (StructType 102)))) (A (Value (Type (StructType 102))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "basic struct definition" =
-  let source = {|
-    struct T { val t: Int[257] }
-  |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings ((T (Value (Type (StructType 105))))))
-      (structs
-       ((105
-         ((struct_fields ((t ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields ((t (Value (Type (StructType 102))))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "Tact function evaluation" =
-  let source =
-    {|
-    fn test(i: Int[257]) -> Int[257] {
-      i
-    }
-    let a = test(test(Int[257].new(1)));
-  |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((a
-         (Value
-          (Struct
-           ((Value (Type (StructType 102))) ((value (Value (Integer 1))))))))
-        (test
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((i (StructType 102))))
-              (function_returns (StructType 102))))
-            (function_impl (Fn (Return (Reference (i (StructType 102))))))))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "struct definition" =
-  let source =
-    {|
-  let MyType = struct {
-       val a: Int[257]
-       val b: Bool
-  };
-  |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings ((MyType (Value (Type (StructType 105))))))
-      (structs
-       ((105
-         ((struct_fields
-           ((a ((field_type (StructType 102)))) (b ((field_type BoolType)))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields
-           ((a (Value (Type (StructType 102))))
-            (b (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "duplicate type field" =
-  let source =
-    {|
-  let MyType = struct {
-      val a: Int[257]
-      val a: Bool
-  };
-  |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (((DuplicateField
-       (a
-        ((mk_struct_fields
-          ((a (Value (Type (StructType 102))))
-           (a (ResolvedReference (Bool <opaque>)))))
-         (mk_struct_details
-          ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 94)
-           (mk_span <opaque>)))))))
-     ((bindings ((MyType (Value (Type (StructType 105))))))
-      (structs
-       ((105
-         ((struct_fields
-           ((a ((field_type (StructType 102)))) (a ((field_type BoolType)))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields
-           ((a (Value (Type (StructType 102))))
-            (a (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "parametric struct instantiation" =
-  let source =
-    {|
-      struct T[A: Type] { val a: A }
-      let TA = T[Int[257]];
-   |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((TA (Value (Type (StructType 105))))
-        (T
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((A (TypeN 0))))
-              (function_returns (StructSig 94))))
-            (function_impl
-             (Fn
-              (Return
-               (MkStructDef
-                ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
-                 (mk_struct_details
-                  ((mk_methods ()) (mk_impls ()) (mk_id 102) (mk_sig 94)
-                   (mk_span <opaque>))))))))))))))
-      (structs
-       ((105
-         ((struct_fields ((a ((field_type (StructType 103))))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 102)))))
-        (104
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 103))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 103))))
-                  (function_returns (StructType 104))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 104)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 103)))))))))))))))
-            (uty_impls ()) (uty_id 104) (uty_base_id -500)))))
-        (103
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 103)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 103))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 104))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 104)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 103)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 103)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 103))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 104))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 104)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 103)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 103)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 103) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields ((a (Reference (A (TypeN 0)))))) (st_sig_methods ())
-          (st_sig_base_id 102) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "function without a return type" =
-  let source = {|
-    fn f() { 1 }
-    let a = f();
-    |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((a (Value (Integer 1)))
-        (f
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ()) (function_returns IntegerType)))
-            (function_impl (Fn (Return (Value (Integer 1)))))))))))
-      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "scoping that `let` introduces in code" =
-  let source =
-    {|
-    fn f(i: Int[257]) {
-      let a = i;
-      a
-    }
-    let b = f(Int[257].new(1));
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((b
-         (Value
-          (Struct
-           ((Value (Type (StructType 102))) ((value (Value (Integer 1))))))))
-        (f
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((i (StructType 102))))
-              (function_returns (StructType 102))))
-            (function_impl
-             (Fn
-              (Block
-               ((Let ((a (Reference (i (StructType 102))))))
-                (Return (Reference (a (StructType 102))))))))))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "reference in function bodies" =
-  let source =
-    {|
-      fn op(i: Int[257], i_: Int[257]) {
-        i
-      }
-
-      fn f(x: Int[257]) {
-        let a = op(x, x);
-        let b = op(a, a);
-      }
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((f
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((x (StructType 102))))
-              (function_returns HoleType)))
-            (function_impl
-             (Fn
-              (Block
-               ((Let
-                 ((a
-                   (FunctionCall
-                    ((ResolvedReference (op <opaque>))
-                     ((Reference (x (StructType 102)))
-                      (Reference (x (StructType 102)))))))))
-                (Let
-                 ((b
-                   (FunctionCall
-                    ((ResolvedReference (op <opaque>))
-                     ((Reference (a (StructType 102)))
-                      (Reference (a (StructType 102)))))))))))))))))
-        (op
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((i (StructType 102)) (i_ (StructType 102))))
-              (function_returns (StructType 102))))
-            (function_impl (Fn (Return (Reference (i (StructType 102))))))))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "resolving a reference from inside a function" =
-  let source =
-    {|
-      let i = 1;
-      fn f() {
-        i
-      }
-      let x = f();
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((x (Value (Integer 1)))
-        (f
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ()) (function_returns IntegerType)))
-            (function_impl (Fn (Return (ResolvedReference (i <opaque>)))))))))
-        (i (Value (Integer 1)))))
-      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "struct method access" =
-  let source =
-    {|
-      struct Foo {
-        fn bar(self: Self, i: Integer) {
-           i
-        }
-      }
-      let foo = Foo {};
-      let res = foo.bar(1);
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((res (Value (Integer 1)))
-        (foo (Value (Struct ((Value (Type (StructType 103))) ()))))
-        (Foo (Value (Type (StructType 103))))))
-      (structs
-       ((103
-         ((struct_fields ())
-          (struct_details
-           ((uty_methods
-             ((bar
-               ((function_signature
-                 ((function_params ((self (StructType 103)) (i IntegerType)))
-                  (function_returns IntegerType)))
-                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields ())
-          (st_sig_methods
-           ((bar
-             ((function_params
-               ((self (ExprType (Reference (Self (StructSig 94)))))
-                (i IntegerType)))
-              (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "struct type method access" =
-  let source =
-    {|
-      struct Foo {
-        fn bar(i: Integer) {
-           i
-        }
-      }
-      let res = Foo.bar(1);
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((res (Value (Integer 1))) (Foo (Value (Type (StructType 103))))))
-      (structs
-       ((103
-         ((struct_fields ())
-          (struct_details
-           ((uty_methods
-             ((bar
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns IntegerType)))
-                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields ())
-          (st_sig_methods
-           ((bar
-             ((function_params ((i IntegerType))) (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "Self type resolution in methods" =
-  let source =
-    {|
-      struct Foo {
-        fn bar(self: Self) -> Self {
-           self
-        }
-      }
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings ((Foo (Value (Type (StructType 103))))))
-      (structs
-       ((103
-         ((struct_fields ())
-          (struct_details
-           ((uty_methods
-             ((bar
-               ((function_signature
-                 ((function_params ((self (StructType 103))))
-                  (function_returns (StructType 103))))
-                (function_impl (Fn (Return (Reference (self (StructType 103))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields ())
-          (st_sig_methods
-           ((bar
-             ((function_params
-               ((self (ExprType (Reference (Self (StructSig 94)))))))
-              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "union method access" =
-  let source =
-    {|
-      union Foo {
-        case Bool
-        fn bar(self: Self, i: Integer) {
-          i
-        }
-      }
-      fn make_foo(foo: Foo) -> Foo {
-        foo
-      }
-      let foo = make_foo(true);
-      let res = foo.bar(1);
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 103))))
-        (make_foo
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((foo (UnionType 103))))
-              (function_returns (UnionType 103))))
-            (function_impl (Fn (Return (Reference (foo (UnionType 103))))))))))
-        (Foo (Value (Type (UnionType 103))))))
-      (structs ())
-      (unions
-       ((103
-         ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
-          (union_details
-           ((uty_methods
-             ((bar
-               ((function_signature
-                 ((function_params ((self (UnionType 103)) (i IntegerType)))
-                  (function_returns IntegerType)))
-                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls
-             (((impl_interface 104)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v BoolType)))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return (MakeUnionVariant ((Reference (v BoolType)) 103))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
-      (interfaces
-       ((104
-         ((interface_methods
-           ((from
-             ((function_params ((from BoolType))) (function_returns SelfType)))))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs
-       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102)))))
-      (attr_executors <opaque>))) |}]
-
-let%expect_test "union type method access" =
-  let source =
-    {|
-      union Foo {
-        case Bool
-        fn bar(i: Integer) {
-           i
-        }
-      }
-      fn make_foo(foo: Foo) -> Foo {
-        foo
-      }
-      let res = Foo.bar(1);
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((res (Value (Integer 1)))
-        (make_foo
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((foo (UnionType 103))))
-              (function_returns (UnionType 103))))
-            (function_impl (Fn (Return (Reference (foo (UnionType 103))))))))))
-        (Foo (Value (Type (UnionType 103))))))
-      (structs ())
-      (unions
-       ((103
-         ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
-          (union_details
-           ((uty_methods
-             ((bar
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns IntegerType)))
-                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls
-             (((impl_interface 104)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v BoolType)))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return (MakeUnionVariant ((Reference (v BoolType)) 103))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
-      (interfaces
-       ((104
-         ((interface_methods
-           ((from
-             ((function_params ((from BoolType))) (function_returns SelfType)))))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs
-       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 102)))))
-      (attr_executors <opaque>))) |}]
-
-let%expect_test "struct instantiation" =
-  let source =
-    {|
-    struct T {
-      val a: Integer
-      val b: Integer
-    }
-
-    let t = T{a: 1, b: 2}
-  |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings
-       ((t
-         (Value
-          (Struct
-           ((Value (Type (StructType 103)))
-            ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 103))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
-      (struct_signs
-       (1
-        (((st_sig_fields
-           ((a (ResolvedReference (Integer <opaque>)))
-            (b (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
-      (union_signs (0 ())) (attr_executors <opaque>))) |}]
-
-let%expect_test "type check error" =
-  let source = {|
-    fn foo(i: Int[32]) -> Int[64] { return i; }
-  |} in
-  pp_compile source ;
-  [%expect
-    {|
-    (((TypeError ((StructType 104) (StructType 102))))
-     ((bindings
-       ((foo
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((i (StructType 102))))
-              (function_returns (StructType 104))))
-            (function_impl (Fn (Return (Reference (i (StructType 102))))))))))))
+     ((bindings ((T (Value (Type (StructType 104))))))
       (structs
        ((105
          ((struct_fields
@@ -2218,7 +134,7 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 104))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 257))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
@@ -2230,7 +146,7 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2272,7 +188,7 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 104))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 257)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2286,7 +202,8 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2315,45 +232,58 @@ let%expect_test "type check error" =
                        (Struct
                         ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 104) (uty_base_id 12)))))
-        (103
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "binding resolution" =
+  let source = {|
+    let T = Int[257];
+  |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((T (Value (Type (StructType 104))))))
+      (structs
+       ((105
          ((struct_fields
            ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
+            (value ((field_type (StructType 104))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 103)))
+                     ((Value (Type (StructType 105)))
                       ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 104))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 104)))
                       ((value (Reference (i IntegerType))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
+                   ((self (StructType 104)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2362,12 +292,2082 @@ let%expect_test "type check error" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "failed scope resolution" =
+  let source = {|
+    let T = Int256;
+  |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (((UnresolvedIdentifier Int256))
+     ((bindings ((T (Value Void)))) (structs ()) (type_counter <opaque>)
+      (memoized_fcalls <opaque>) (struct_signs (0 ())) (union_signs (0 ()))
+      (attr_executors <opaque>))) |}]
+
+let%expect_test "scope resolution after let binding" =
+  let source = {|
+    let A = Int[257];
+    let B = A;
+  |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((B (Value (Type (StructType 104)))) (A (Value (Type (StructType 104))))))
+      (structs
+       ((105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "basic struct definition" =
+  let source = {|
+    struct T { val t: Int[257] }
+  |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((T (Value (Type (StructType 107))))))
+      (structs
+       ((107
+         ((struct_fields ((t ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
+        (105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ((t (Value (Type (StructType 104))))))
+          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "Tact function evaluation" =
+  let source =
+    {|
+    fn test(i: Int[257]) -> Int[257] {
+      i
+    }
+    let a = test(test(Int[257].new(1)));
+  |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((a
+         (Value
+          (Struct
+           ((Value (Type (StructType 104))) ((value (Value (Integer 1))))))))
+        (test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((i (StructType 104))))
+              (function_returns (StructType 104))))
+            (function_impl (Fn (Return (Reference (i (StructType 104))))))))))))
+      (structs
+       ((105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "struct definition" =
+  let source =
+    {|
+  let MyType = struct {
+       val a: Int[257]
+       val b: Bool
+  };
+  |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((MyType (Value (Type (StructType 107))))))
+      (structs
+       ((107
+         ((struct_fields
+           ((a ((field_type (StructType 104)))) (b ((field_type BoolType)))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
+        (105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields
+           ((a (Value (Type (StructType 104))))
+            (b (ResolvedReference (Bool <opaque>)))))
+          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "duplicate type field" =
+  let source =
+    {|
+  let MyType = struct {
+      val a: Int[257]
+      val a: Bool
+  };
+  |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (((DuplicateField
+       (a
+        ((mk_struct_fields
+          ((a (Value (Type (StructType 104))))
+           (a (ResolvedReference (Bool <opaque>)))))
+         (mk_struct_details
+          ((mk_methods ()) (mk_impls ()) (mk_id 106) (mk_sig 59)
+           (mk_span <opaque>)))))))
+     ((bindings ((MyType (Value (Type (StructType 107))))))
+      (structs
+       ((107
+         ((struct_fields
+           ((a ((field_type (StructType 104)))) (a ((field_type BoolType)))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
+        (105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields
+           ((a (Value (Type (StructType 104))))
+            (a (ResolvedReference (Bool <opaque>)))))
+          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "parametric struct instantiation" =
+  let source =
+    {|
+      struct T[A: Type] { val a: A }
+      let TA = T[Int[257]];
+   |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((TA (Value (Type (StructType 107))))
+        (T
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((A (TypeN 0))))
+              (function_returns (StructSig 59))))
+            (function_impl
+             (Fn
+              (Return
+               (MkStructDef
+                ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
+                 (mk_struct_details
+                  ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 59)
+                   (mk_span <opaque>))))))))))))))
+      (structs
+       ((107
+         ((struct_fields ((a ((field_type (StructType 105))))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 104)))))
+        (106
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 105))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 105))))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 105)))))))))))))))
+            (uty_impls ()) (uty_id 106) (uty_base_id -500)))))
+        (105
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 105)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 105))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 106)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 105)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 105)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 105))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 106)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 105)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 105)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 105) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ((a (Reference (A (TypeN 0)))))) (st_sig_methods ())
+          (st_sig_base_id 104) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "function without a return type" =
+  let source = {|
+    fn f() { 1 }
+    let a = f();
+    |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((a (Value (Integer 1)))
+        (f
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ()) (function_returns IntegerType)))
+            (function_impl (Fn (Return (Value (Integer 1)))))))))))
+      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "scoping that `let` introduces in code" =
+  let source =
+    {|
+    fn f(i: Int[257]) {
+      let a = i;
+      a
+    }
+    let b = f(Int[257].new(1));
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((b
+         (Value
+          (Struct
+           ((Value (Type (StructType 104))) ((value (Value (Integer 1))))))))
+        (f
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((i (StructType 104))))
+              (function_returns (StructType 104))))
+            (function_impl
+             (Fn
+              (Block
+               ((Let ((a (Reference (i (StructType 104))))))
+                (Return (Reference (a (StructType 104))))))))))))))
+      (structs
+       ((105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "reference in function bodies" =
+  let source =
+    {|
+      fn op(i: Int[257], i_: Int[257]) {
+        i
+      }
+
+      fn f(x: Int[257]) {
+        let a = op(x, x);
+        let b = op(a, a);
+      }
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((f
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((x (StructType 104))))
+              (function_returns HoleType)))
+            (function_impl
+             (Fn
+              (Block
+               ((Let
+                 ((a
+                   (FunctionCall
+                    ((ResolvedReference (op <opaque>))
+                     ((Reference (x (StructType 104)))
+                      (Reference (x (StructType 104)))))))))
+                (Let
+                 ((b
+                   (FunctionCall
+                    ((ResolvedReference (op <opaque>))
+                     ((Reference (a (StructType 104)))
+                      (Reference (a (StructType 104)))))))))))))))))
+        (op
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((i (StructType 104)) (i_ (StructType 104))))
+              (function_returns (StructType 104))))
+            (function_impl (Fn (Return (Reference (i (StructType 104))))))))))))
+      (structs
+       ((105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
+                      (Value (Integer 257))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 105)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 104)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 104)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 104))) value IntegerType))
+                         (Value (Integer 257)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 105))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 105)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 104)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 104)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 104) (uty_base_id 12)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "resolving a reference from inside a function" =
+  let source =
+    {|
+      let i = 1;
+      fn f() {
+        i
+      }
+      let x = f();
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((x (Value (Integer 1)))
+        (f
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ()) (function_returns IntegerType)))
+            (function_impl (Fn (Return (ResolvedReference (i <opaque>)))))))))
+        (i (Value (Integer 1)))))
+      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "struct method access" =
+  let source =
+    {|
+      struct Foo {
+        fn bar(self: Self, i: Integer) {
+           i
+        }
+      }
+      let foo = Foo {};
+      let res = foo.bar(1);
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((res (Value (Integer 1)))
+        (foo (Value (Struct ((Value (Type (StructType 105))) ()))))
+        (Foo (Value (Type (StructType 105))))))
+      (structs
+       ((105
+         ((struct_fields ())
+          (struct_details
+           ((uty_methods
+             ((bar
+               ((function_signature
+                 ((function_params ((self (StructType 105)) (i IntegerType)))
+                  (function_returns IntegerType)))
+                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ())
+          (st_sig_methods
+           ((bar
+             ((function_params
+               ((self (ExprType (Reference (Self (StructSig 59)))))
+                (i IntegerType)))
+              (function_returns IntegerType)))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "struct type method access" =
+  let source =
+    {|
+      struct Foo {
+        fn bar(i: Integer) {
+           i
+        }
+      }
+      let res = Foo.bar(1);
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((res (Value (Integer 1))) (Foo (Value (Type (StructType 105))))))
+      (structs
+       ((105
+         ((struct_fields ())
+          (struct_details
+           ((uty_methods
+             ((bar
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns IntegerType)))
+                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ())
+          (st_sig_methods
+           ((bar
+             ((function_params ((i IntegerType))) (function_returns IntegerType)))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "Self type resolution in methods" =
+  let source =
+    {|
+      struct Foo {
+        fn bar(self: Self) -> Self {
+           self
+        }
+      }
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((Foo (Value (Type (StructType 105))))))
+      (structs
+       ((105
+         ((struct_fields ())
+          (struct_details
+           ((uty_methods
+             ((bar
+               ((function_signature
+                 ((function_params ((self (StructType 105))))
+                  (function_returns (StructType 105))))
+                (function_impl (Fn (Return (Reference (self (StructType 105))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields ())
+          (st_sig_methods
+           ((bar
+             ((function_params
+               ((self (ExprType (Reference (Self (StructSig 59)))))))
+              (function_returns (ExprType (Reference (Self (StructSig 59)))))))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "union method access" =
+  let source =
+    {|
+      union Foo {
+        case Bool
+        fn bar(self: Self, i: Integer) {
+          i
+        }
+      }
+      fn make_foo(foo: Foo) -> Foo {
+        foo
+      }
+      let foo = make_foo(true);
+      let res = foo.bar(1);
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 105))))
+        (make_foo
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((foo (UnionType 105))))
+              (function_returns (UnionType 105))))
+            (function_impl (Fn (Return (Reference (foo (UnionType 105))))))))))
+        (Foo (Value (Type (UnionType 105))))))
+      (structs ())
+      (unions
+       ((105
+         ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
+          (union_details
+           ((uty_methods
+             ((bar
+               ((function_signature
+                 ((function_params ((self (UnionType 105)) (i IntegerType)))
+                  (function_returns IntegerType)))
+                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
+            (uty_impls
+             (((impl_interface 106)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v BoolType)))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return (MakeUnionVariant ((Reference (v BoolType)) 105))))))))))))
+            (uty_id 105) (uty_base_id 104)))))))
+      (interfaces
+       ((106
+         ((interface_methods
+           ((from
+             ((function_params ((from BoolType))) (function_returns SelfType)))))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 104)))))
+      (attr_executors <opaque>))) |}]
+
+let%expect_test "union type method access" =
+  let source =
+    {|
+      union Foo {
+        case Bool
+        fn bar(i: Integer) {
+           i
+        }
+      }
+      fn make_foo(foo: Foo) -> Foo {
+        foo
+      }
+      let res = Foo.bar(1);
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((res (Value (Integer 1)))
+        (make_foo
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((foo (UnionType 105))))
+              (function_returns (UnionType 105))))
+            (function_impl (Fn (Return (Reference (foo (UnionType 105))))))))))
+        (Foo (Value (Type (UnionType 105))))))
+      (structs ())
+      (unions
+       ((105
+         ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
+          (union_details
+           ((uty_methods
+             ((bar
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns IntegerType)))
+                (function_impl (Fn (Return (Reference (i IntegerType)))))))))
+            (uty_impls
+             (((impl_interface 106)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v BoolType)))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return (MakeUnionVariant ((Reference (v BoolType)) 105))))))))))))
+            (uty_id 105) (uty_base_id 104)))))))
+      (interfaces
+       ((106
+         ((interface_methods
+           ((from
+             ((function_params ((from BoolType))) (function_returns SelfType)))))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (1 (((un_sig_cases (BoolType)) (un_sig_methods ()) (un_sig_base_id 104)))))
+      (attr_executors <opaque>))) |}]
+
+let%expect_test "struct instantiation" =
+  let source =
+    {|
+    struct T {
+      val a: Integer
+      val b: Integer
+    }
+
+    let t = T{a: 1, b: 2}
+  |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings
+       ((t
+         (Value
+          (Struct
+           ((Value (Type (StructType 105)))
+            ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
+        (T (Value (Type (StructType 105))))))
+      (structs
+       ((105
+         ((struct_fields
+           ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>)
+      (struct_signs
+       (1
+        (((st_sig_fields
+           ((a (ResolvedReference (Integer <opaque>)))
+            (b (ResolvedReference (Integer <opaque>)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 59)))))
+      (union_signs (0 ())) (attr_executors <opaque>))) |}]
+
+let%expect_test "type check error" =
+  let source = {|
+    fn foo(i: Int[32]) -> Int[64] { return i; }
+  |} in
+  pp_compile source ;
+  [%expect
+    {|
+    (((TypeError ((StructType 106) (StructType 104))))
+     ((bindings
+       ((foo
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((i (StructType 104))))
+              (function_returns (StructType 106))))
+            (function_impl (Fn (Return (Reference (i (StructType 104))))))))))))
+      (structs
+       ((107
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 106))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 106))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 107)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 106)))))))))))))))
+            (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+        (106
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 106)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 106))) value IntegerType))
+                      (Value (Integer 64))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 106)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 106)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 106))) value IntegerType))
+                         (Value (Integer 64)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 107))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 107)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 106)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 106)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 106) (uty_base_id 12)))))
+        (105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
                       (Value (Integer 32))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Block
@@ -2383,23 +2383,23 @@ let%expect_test "type check error" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((slice (Reference (slice (StructType 6))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 102)))
+                            ((Value (Type (StructType 104)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 104))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 104)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -2407,7 +2407,7 @@ let%expect_test "type check error" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
+                      ((self (StructType 104)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2416,14 +2416,14 @@ let%expect_test "type check error" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
+                          ((Reference (self (StructType 104))) value IntegerType))
                          (Value (Integer 32)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
+                     (function_returns (StructType 105))))
                    (function_impl
                     (Fn
                      (Block
@@ -2440,32 +2440,32 @@ let%expect_test "type check error" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 103)))
+                          ((Value (Type (StructType 105)))
                            ((slice (Reference (slice (StructType 6))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 102)))
+                               ((Value (Type (StructType 104)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
               ((impl_interface 13)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
+                     (function_returns (StructType 104))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 102)))
+                        ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (interfaces
-       ((106
+       ((108
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 102))))
+             ((function_params ((from (StructType 104))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
@@ -2596,10 +2596,155 @@ let%expect_test "type check error" =
   pp_compile source ;
   [%expect
     {|
-    (((TypeError ((StructType 102) (StructType 104))))
+    (((TypeError ((StructType 104) (StructType 106))))
      ((bindings ())
       (structs
-       ((105
+       ((107
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 106))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 106))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 107)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 106)))))))))))))))
+            (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+        (106
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 106)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 106))) value IntegerType))
+                      (Value (Integer 10))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 10))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 106)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 106)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 106))) value IntegerType))
+                         (Value (Integer 10)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 107))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6))) (Value (Integer 10))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 107)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 106)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 106)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 106) (uty_base_id 12)))))
+        (105
          ((struct_fields
            ((slice ((field_type (StructType 6))))
             (value ((field_type (StructType 104))))))
@@ -2646,7 +2791,7 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 104))) value IntegerType))
-                      (Value (Integer 10))))))))))
+                      (Value (Integer 99))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
@@ -2658,7 +2803,7 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 10))))))))
+                         ((Reference (s (StructType 6))) (Value (Integer 99))))))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2700,7 +2845,7 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 104))) value IntegerType))
-                         (Value (Integer 10)))))))))))))
+                         (Value (Integer 99)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2714,7 +2859,7 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 10))))))))
+                            ((Reference (s (StructType 6))) (Value (Integer 99))))))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2743,157 +2888,12 @@ let%expect_test "type check error" =
                        (Struct
                         ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 104) (uty_base_id 12)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 99))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 99))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 99)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 99))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (interfaces
-       ((106
+       ((108
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 104))))
+             ((function_params ((from (StructType 106))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
@@ -2914,9 +2914,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 103))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 105))))))
       (structs
-       ((103
+       ((105
          ((struct_fields ())
           (struct_details
            ((uty_methods
@@ -2933,7 +2933,7 @@ let%expect_test "implement interface op" =
                     ((function_params ((left IntegerType) (right IntegerType)))
                      (function_returns IntegerType)))
                    (function_impl (Fn (Return (Reference (left IntegerType))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
+            (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -2942,7 +2942,7 @@ let%expect_test "implement interface op" =
            ((op
              ((function_params ((left IntegerType) (right IntegerType)))
               (function_returns IntegerType)))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -2964,33 +2964,33 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct ((Value (Type (StructType 104))) ()))))
-        (Empty (Value (Type (StructType 104))))
-        (Make (Value (Type (InterfaceType 102))))))
+       ((empty (Value (Struct ((Value (Type (StructType 106))) ()))))
+        (Empty (Value (Type (StructType 106))))
+        (Make (Value (Type (InterfaceType 104))))))
       (structs
-       ((104
+       ((106
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ()) (function_returns (StructType 104))))
+                 ((function_params ()) (function_returns (StructType 106))))
                 (function_impl
                  (Fn
-                  (Return (Value (Struct ((Value (Type (StructType 104))) ()))))))))))
+                  (Return (Value (Struct ((Value (Type (StructType 106))) ()))))))))))
             (uty_impls
-             (((impl_interface 102)
+             (((impl_interface 104)
                (impl_methods
                 ((new
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 104))))
+                    ((function_params ()) (function_returns (StructType 106))))
                    (function_impl
                     (Fn
                      (Return
-                      (Value (Struct ((Value (Type (StructType 104))) ())))))))))))))
-            (uty_id 104) (uty_base_id 103)))))))
+                      (Value (Struct ((Value (Type (StructType 106))) ())))))))))))))
+            (uty_id 106) (uty_base_id 105)))))))
       (interfaces
-       ((102
+       ((104
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
@@ -3000,8 +3000,8 @@ let%expect_test "implement interface op" =
           (st_sig_methods
            ((new
              ((function_params ())
-              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
-          (st_sig_base_id 103) (st_sig_id 94)))))
+              (function_returns (ExprType (Reference (Self (StructSig 59)))))))))
+          (st_sig_base_id 105) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
@@ -3021,7 +3021,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 107)) (b (StructType 3))))
+             ((function_params ((self (StructType 109)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -3033,7 +3033,7 @@ let%expect_test "serializer inner struct" =
                       (Function
                        ((function_signature
                          ((function_params
-                           ((self (StructType 102)) (builder (StructType 3))))
+                           ((self (StructType 104)) (builder (StructType 3))))
                           (function_returns (StructType 3))))
                         (function_impl
                          (Fn
@@ -3042,64 +3042,64 @@ let%expect_test "serializer inner struct" =
                             ((ResolvedReference (serialize_int <opaque>))
                              ((Reference (builder (StructType 3)))
                               (StructField
-                               ((Reference (self (StructType 102))) value
+                               ((Reference (self (StructType 104))) value
                                 IntegerType))
                               (Value (Integer 32)))))))))))
                      ((StructField
-                       ((Reference (self (StructType 107))) y (StructType 102)))
+                       ((Reference (self (StructType 109))) y (StructType 104)))
                       (Reference (b (StructType 3)))))))))
                 (Return (Reference (b (StructType 3))))))))))))
-        (Outer (Value (Type (StructType 107))))
-        (Inner (Value (Type (StructType 105))))))
+        (Outer (Value (Type (StructType 109))))
+        (Inner (Value (Type (StructType 107))))))
       (structs
-       ((107
+       ((109
          ((struct_fields
-           ((y ((field_type (StructType 102))))
-            (z ((field_type (StructType 105))))))
+           ((y ((field_type (StructType 104))))
+            (z ((field_type (StructType 107))))))
+          (struct_details
+           ((uty_methods ()) (uty_impls ()) (uty_id 109) (uty_base_id 108)))))
+        (107
+         ((struct_fields ((x ((field_type (StructType 104))))))
           (struct_details
            ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
         (105
-         ((struct_fields ((x ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))
-        (103
          ((struct_fields
            ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
+            (value ((field_type (StructType 104))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 103)))
+                     ((Value (Type (StructType 105)))
                       ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 104))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 104)))
                       ((value (Reference (i IntegerType))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
+                   ((self (StructType 104)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3108,12 +3108,12 @@ let%expect_test "serializer inner struct" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
+                       ((Reference (self (StructType 104))) value IntegerType))
                       (Value (Integer 32))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Block
@@ -3129,23 +3129,23 @@ let%expect_test "serializer inner struct" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((slice (Reference (slice (StructType 6))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 102)))
+                            ((Value (Type (StructType 104)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 104))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 104)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -3153,7 +3153,7 @@ let%expect_test "serializer inner struct" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
+                      ((self (StructType 104)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -3162,14 +3162,14 @@ let%expect_test "serializer inner struct" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
+                          ((Reference (self (StructType 104))) value IntegerType))
                          (Value (Integer 32)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
+                     (function_returns (StructType 105))))
                    (function_impl
                     (Fn
                      (Block
@@ -3186,36 +3186,36 @@ let%expect_test "serializer inner struct" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 103)))
+                          ((Value (Type (StructType 105)))
                            ((slice (Reference (slice (StructType 6))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 102)))
+                               ((Value (Type (StructType 104)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
               ((impl_interface 13)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
+                     (function_returns (StructType 104))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 102)))
+                        ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (2
         (((st_sig_fields
-           ((y (Value (Type (StructType 102))))
+           ((y (Value (Type (StructType 104))))
             (z (ResolvedReference (Inner <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 95))
-         ((st_sig_fields ((x (Value (Type (StructType 102))))))
-          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 94)))))
+          (st_sig_methods ()) (st_sig_base_id 108) (st_sig_id 60))
+         ((st_sig_fields ((x (Value (Type (StructType 104))))))
+          (st_sig_methods ()) (st_sig_base_id 106) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -3364,365 +3364,17 @@ let%expect_test "union variants constructing" =
          (Value
           (UnionVariant
            ((Struct
-             ((Value (Type (StructType 102))) ((value (Value (Integer 1))))))
-            105))))
-        (a (Value (UnionVariant ((Integer 10) 105))))
+             ((Value (Type (StructType 104))) ((value (Value (Integer 1))))))
+            107))))
+        (a (Value (UnionVariant ((Integer 10) 107))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 105))))
-              (function_returns (UnionType 105))))
-            (function_impl (Fn (Return (Reference (value (UnionType 105))))))))))
-        (Uni (Value (Type (UnionType 105))))))
-      (structs
-       ((103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 32))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
-      (unions
-       ((105
-         ((union_attributes ())
-          (cases
-           (((StructType 102) (Discriminator 1)) (IntegerType (Discriminator 0))))
-          (union_details
-           ((uty_methods ())
-            (uty_impls
-             (((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 104))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 105))))))))))
-              ((impl_interface 106)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v (StructType 102))))
-                     (function_returns (UnionType 104))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v (StructType 102))) 105))))))))))))
-            (uty_id 105) (uty_base_id 104)))))))
-      (interfaces
-       ((106
-         ((interface_methods
-           ((from
-             ((function_params ((from (StructType 102))))
-              (function_returns SelfType)))))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs
-       (1
-        (((un_sig_cases (IntegerType (StructType 102))) (un_sig_methods ())
-          (un_sig_base_id 104)))))
-      (attr_executors <opaque>))) |}]
-
-let%expect_test "unions duplicate variant" =
-  let source =
-    {|
-      fn Test(T: Type) {
-        union {
-          case Integer
-          case T
-        }
-      }
-      let a = Test[builtin_Builder]; // should be OK
-      let b = Test[Integer]; // should fail
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (((DuplicateVariant (IntegerType <opaque>)))
-     ((bindings
-       ((b (Value (Type (UnionType 105)))) (a (Value (Type (UnionType 103))))
-        (Test
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((T (TypeN 0)))) (function_returns (UnionSig 5))))
-            (function_impl
-             (Fn
-              (Return
-               (MkUnionDef
-                ((mk_cases
-                  ((ResolvedReference (Integer <opaque>))
-                   (Reference (T (TypeN 0)))))
-                 (mk_union_details
-                  ((mk_methods ())
-                   (mk_impls
-                    (((mk_impl_interface (Value (Type (InterfaceType 13))))
-                      (mk_impl_methods
-                       ((from
-                         (Value
-                          (Function
-                           ((function_signature
-                             ((function_params ((v IntegerType)))
-                              (function_returns (UnionType 102))))
-                            (function_impl
-                             (Fn
-                              (Return
-                               (MakeUnionVariant
-                                ((Reference (v IntegerType)) 102))))))))))))
-                     ((mk_impl_interface
-                       (FunctionCall
-                        ((Value
-                          (Function
-                           ((function_signature
-                             ((function_params ((T (TypeN 0))))
-                              (function_returns HoleType)))
-                            (function_impl (BuiltinFn (<fun> <opaque>))))))
-                         ((Value (Type (ExprType (Reference (T (TypeN 0))))))))))
-                      (mk_impl_methods
-                       ((from
-                         (Value
-                          (Function
-                           ((function_signature
-                             ((function_params
-                               ((v (ExprType (Reference (T (TypeN 0)))))))
-                              (function_returns (UnionType 102))))
-                            (function_impl
-                             (Fn
-                              (Return
-                               (MakeUnionVariant
-                                ((Reference
-                                  (v (ExprType (Reference (T (TypeN 0))))))
-                                 102))))))))))))))
-                   (mk_id 102) (mk_sig 5) (mk_span <opaque>))))))))))))))
-      (structs ())
-      (unions
-       ((105
-         ((union_attributes ()) (cases ((IntegerType (Discriminator 0))))
-          (union_details
-           ((uty_methods ())
-            (uty_impls
-             (((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 105))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 105))))))))))))
-            (uty_id 105) (uty_base_id 102)))))
-        (103
-         ((union_attributes ())
-          (cases
-           (((BuiltinType Builder) (Discriminator 1))
-            (IntegerType (Discriminator 0))))
-          (union_details
-           ((uty_methods ())
-            (uty_impls
-             (((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 103))))))))))
-              ((impl_interface 104)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v (BuiltinType Builder))))
-                     (function_returns (UnionType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant
-                       ((Reference (v (BuiltinType Builder))) 103))))))))))))
-            (uty_id 103) (uty_base_id 102)))))))
-      (interfaces
-       ((104
-         ((interface_methods
-           ((from
-             ((function_params ((from (BuiltinType Builder))))
-              (function_returns SelfType)))))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
-      (union_signs
-       (1
-        (((un_sig_cases (IntegerType (ExprType (Reference (T (TypeN 0))))))
-          (un_sig_methods ()) (un_sig_base_id 102)))))
-      (attr_executors <opaque>))) |}]
-
-let%expect_test "unions" =
-  let source =
-    {|
-      union Test {
-        case Int[257]
-        case Int[64]
-        fn id(self: Self) -> Self {
-          self
-        }
-      }
-    |}
-  in
-  pp_compile source ;
-  [%expect
-    {|
-    (Ok
-     ((bindings ((Test (Value (Type (UnionType 107))))))
+             ((function_params ((value (UnionType 107))))
+              (function_returns (UnionType 107))))
+            (function_impl (Fn (Return (Reference (value (UnionType 107))))))))))
+        (Uni (Value (Type (UnionType 107))))))
       (structs
        ((105
          ((struct_fields
@@ -3771,7 +3423,7 @@ let%expect_test "unions" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 104))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 32))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
@@ -3783,7 +3435,7 @@ let%expect_test "unions" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -3825,7 +3477,7 @@ let%expect_test "unions" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 104))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 32)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -3839,7 +3491,7 @@ let%expect_test "unions" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -3868,45 +3520,248 @@ let%expect_test "unions" =
                        (Struct
                         ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 104) (uty_base_id 12)))))
-        (103
+            (uty_id 104) (uty_base_id 12)))))))
+      (unions
+       ((107
+         ((union_attributes ())
+          (cases
+           (((StructType 104) (Discriminator 1)) (IntegerType (Discriminator 0))))
+          (union_details
+           ((uty_methods ())
+            (uty_impls
+             (((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v IntegerType)))
+                     (function_returns (UnionType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v IntegerType)) 107))))))))))
+              ((impl_interface 108)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (StructType 104))))
+                     (function_returns (UnionType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v (StructType 104))) 107))))))))))))
+            (uty_id 107) (uty_base_id 106)))))))
+      (interfaces
+       ((108
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 104))))
+              (function_returns SelfType)))))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (1
+        (((un_sig_cases (IntegerType (StructType 104))) (un_sig_methods ())
+          (un_sig_base_id 106)))))
+      (attr_executors <opaque>))) |}]
+
+let%expect_test "unions duplicate variant" =
+  let source =
+    {|
+      fn Test(T: Type) {
+        union {
+          case Integer
+          case T
+        }
+      }
+      let a = Test[builtin_Builder]; // should be OK
+      let b = Test[Integer]; // should fail
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (((DuplicateVariant (IntegerType <opaque>)))
+     ((bindings
+       ((b (Value (Type (UnionType 107)))) (a (Value (Type (UnionType 105))))
+        (Test
+         (Value
+          (Function
+           ((function_signature
+             ((function_params ((T (TypeN 0)))) (function_returns (UnionSig 5))))
+            (function_impl
+             (Fn
+              (Return
+               (MkUnionDef
+                ((mk_cases
+                  ((ResolvedReference (Integer <opaque>))
+                   (Reference (T (TypeN 0)))))
+                 (mk_union_details
+                  ((mk_methods ())
+                   (mk_impls
+                    (((mk_impl_interface (Value (Type (InterfaceType 13))))
+                      (mk_impl_methods
+                       ((from
+                         (Value
+                          (Function
+                           ((function_signature
+                             ((function_params ((v IntegerType)))
+                              (function_returns (UnionType 104))))
+                            (function_impl
+                             (Fn
+                              (Return
+                               (MakeUnionVariant
+                                ((Reference (v IntegerType)) 104))))))))))))
+                     ((mk_impl_interface
+                       (FunctionCall
+                        ((Value
+                          (Function
+                           ((function_signature
+                             ((function_params ((T (TypeN 0))))
+                              (function_returns HoleType)))
+                            (function_impl (BuiltinFn (<fun> <opaque>))))))
+                         ((Value (Type (ExprType (Reference (T (TypeN 0))))))))))
+                      (mk_impl_methods
+                       ((from
+                         (Value
+                          (Function
+                           ((function_signature
+                             ((function_params
+                               ((v (ExprType (Reference (T (TypeN 0)))))))
+                              (function_returns (UnionType 104))))
+                            (function_impl
+                             (Fn
+                              (Return
+                               (MakeUnionVariant
+                                ((Reference
+                                  (v (ExprType (Reference (T (TypeN 0))))))
+                                 104))))))))))))))
+                   (mk_id 104) (mk_sig 5) (mk_span <opaque>))))))))))))))
+      (structs ())
+      (unions
+       ((107
+         ((union_attributes ()) (cases ((IntegerType (Discriminator 0))))
+          (union_details
+           ((uty_methods ())
+            (uty_impls
+             (((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v IntegerType)))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v IntegerType)) 107))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v IntegerType)))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v IntegerType)) 107))))))))))))
+            (uty_id 107) (uty_base_id 104)))))
+        (105
+         ((union_attributes ())
+          (cases
+           (((BuiltinType Builder) (Discriminator 1))
+            (IntegerType (Discriminator 0))))
+          (union_details
+           ((uty_methods ())
+            (uty_impls
+             (((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v IntegerType)))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v IntegerType)) 105))))))))))
+              ((impl_interface 106)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (BuiltinType Builder))))
+                     (function_returns (UnionType 104))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant
+                       ((Reference (v (BuiltinType Builder))) 105))))))))))))
+            (uty_id 105) (uty_base_id 104)))))))
+      (interfaces
+       ((106
+         ((interface_methods
+           ((from
+             ((function_params ((from (BuiltinType Builder))))
+              (function_returns SelfType)))))))))
+      (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
+      (union_signs
+       (1
+        (((un_sig_cases (IntegerType (ExprType (Reference (T (TypeN 0))))))
+          (un_sig_methods ()) (un_sig_base_id 104)))))
+      (attr_executors <opaque>))) |}]
+
+let%expect_test "unions" =
+  let source =
+    {|
+      union Test {
+        case Int[257]
+        case Int[64]
+        fn id(self: Self) -> Self {
+          self
+        }
+      }
+    |}
+  in
+  pp_compile source ;
+  [%expect
+    {|
+    (Ok
+     ((bindings ((Test (Value (Type (UnionType 109))))))
+      (structs
+       ((107
          ((struct_fields
            ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
+            (value ((field_type (StructType 106))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
+                 ((function_params ((s (StructType 6)) (v (StructType 106))))
+                  (function_returns (StructType 107))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 103)))
+                     ((Value (Type (StructType 107)))
                       ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
+                       (value (Reference (v (StructType 106)))))))))))))))
+            (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+        (106
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 106))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 106)))
                       ((value (Reference (i IntegerType))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
+                   ((self (StructType 106)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3915,12 +3770,157 @@ let%expect_test "unions" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
+                       ((Reference (self (StructType 106))) value IntegerType))
+                      (Value (Integer 64))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 106)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 106)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 106))) value IntegerType))
+                         (Value (Integer 64)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 107))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 107)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 106)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 106)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 106) (uty_base_id 12)))))
+        (105
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 104))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 104))))
+                  (function_returns (StructType 105))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 105)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 104)))))))))))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id -500)))))
+        (104
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 104))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 104)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 104)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 104))) value IntegerType))
                       (Value (Integer 257))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Block
@@ -3936,23 +3936,23 @@ let%expect_test "unions" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 103)))
+                       ((Value (Type (StructType 105)))
                         ((slice (Reference (slice (StructType 6))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 102)))
+                            ((Value (Type (StructType 104)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
+                  (function_returns (StructType 104))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 102)))
+                     ((Value (Type (StructType 104)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -3960,7 +3960,7 @@ let%expect_test "unions" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
+                      ((self (StructType 104)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -3969,14 +3969,14 @@ let%expect_test "unions" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
+                          ((Reference (self (StructType 104))) value IntegerType))
                          (Value (Integer 257)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
+                     (function_returns (StructType 105))))
                    (function_impl
                     (Fn
                      (Block
@@ -3994,78 +3994,78 @@ let%expect_test "unions" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 103)))
+                          ((Value (Type (StructType 105)))
                            ((slice (Reference (slice (StructType 6))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 102)))
+                               ((Value (Type (StructType 104)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
               ((impl_interface 13)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
+                     (function_returns (StructType 104))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 102)))
+                        ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (unions
-       ((107
+       ((109
          ((union_attributes ())
           (cases
-           (((StructType 104) (Discriminator 1))
-            ((StructType 102) (Discriminator 0))))
+           (((StructType 106) (Discriminator 1))
+            ((StructType 104) (Discriminator 0))))
           (union_details
            ((uty_methods
              ((id
                ((function_signature
-                 ((function_params ((self (UnionType 107))))
-                  (function_returns (UnionType 107))))
-                (function_impl (Fn (Return (Reference (self (UnionType 107))))))))))
+                 ((function_params ((self (UnionType 109))))
+                  (function_returns (UnionType 109))))
+                (function_impl (Fn (Return (Reference (self (UnionType 109))))))))))
             (uty_impls
-             (((impl_interface 108)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v (StructType 102))))
-                     (function_returns (UnionType 106))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v (StructType 102))) 107))))))))))
-              ((impl_interface 109)
+             (((impl_interface 110)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v (StructType 104))))
-                     (function_returns (UnionType 106))))
+                     (function_returns (UnionType 108))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 104))) 107))))))))))))
-            (uty_id 107) (uty_base_id 106)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 104))) 109))))))))))
+              ((impl_interface 111)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (StructType 106))))
+                     (function_returns (UnionType 108))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v (StructType 106))) 109))))))))))))
+            (uty_id 109) (uty_base_id 108)))))))
       (interfaces
-       ((109
+       ((111
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 106))))
+              (function_returns SelfType)))))))
+        (110
          ((interface_methods
            ((from
              ((function_params ((from (StructType 104))))
-              (function_returns SelfType)))))))
-        (108
-         ((interface_methods
-           ((from
-             ((function_params ((from (StructType 102))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 102) (StructType 104))) (un_sig_methods ())
-          (un_sig_base_id 106)))))
+        (((un_sig_cases ((StructType 104) (StructType 106))) (un_sig_methods ())
+          (un_sig_base_id 108)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =
@@ -4089,16 +4089,16 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct ((Value (Type (StructType 105))) ()))))
-        (foo_empty (Value (Struct ((Value (Type (StructType 106))) ()))))
-        (Empty (Value (Type (StructType 105)))) (x (Value (Integer 10)))
-        (foo (Value (Struct ((Value (Type (StructType 103))) ()))))
+       ((y (Value (Struct ((Value (Type (StructType 107))) ()))))
+        (foo_empty (Value (Struct ((Value (Type (StructType 108))) ()))))
+        (Empty (Value (Type (StructType 107)))) (x (Value (Integer 10)))
+        (foo (Value (Struct ((Value (Type (StructType 105))) ()))))
         (Foo
          (Value
           (Function
            ((function_signature
              ((function_params ((X (TypeN 0))))
-              (function_returns (StructSig 94))))
+              (function_returns (StructSig 59))))
             (function_impl
              (Fn
               (Return
@@ -4110,53 +4110,53 @@ let%expect_test "methods monomorphization" =
                       (MkFunction
                        ((function_signature
                          ((function_params
-                           ((self (ExprType (Reference (Self (StructSig 94)))))
+                           ((self (ExprType (Reference (Self (StructSig 59)))))
                             (x (ExprType (Reference (X (TypeN 0)))))))
                           (function_returns (ExprType (Reference (X (TypeN 0)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))
-                   (mk_impls ()) (mk_id 102) (mk_sig 94) (mk_span <opaque>))))))))))))))
+                   (mk_impls ()) (mk_id 104) (mk_sig 59) (mk_span <opaque>))))))))))))))
       (structs
-       ((106
+       ((108
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((id
                ((function_signature
                  ((function_params
-                   ((self (StructType 106)) (x (StructType 105))))
-                  (function_returns (StructType 105))))
-                (function_impl (Fn (Return (Reference (x (StructType 105))))))))))
-            (uty_impls ()) (uty_id 106) (uty_base_id 102)))))
-        (105
+                   ((self (StructType 108)) (x (StructType 107))))
+                  (function_returns (StructType 107))))
+                (function_impl (Fn (Return (Reference (x (StructType 107))))))))))
+            (uty_impls ()) (uty_id 108) (uty_base_id 104)))))
+        (107
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))
-        (103
+           ((uty_methods ()) (uty_impls ()) (uty_id 107) (uty_base_id 106)))))
+        (105
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((id
                ((function_signature
-                 ((function_params ((self (StructType 103)) (x IntegerType)))
+                 ((function_params ((self (StructType 105)) (x IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (x IntegerType)))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (2
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 104)
-          (st_sig_id 95))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 106)
+          (st_sig_id 60))
          ((st_sig_fields ())
           (st_sig_methods
            ((id
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 94)))))
+               ((self (ExprType (Reference (Self (StructSig 59)))))
                 (x (ExprType (Reference (X (TypeN 0)))))))
               (function_returns (ExprType (Reference (X (TypeN 0)))))))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -4186,21 +4186,166 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 107))))
+             ((function_params ((i (UnionType 109))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Break
                (Switch
-                ((switch_condition (Reference (i (UnionType 107))))
+                ((switch_condition (Reference (i (UnionType 109))))
                  (branches
-                  (((branch_ty (StructType 102)) (branch_var vax)
+                  (((branch_ty (StructType 104)) (branch_var vax)
                     (branch_stmt (Block ((Return (Value (Integer 32)))))))
-                   ((branch_ty (StructType 104)) (branch_var vax)
+                   ((branch_ty (StructType 106)) (branch_var vax)
                     (branch_stmt (Block ((Return (Value (Integer 64))))))))))))))))))
-        (Ints (Value (Type (UnionType 107))))))
+        (Ints (Value (Type (UnionType 109))))))
       (structs
-       ((105
+       ((107
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 106))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 106))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 107)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 106)))))))))))))))
+            (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+        (106
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 106)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 106))) value IntegerType))
+                      (Value (Integer 64))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 106)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 106)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 106))) value IntegerType))
+                         (Value (Integer 64)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 107))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 107)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 106)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 106)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 106) (uty_base_id 12)))))
+        (105
          ((struct_fields
            ((slice ((field_type (StructType 6))))
             (value ((field_type (StructType 104))))))
@@ -4247,7 +4392,7 @@ let%expect_test "switch statement" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 104))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 32))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
@@ -4259,7 +4404,7 @@ let%expect_test "switch statement" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4301,7 +4446,7 @@ let%expect_test "switch statement" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 104))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 32)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4315,7 +4460,7 @@ let%expect_test "switch statement" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4344,198 +4489,53 @@ let%expect_test "switch statement" =
                        (Struct
                         ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 104) (uty_base_id 12)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 32))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (unions
-       ((107
+       ((109
          ((union_attributes ())
           (cases
-           (((StructType 104) (Discriminator 1))
-            ((StructType 102) (Discriminator 0))))
+           (((StructType 106) (Discriminator 1))
+            ((StructType 104) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 108)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((v (StructType 102))))
-                     (function_returns (UnionType 106))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (MakeUnionVariant ((Reference (v (StructType 102))) 107))))))))))
-              ((impl_interface 109)
+             (((impl_interface 110)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v (StructType 104))))
-                     (function_returns (UnionType 106))))
+                     (function_returns (UnionType 108))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 104))) 107))))))))))))
-            (uty_id 107) (uty_base_id 106)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 104))) 109))))))))))
+              ((impl_interface 111)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((v (StructType 106))))
+                     (function_returns (UnionType 108))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (MakeUnionVariant ((Reference (v (StructType 106))) 109))))))))))))
+            (uty_id 109) (uty_base_id 108)))))))
       (interfaces
-       ((109
+       ((111
+         ((interface_methods
+           ((from
+             ((function_params ((from (StructType 106))))
+              (function_returns SelfType)))))))
+        (110
          ((interface_methods
            ((from
              ((function_params ((from (StructType 104))))
-              (function_returns SelfType)))))))
-        (108
-         ((interface_methods
-           ((from
-             ((function_params ((from (StructType 102))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 102) (StructType 104))) (un_sig_methods ())
-          (un_sig_base_id 106)))))
+        (((un_sig_cases ((StructType 104) (StructType 106))) (un_sig_methods ())
+          (un_sig_base_id 108)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "partial evaluation of a function" =
@@ -4615,13 +4615,158 @@ let%expect_test "let binding with type" =
        ((a
          (Value
           (Struct
-           ((Value (Type (StructType 104))) ((value (Value (Integer 2))))))))
+           ((Value (Type (StructType 106))) ((value (Value (Integer 2))))))))
         (a
          (Value
           (Struct
-           ((Value (Type (StructType 102))) ((value (Value (Integer 1))))))))))
+           ((Value (Type (StructType 104))) ((value (Value (Integer 1))))))))))
       (structs
-       ((105
+       ((107
+         ((struct_fields
+           ((slice ((field_type (StructType 6))))
+            (value ((field_type (StructType 106))))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((s (StructType 6)) (v (StructType 106))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 107)))
+                      ((slice (Reference (s (StructType 6))))
+                       (value (Reference (v (StructType 106)))))))))))))))
+            (uty_impls ()) (uty_id 107) (uty_base_id -500)))))
+        (106
+         ((struct_fields ((value ((field_type IntegerType)))))
+          (struct_details
+           ((uty_methods
+             ((new
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))
+              (serialize
+               ((function_signature
+                 ((function_params
+                   ((self (StructType 106)) (builder (StructType 3))))
+                  (function_returns (StructType 3))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (FunctionCall
+                    ((ResolvedReference (serialize_int <opaque>))
+                     ((Reference (builder (StructType 3)))
+                      (StructField
+                       ((Reference (self (StructType 106))) value IntegerType))
+                      (Value (Integer 32))))))))))
+              (deserialize
+               ((function_signature
+                 ((function_params ((s (StructType 6))))
+                  (function_returns (StructType 107))))
+                (function_impl
+                 (Fn
+                  (Block
+                   ((Let
+                     ((res
+                       (FunctionCall
+                        ((ResolvedReference (load_int <opaque>))
+                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
+                    (DestructuringLet
+                     ((destructuring_let ((slice slice) (value value)))
+                      (destructuring_let_expr (Reference (res (StructType 5))))
+                      (destructuring_let_rest false)))
+                    (Return
+                     (Value
+                      (Struct
+                       ((Value (Type (StructType 107)))
+                        ((slice (Reference (slice (StructType 6))))
+                         (value
+                          (Value
+                           (Struct
+                            ((Value (Type (StructType 106)))
+                             ((value (Reference (value IntegerType)))))))))))))))))))
+              (from
+               ((function_signature
+                 ((function_params ((i IntegerType)))
+                  (function_returns (StructType 106))))
+                (function_impl
+                 (Fn
+                  (Return
+                   (Value
+                    (Struct
+                     ((Value (Type (StructType 106)))
+                      ((value (Reference (i IntegerType))))))))))))))
+            (uty_impls
+             (((impl_interface -1)
+               (impl_methods
+                ((serialize
+                  ((function_signature
+                    ((function_params
+                      ((self (StructType 106)) (builder (StructType 3))))
+                     (function_returns (StructType 3))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (FunctionCall
+                       ((ResolvedReference (serialize_int <opaque>))
+                        ((Reference (builder (StructType 3)))
+                         (StructField
+                          ((Reference (self (StructType 106))) value IntegerType))
+                         (Value (Integer 32)))))))))))))
+              ((impl_interface -2)
+               (impl_methods
+                ((deserialize
+                  ((function_signature
+                    ((function_params ((s (StructType 6))))
+                     (function_returns (StructType 107))))
+                   (function_impl
+                    (Fn
+                     (Block
+                      ((Let
+                        ((res
+                          (FunctionCall
+                           ((ResolvedReference (load_int <opaque>))
+                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
+                       (DestructuringLet
+                        ((destructuring_let ((slice slice) (value value)))
+                         (destructuring_let_expr
+                          (Reference (res (StructType 5))))
+                         (destructuring_let_rest false)))
+                       (Return
+                        (Value
+                         (Struct
+                          ((Value (Type (StructType 107)))
+                           ((slice (Reference (slice (StructType 6))))
+                            (value
+                             (Value
+                              (Struct
+                               ((Value (Type (StructType 106)))
+                                ((value (Reference (value IntegerType))))))))))))))))))))))
+              ((impl_interface 13)
+               (impl_methods
+                ((from
+                  ((function_signature
+                    ((function_params ((i IntegerType)))
+                     (function_returns (StructType 106))))
+                   (function_impl
+                    (Fn
+                     (Return
+                      (Value
+                       (Struct
+                        ((Value (Type (StructType 106)))
+                         ((value (Reference (i IntegerType)))))))))))))))))
+            (uty_id 106) (uty_base_id 12)))))
+        (105
          ((struct_fields
            ((slice ((field_type (StructType 6))))
             (value ((field_type (StructType 104))))))
@@ -4668,7 +4813,7 @@ let%expect_test "let binding with type" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 104))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 257))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 6))))
@@ -4680,7 +4825,7 @@ let%expect_test "let binding with type" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4722,7 +4867,7 @@ let%expect_test "let binding with type" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 104))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 257)))))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4736,7 +4881,8 @@ let%expect_test "let binding with type" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 6)))
+                             (Value (Integer 257))))))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4765,153 +4911,7 @@ let%expect_test "let binding with type" =
                        (Struct
                         ((Value (Type (StructType 104)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 104) (uty_base_id 12)))))
-        (103
-         ((struct_fields
-           ((slice ((field_type (StructType 6))))
-            (value ((field_type (StructType 102))))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((s (StructType 6)) (v (StructType 102))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 103)))
-                      ((slice (Reference (s (StructType 6))))
-                       (value (Reference (v (StructType 102)))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id -500)))))
-        (102
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))
-              (serialize
-               ((function_signature
-                 ((function_params
-                   ((self (StructType 102)) (builder (StructType 3))))
-                  (function_returns (StructType 3))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (FunctionCall
-                    ((ResolvedReference (serialize_int <opaque>))
-                     ((Reference (builder (StructType 3)))
-                      (StructField
-                       ((Reference (self (StructType 102))) value IntegerType))
-                      (Value (Integer 257))))))))))
-              (deserialize
-               ((function_signature
-                 ((function_params ((s (StructType 6))))
-                  (function_returns (StructType 103))))
-                (function_impl
-                 (Fn
-                  (Block
-                   ((Let
-                     ((res
-                       (FunctionCall
-                        ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 6))) (Value (Integer 257))))))))
-                    (DestructuringLet
-                     ((destructuring_let ((slice slice) (value value)))
-                      (destructuring_let_expr (Reference (res (StructType 5))))
-                      (destructuring_let_rest false)))
-                    (Return
-                     (Value
-                      (Struct
-                       ((Value (Type (StructType 103)))
-                        ((slice (Reference (slice (StructType 6))))
-                         (value
-                          (Value
-                           (Struct
-                            ((Value (Type (StructType 102)))
-                             ((value (Reference (value IntegerType)))))))))))))))))))
-              (from
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 102))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 102)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls
-             (((impl_interface -1)
-               (impl_methods
-                ((serialize
-                  ((function_signature
-                    ((function_params
-                      ((self (StructType 102)) (builder (StructType 3))))
-                     (function_returns (StructType 3))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (FunctionCall
-                       ((ResolvedReference (serialize_int <opaque>))
-                        ((Reference (builder (StructType 3)))
-                         (StructField
-                          ((Reference (self (StructType 102))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
-              ((impl_interface -2)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ((s (StructType 6))))
-                     (function_returns (StructType 103))))
-                   (function_impl
-                    (Fn
-                     (Block
-                      ((Let
-                        ((res
-                          (FunctionCall
-                           ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 6)))
-                             (Value (Integer 257))))))))
-                       (DestructuringLet
-                        ((destructuring_let ((slice slice) (value value)))
-                         (destructuring_let_expr
-                          (Reference (res (StructType 5))))
-                         (destructuring_let_rest false)))
-                       (Return
-                        (Value
-                         (Struct
-                          ((Value (Type (StructType 103)))
-                           ((slice (Reference (slice (StructType 6))))
-                            (value
-                             (Value
-                              (Struct
-                               ((Value (Type (StructType 102)))
-                                ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 13)
-               (impl_methods
-                ((from
-                  ((function_signature
-                    ((function_params ((i IntegerType)))
-                     (function_returns (StructType 102))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 102)))
-                         ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 102) (uty_base_id 12)))))))
+            (uty_id 104) (uty_base_id 12)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -4953,7 +4953,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 104))))
+             ((function_params ((t (StructType 106))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -4962,19 +4962,19 @@ let%expect_test "interface constraints" =
                 ((Value
                   (Function
                    ((function_signature
-                     ((function_params ((self (StructType 104))))
+                     ((function_params ((self (StructType 106))))
                       (function_returns IntegerType)))
                     (function_impl (Fn (Return (Value (Integer 1))))))))
-                 ((Reference (t (StructType 104)))))))))))))
+                 ((Reference (t (StructType 106)))))))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 102))))
+             ((function_params ((T (InterfaceType 104))))
               (function_returns
                (FunctionType
                 ((function_params
-                  ((t (ExprType (Reference (T (InterfaceType 102)))))))
+                  ((t (ExprType (Reference (T (InterfaceType 104)))))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -4982,45 +4982,45 @@ let%expect_test "interface constraints" =
                (MkFunction
                 ((function_signature
                   ((function_params
-                    ((t (ExprType (Reference (T (InterfaceType 102)))))))
+                    ((t (ExprType (Reference (T (InterfaceType 104)))))))
                    (function_returns IntegerType)))
                  (function_impl
                   (Fn
                    (Return
                     (IntfMethodCall
-                     ((intf_instance (Reference (T (InterfaceType 102))))
-                      (intf_def 102)
+                     ((intf_instance (Reference (T (InterfaceType 104))))
+                      (intf_def 104)
                       (intf_method
                        (beep
                         ((function_params ((self SelfType)))
                          (function_returns IntegerType))))
                       (intf_args
                        ((Reference
-                         (t (ExprType (Reference (T (InterfaceType 102))))))))
+                         (t (ExprType (Reference (T (InterfaceType 104))))))))
                       (intf_loc <opaque>)))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 104))))
-        (Beep (Value (Type (InterfaceType 102))))))
+        (BeeperImpl1 (Value (Type (StructType 106))))
+        (Beep (Value (Type (InterfaceType 104))))))
       (structs
-       ((104
+       ((106
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((beep
                ((function_signature
-                 ((function_params ((self (StructType 104))))
+                 ((function_params ((self (StructType 106))))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Value (Integer 1)))))))))
             (uty_impls
-             (((impl_interface 102)
+             (((impl_interface 104)
                (impl_methods
                 ((beep
                   ((function_signature
-                    ((function_params ((self (StructType 104))))
+                    ((function_params ((self (StructType 106))))
                      (function_returns IntegerType)))
                    (function_impl (Fn (Return (Value (Integer 1))))))))))))
-            (uty_id 104) (uty_base_id 103)))))))
+            (uty_id 106) (uty_base_id 105)))))))
       (interfaces
-       ((102
+       ((104
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))
@@ -5031,9 +5031,9 @@ let%expect_test "interface constraints" =
           (st_sig_methods
            ((beep
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 94)))))))
+               ((self (ExprType (Reference (Self (StructSig 59)))))))
               (function_returns IntegerType)))))
-          (st_sig_base_id 103) (st_sig_id 94)))))
+          (st_sig_base_id 105) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let" =
@@ -5062,24 +5062,24 @@ let%expect_test "destructuring let" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 103))))
+             ((function_params ((t (StructType 105))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((x x) (y y2) (z z)))
-                  (destructuring_let_expr (Reference (t (StructType 103))))
+                  (destructuring_let_expr (Reference (t (StructType 105))))
                   (destructuring_let_rest false)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 103))))))
+        (T (Value (Type (StructType 105))))))
       (structs
-       ((103
+       ((105
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5087,7 +5087,7 @@ let%expect_test "destructuring let" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields" =
@@ -5107,30 +5107,30 @@ let%expect_test "destructuring let with missing fields" =
   pp_compile source ;
   [%expect
     {|
-    (((MissingField ((StructType 103) x)) (MissingField ((StructType 103) z)))
+    (((MissingField ((StructType 105) x)) (MissingField ((StructType 105) z)))
      ((bindings
        ((test
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 103))))
+             ((function_params ((t (StructType 105))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((y y2)))
-                  (destructuring_let_expr (Reference (t (StructType 103))))
+                  (destructuring_let_expr (Reference (t (StructType 105))))
                   (destructuring_let_rest false)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 103))))))
+        (T (Value (Type (StructType 105))))))
       (structs
-       ((103
+       ((105
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5138,7 +5138,7 @@ let%expect_test "destructuring let with missing fields" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields ignored" =
@@ -5164,24 +5164,24 @@ let%expect_test "destructuring let with missing fields ignored" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 103))))
+             ((function_params ((t (StructType 105))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((y y2)))
-                  (destructuring_let_expr (Reference (t (StructType 103))))
+                  (destructuring_let_expr (Reference (t (StructType 105))))
                   (destructuring_let_rest true)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 103))))))
+        (T (Value (Type (StructType 105))))))
       (structs
-       ((103
+       ((105
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5189,7 +5189,7 @@ let%expect_test "destructuring let with missing fields ignored" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 102) (st_sig_id 94)))))
+          (st_sig_methods ()) (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type that does not implement interface passed to the \
@@ -5205,28 +5205,28 @@ let%expect_test "type that does not implement interface passed to the \
   pp_compile source ;
   [%expect
     {|
-    (((TypeError ((InterfaceType 102) (TypeN 0))))
+    (((TypeError ((InterfaceType 104) (TypeN 0))))
      ((bindings
-       ((a (Value Void)) (Foo (Value (Type (StructType 104))))
+       ((a (Value Void)) (Foo (Value (Type (StructType 106))))
         (ExpectedIntf
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 102))))
+             ((function_params ((T (InterfaceType 104))))
               (function_returns HoleType)))
             (function_impl (Fn (Block ())))))))
-        (Intf (Value (Type (InterfaceType 102))))))
+        (Intf (Value (Type (InterfaceType 104))))))
       (structs
-       ((104
+       ((106
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 104) (uty_base_id 103)))))))
-      (interfaces ((102 ((interface_methods ()))))) (type_counter <opaque>)
+           ((uty_methods ()) (uty_impls ()) (uty_id 106) (uty_base_id 105)))))))
+      (interfaces ((104 ((interface_methods ()))))) (type_counter <opaque>)
       (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 103)
-          (st_sig_id 94)))))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 105)
+          (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct signatures" =
@@ -5293,7 +5293,7 @@ let%expect_test "struct signatures" =
           (Function
            ((function_signature
              ((function_params ((bits IntegerType)))
-              (function_returns (StructSig 94))))
+              (function_returns (StructSig 59))))
             (function_impl
              (Fn
               (Return
@@ -5307,48 +5307,48 @@ let%expect_test "struct signatures" =
                        ((function_signature
                          ((function_params ((i IntegerType)))
                           (function_returns
-                           (ExprType (Reference (Self (StructSig 94)))))))
+                           (ExprType (Reference (Self (StructSig 59)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Value
                             (Struct
-                             ((Reference (Self (StructSig 94)))
+                             ((Reference (Self (StructSig 59)))
                               ((value (Reference (i IntegerType)))))))))))))))
-                   (mk_impls ()) (mk_id 102) (mk_sig 94) (mk_span <opaque>))))))))))))))
+                   (mk_impls ()) (mk_id 104) (mk_sig 59) (mk_span <opaque>))))))))))))))
       (structs
-       ((104
+       ((106
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 104))))
+                  (function_returns (StructType 106))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 104)))
+                     ((Value (Type (StructType 106)))
                       ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls ()) (uty_id 104) (uty_base_id 102)))))
-        (103
+            (uty_impls ()) (uty_id 106) (uty_base_id 104)))))
+        (105
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 103))))
+                  (function_returns (StructType 105))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 103)))
+                     ((Value (Type (StructType 105)))
                       ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+            (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5356,8 +5356,8 @@ let%expect_test "struct signatures" =
           (st_sig_methods
            ((new
              ((function_params ((i IntegerType)))
-              (function_returns (ExprType (Reference (Self (StructSig 94)))))))))
-          (st_sig_base_id 102) (st_sig_id 94)))))
+              (function_returns (ExprType (Reference (Self (StructSig 59)))))))))
+          (st_sig_base_id 104) (st_sig_id 59)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserilize intf with constraints" =
@@ -5831,8 +5831,8 @@ let%expect_test "attributes" =
     {|
       (Ok
        ((bindings
-         ((Ti (Value (Type (StructType 114)))) (U1 (Value (Type (UnionType 112))))
-          (U (Value (Type (UnionType 109)))) (I (Value (Type (InterfaceType 107))))
+         ((Ti (Value (Type (StructType 116)))) (U1 (Value (Type (UnionType 114))))
+          (U (Value (Type (UnionType 111)))) (I (Value (Type (InterfaceType 109))))
           (x1
            (Value
             (Function
@@ -5849,13 +5849,13 @@ let%expect_test "attributes" =
                  (((attribute_ident attr) (attribute_exprs ()))))
                 (function_params ()) (function_returns HoleType)))
               (function_impl (Fn (Block ())))))))
-          (T1 (Value (Type (StructType 106))))
+          (T1 (Value (Type (StructType 108))))
           (Ta
            (Value
             (Function
              ((function_signature
                ((function_params ((X IntegerType)))
-                (function_returns (StructSig 95))))
+                (function_returns (StructSig 60))))
               (function_impl
                (Fn
                 (Return
@@ -5864,11 +5864,11 @@ let%expect_test "attributes" =
                     (((attribute_ident attr) (attribute_exprs ()))))
                    (mk_struct_fields ())
                    (mk_struct_details
-                    ((mk_methods ()) (mk_impls ()) (mk_id 104) (mk_sig 95)
+                    ((mk_methods ()) (mk_impls ()) (mk_id 106) (mk_sig 60)
                      (mk_span <opaque>))))))))))))
-          (T (Value (Type (StructType 103))))))
+          (T (Value (Type (StructType 105))))))
         (structs
-         ((114
+         ((116
            ((struct_fields ())
             (struct_details
              ((uty_methods
@@ -5880,7 +5880,7 @@ let%expect_test "attributes" =
                   (function_impl (Fn (Return (Value (Bool true)))))))))
               (uty_impls
                (((impl_attributes (((attribute_ident attr) (attribute_exprs ()))))
-                 (impl_interface 107)
+                 (impl_interface 109)
                  (impl_methods
                   ((x
                     ((function_signature
@@ -5888,13 +5888,13 @@ let%expect_test "attributes" =
                         (((attribute_ident attr) (attribute_exprs ()))))
                        (function_params ()) (function_returns BoolType)))
                      (function_impl (Fn (Return (Value (Bool true))))))))))))
-              (uty_id 114) (uty_base_id 113)))))
-          (106
+              (uty_id 116) (uty_base_id 115)))))
+          (108
            ((struct_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (struct_fields ())
             (struct_details
-             ((uty_methods ()) (uty_impls ()) (uty_id 106) (uty_base_id 105)))))
-          (103
+             ((uty_methods ()) (uty_impls ()) (uty_id 108) (uty_base_id 107)))))
+          (105
            ((struct_attributes
              (((attribute_ident attr) (attribute_exprs ()))
               ((attribute_ident attr) (attribute_exprs ((Value (Integer 1)))))
@@ -5909,46 +5909,46 @@ let%expect_test "attributes" =
                      (((attribute_ident attr) (attribute_exprs ()))))
                     (function_params ()) (function_returns BoolType)))
                   (function_impl (Fn (Return (Value (Bool true)))))))))
-              (uty_impls ()) (uty_id 103) (uty_base_id 102)))))))
+              (uty_impls ()) (uty_id 105) (uty_base_id 104)))))))
         (unions
-         ((112
+         ((114
            ((union_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (cases (((ExprType (Value Void)) (Discriminator 0))))
             (union_details
              ((uty_methods ())
               (uty_impls
-               (((impl_interface 110)
+               (((impl_interface 112)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((v VoidType)))
-                       (function_returns (UnionType 111))))
+                       (function_returns (UnionType 113))))
                      (function_impl
                       (Fn
-                       (Return (MakeUnionVariant ((Reference (v VoidType)) 112))))))))))))
-              (uty_id 112) (uty_base_id 111)))))
-          (109
+                       (Return (MakeUnionVariant ((Reference (v VoidType)) 114))))))))))))
+              (uty_id 114) (uty_base_id 113)))))
+          (111
            ((union_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (cases (((ExprType (Value Void)) (Discriminator 0))))
             (union_details
              ((uty_methods ())
               (uty_impls
-               (((impl_interface 110)
+               (((impl_interface 112)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((v VoidType)))
-                       (function_returns (UnionType 108))))
+                       (function_returns (UnionType 110))))
                      (function_impl
                       (Fn
-                       (Return (MakeUnionVariant ((Reference (v VoidType)) 109))))))))))))
-              (uty_id 109) (uty_base_id 108)))))))
+                       (Return (MakeUnionVariant ((Reference (v VoidType)) 111))))))))))))
+              (uty_id 111) (uty_base_id 110)))))))
         (interfaces
-         ((110
+         ((112
            ((interface_methods
              ((from
                ((function_params ((from VoidType))) (function_returns SelfType)))))))
-          (107
+          (109
            ((interface_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (interface_methods
              ((x
@@ -5964,13 +5964,13 @@ let%expect_test "attributes" =
                ((function_attributes
                  (((attribute_ident attr) (attribute_exprs ()))))
                 (function_params ()) (function_returns BoolType)))))
-            (st_sig_base_id 113) (st_sig_id 97))
+            (st_sig_base_id 115) (st_sig_id 62))
            ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
-            (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 105)
-            (st_sig_id 96))
+            (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 107)
+            (st_sig_id 61))
            ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
-            (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 104)
-            (st_sig_id 95))
+            (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 106)
+            (st_sig_id 60))
            ((st_sig_attributes
              (((attribute_ident attr) (attribute_exprs ()))
               ((attribute_ident attr) (attribute_exprs ((Value (Integer 1)))))
@@ -5982,13 +5982,13 @@ let%expect_test "attributes" =
                ((function_attributes
                  (((attribute_ident attr) (attribute_exprs ()))))
                 (function_params ()) (function_returns BoolType)))))
-            (st_sig_base_id 102) (st_sig_id 94)))))
+            (st_sig_base_id 104) (st_sig_id 59)))))
         (union_signs
          (2
           (((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (un_sig_cases ((ExprType (Value Void)))) (un_sig_methods ())
-            (un_sig_base_id 111))
+            (un_sig_base_id 113))
            ((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
             (un_sig_cases ((ExprType (Value Void)))) (un_sig_methods ())
-            (un_sig_base_id 108)))))
+            (un_sig_base_id 110)))))
         (attr_executors <opaque>))) |}]


### PR DESCRIPTION
This PR adds `deserializer` implementation for the unions and place `@derive` on the `Deserialize` impl on the union types in the Std.