### PR TITLE
Add type functions

### DIFF
--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -25,7 +25,7 @@ functor
                 FunctionCall
                   ( bl @@ Reference (bl "serializer", HoleType),
                     [bl @@ Value (Type self_ty)],
-                    false )
+                    true )
               in
               let fun_body =
                 bl
@@ -72,7 +72,7 @@ functor
                 FunctionCall
                   ( bl @@ Reference (bl "deserializer", HoleType),
                     [bl @@ Value (Type self_ty)],
-                    false )
+                    true )
               in
               let fun_body =
                 bl
@@ -87,7 +87,7 @@ functor
                 ExprType
                   ( bl
                   @@ FunctionCall
-                       (load_result_f, [bl @@ Value (Type self_ty)], false) )
+                       (load_result_f, [bl @@ Value (Type self_ty)], true) )
               in
               let function_signature =
                 bl

--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -39,6 +39,7 @@ functor
                 bl
                 @@ { function_params =
                        [(bl "self", self_ty); (bl "b", builder_ty)];
+                     function_is_type = false;
                      function_returns = builder_ty;
                      function_attributes = [] }
               in
@@ -87,6 +88,7 @@ functor
               let function_signature =
                 bl
                 @@ { function_params = [(bl "s", slice_ty)];
+                     function_is_type = false;
                      function_returns = ret_ty;
                      function_attributes = [] }
               in

--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -24,7 +24,8 @@ functor
               let self_serializer =
                 FunctionCall
                   ( bl @@ Reference (bl "serializer", HoleType),
-                    [bl @@ Value (Type self_ty)] )
+                    [bl @@ Value (Type self_ty)],
+                    false )
               in
               let fun_body =
                 bl
@@ -33,7 +34,8 @@ functor
                      @@ FunctionCall
                           ( bl @@ self_serializer,
                             [ bl @@ Reference (bl "self", self_ty);
-                              bl @@ Reference (bl "b", builder_ty) ] ) )
+                              bl @@ Reference (bl "b", builder_ty) ],
+                            false ) )
               in
               let function_signature =
                 bl
@@ -69,7 +71,8 @@ functor
               let self_deserializer =
                 FunctionCall
                   ( bl @@ Reference (bl "deserializer", HoleType),
-                    [bl @@ Value (Type self_ty)] )
+                    [bl @@ Value (Type self_ty)],
+                    false )
               in
               let fun_body =
                 bl
@@ -77,13 +80,14 @@ functor
                      ( bl
                      @@ FunctionCall
                           ( bl @@ self_deserializer,
-                            [bl @@ Reference (bl "s", slice_ty)] ) )
+                            [bl @@ Reference (bl "s", slice_ty)],
+                            false ) )
               in
               let ret_ty =
                 ExprType
                   ( bl
-                  @@ FunctionCall (load_result_f, [bl @@ Value (Type self_ty)])
-                  )
+                  @@ FunctionCall
+                       (load_result_f, [bl @@ Value (Type self_ty)], false) )
               in
               let function_signature =
                 bl

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -154,8 +154,8 @@ functor
                         ( bl
                         @@ FunctionCall
                              ( load_result_f,
-                               [bl @@ Reference (bl "Self", SelfType)] ) ) } )
-            ] }
+                               [bl @@ Reference (bl "Self", SelfType)],
+                               true ) ) } ) ] }
       in
       intf
 
@@ -246,7 +246,8 @@ functor
                                                   bl
                                                   @@ Reference
                                                        (bl "b", builder_struct)
-                                                ] ) ) ];
+                                                ],
+                                                false ) ) ];
                                 bl
                                 @@ Return
                                      (bl @@ Reference (bl "b", builder_struct))
@@ -301,8 +302,8 @@ functor
                                                   s.struct_details.uty_id ),
                                          name,
                                          f ) )
-                                  :: [bl @@ Reference (bl "b", builder_struct)]
-                                ) ) ]
+                                  :: [bl @@ Reference (bl "b", builder_struct)],
+                                  false ) ) ]
                      |> bl ) )
         in
         let body =
@@ -355,8 +356,9 @@ functor
                        ExprType
                          ( bl
                          @@ FunctionCall
-                              (load_result_fn, [bl @@ Reference (bl "t", type0)])
-                         ) } ) }
+                              ( load_result_fn,
+                                [bl @@ Reference (bl "t", type0)],
+                                true ) ) } ) }
       in
       let deserializer_struct_ty sid p =
         let s = Program.get_struct p sid in
@@ -391,7 +393,8 @@ functor
               let deserialize_field_expr =
                 FunctionCall
                   ( bl @@ Value (Function field_deserialize_fn),
-                    [bl @@ Reference (bl "slice", slice_ty)] )
+                    [bl @@ Reference (bl "slice", slice_ty)],
+                    false )
               in
               let deserialize_field =
                 bl
@@ -471,7 +474,9 @@ functor
           (* This is a hack to get LoadResult[Integer] type *)
           let res_discr_ty =
             type_of p
-              (bl @@ FunctionCall (m, [bl @@ Value Void; bl @@ Value Void]))
+              ( bl
+              @@ FunctionCall (m, [bl @@ Value Void; bl @@ Value Void], false)
+              )
           in
           bl
           @@ StructField
@@ -499,7 +504,9 @@ functor
                 let fcall =
                   bl
                   @@ FunctionCall
-                       (load_uint_fn, [slice_expr; bl @@ discriminator_len])
+                       ( load_uint_fn,
+                         [slice_expr; bl @@ discriminator_len],
+                         false )
                 in
                 bl @@ Let [(bl "res_discr", fcall)]
               in
@@ -514,7 +521,8 @@ functor
                     ( bl
                     @@ FunctionCall
                          ( get_method slice_ty "load_uint",
-                           [bl @@ Value Void; bl @@ Value Void] ) )
+                           [bl @@ Value Void; bl @@ Value Void],
+                           false ) )
                 in
                 let get_discr =
                   bl
@@ -525,7 +533,9 @@ functor
                 in
                 bl
                 @@ FunctionCall
-                     (eq_fn, [get_discr; bl @@ Value (Integer (Z.of_int disc))])
+                     ( eq_fn,
+                       [get_discr; bl @@ Value (Integer (Z.of_int disc))],
+                       false )
               in
               (* Stmt 3: let res = <CaseTy>.deserialize(res_discr.slice); *)
               let deserialize_stmt =
@@ -533,8 +543,9 @@ functor
                 @@ Let
                      [ ( bl "res",
                          bl
-                         @@ FunctionCall (case_deserialize_fn, [res_discr_slice])
-                       ) ]
+                         @@ FunctionCall
+                              (case_deserialize_fn, [res_discr_slice], false) )
+                     ]
               in
               (* Stmt 4: return <load_result_ty>.new(res.slice, res.value); *)
               let deserialize_out =
@@ -551,7 +562,8 @@ functor
                         @@ StructField
                              ( bl @@ Reference (bl "res", load_result_ty),
                                bl "value",
-                               case_ty ) ] )
+                               case_ty ) ],
+                      true )
                 in
                 bl @@ Return (bl fcall)
               in

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -40,6 +40,7 @@ functor
                     { function_signature =
                         bl
                           { function_attributes = [];
+                            function_is_type = false;
                             function_params =
                               [(bl "s", slice_struct); (bl "v", t)];
                             function_returns = StructType id };
@@ -68,6 +69,7 @@ functor
       let function_signature =
         bl
           { function_attributes = [];
+            function_is_type = true;
             function_params = [(bl "T", type0)];
             function_returns =
               (let id, _ =
@@ -85,6 +87,7 @@ functor
                          [ ( bl "new",
                              bl
                                { function_attributes = [];
+                                 function_is_type = false;
                                  function_params =
                                    [ (bl "s", slice_struct);
                                      ( bl "v",
@@ -124,6 +127,7 @@ functor
             [ ( "serialize",
                 bl
                   { function_attributes = [];
+                    function_is_type = false;
                     function_params =
                       [(bl "self", SelfType); (bl "b", builder_struct)];
                     function_returns = builder_struct } ) ] }
@@ -143,6 +147,7 @@ functor
             [ ( "deserialize",
                 bl
                   { function_attributes = [];
+                    function_is_type = false;
                     function_params = [(bl "b", builder_struct)];
                     function_returns =
                       ExprType
@@ -160,11 +165,13 @@ functor
       let function_signature =
         bl
           { function_attributes = [];
+            function_is_type = true;
             function_params = [(bl "t", type0)];
             function_returns =
               FunctionType
                 (bl
                    { function_attributes = [];
+                     function_is_type = false;
                      function_params =
                        [(bl "t", HoleType); (bl "b", builder_struct)];
                      function_returns = builder_struct } ) }
@@ -255,6 +262,7 @@ functor
         { function_signature =
             bl
               { function_attributes = [];
+                function_is_type = false;
                 function_params =
                   [ (bl "self", UnionType union.union_details.uty_id);
                     (bl "b", builder_struct) ];
@@ -304,6 +312,7 @@ functor
         { function_signature =
             bl
               { function_attributes = [];
+                function_is_type = false;
                 function_params =
                   [ (bl "self", StructType s.struct_details.uty_id);
                     (bl "b", builder_struct) ];
@@ -334,11 +343,13 @@ functor
       let function_signature =
         bl
           { function_attributes = [];
+            function_is_type = true;
             function_params = [(bl "t", type0)];
             function_returns =
               FunctionType
                 (bl
                    { function_attributes = [];
+                     function_is_type = false;
                      function_params = [(bl "slice", slice_ty)];
                      function_returns =
                        ExprType
@@ -413,6 +424,7 @@ functor
         { function_signature =
             bl
               { function_attributes = [];
+                function_is_type = false;
                 function_params = [(bl "slice", slice_ty)];
                 function_returns = load_result_ty };
           function_impl = Fn (bl body) }
@@ -557,6 +569,7 @@ functor
         { function_signature =
             bl
               { function_attributes = [];
+                function_is_type = false;
                 function_params = [(bl "slice", slice_ty)];
                 function_returns = load_result_ty };
           function_impl = Fn body }
@@ -582,6 +595,7 @@ functor
       let function_signature =
         bl
           { function_attributes = [];
+            function_is_type = true;
             function_params = [(bl "T", type0)];
             function_returns = HoleType }
       in
@@ -592,6 +606,7 @@ functor
               [ ( "from",
                   bl
                     { function_attributes = [];
+                      function_is_type = false;
                       function_params = [(bl "from", t)];
                       function_returns = SelfType } ) ] }
         in
@@ -661,6 +676,7 @@ functor
                     { function_signature =
                         bl
                           { function_attributes = [];
+                            function_is_type = false;
                             function_params = args;
                             function_returns = ret_ty };
                       function_impl =
@@ -733,6 +749,7 @@ functor
       let function_signature =
         bl
           { function_attributes = [];
+            function_is_type = false;
             function_params = [(bl "x", HoleType)];
             function_returns = HoleType }
       in

--- a/lib/codegen_func.ml
+++ b/lib/codegen_func.ml
@@ -93,7 +93,8 @@ functor
             | Value (Function f) ->
                 let f' = self#add_function f in
                 F.Reference (f'.function_name, F.FunctionType f')
-            | FunctionCall (func, args) -> (
+            | FunctionCall (func, args, _is_ty) -> (
+                (* TODO: if is_ty then ice "Type function in runtime context." ;*)
                 let args = List.map args ~f:self#cg_expr in
                 match self#cg_expr func with
                 | Reference (name, F.FunctionType f) ->

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -215,7 +215,8 @@ functor
                     in
                     self#interpret_fc
                       ( {value = Value (Function method_); span = intf_loc},
-                        intf_args )
+                        intf_args,
+                        false )
                 | None ->
                     ice "Interface implementation is not found" )
             | StructSigMethodCall
@@ -243,7 +244,8 @@ functor
                     self#interpret_fc
                       ( { value = Value (Function method_);
                           span = st_sig_call_span },
-                        st_sig_call_args )
+                        st_sig_call_args,
+                        false )
                 | None ->
                     ice "Interface implementation is not found" )
             | ResolvedReference (_, expr') ->
@@ -487,11 +489,11 @@ functor
         method interpret_function = partial_evaluate ctx
 
         method interpret_fc : function_call -> value =
-          fun (func, args) ->
+          fun (func, args, is_ty) ->
             let f = self#interpret_expr func in
             let args' = List.map args ~f:(fun arg -> self#interpret_expr arg) in
             let mk_err =
-              Expr {value = FunctionCall (func, args); span = func.span}
+              Expr {value = FunctionCall (func, args, is_ty); span = func.span}
             in
             let args_to_list params values =
               match

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -372,6 +372,7 @@ functor
                           ( name,
                             { function_attributes =
                                 sign.value.function_attributes;
+                              function_is_type = sign.value.function_is_type;
                               function_params =
                                 List.map sign.value.function_params
                                   ~f:(fun (pname, ty) ->

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -112,7 +112,7 @@ functor
 
         method build_Function _env fn = MkFunction fn
 
-        method build_FunctionCall _env (f, args) =
+        method build_FunctionCall _env (f, args, _is_type_fn) =
           let span =
             merge_spans f.span (merge_spans_list @@ List.map args ~f:span)
           in
@@ -498,7 +498,7 @@ functor
           | _ ->
               mk_err ()
 
-        method build_function_call _env fn args = (fn, args)
+        method build_function_call _env fn args is_ty = (fn, args, is_ty)
 
         method build_method_call _env in_receiver fn args =
           let dummy : expr_kind =

--- a/lib/lang.ml
+++ b/lib/lang.ml
@@ -510,6 +510,7 @@ functor
                              { function_signature =
                                  { value =
                                      { function_attributes = [];
+                                       function_is_type = false;
                                        function_params = [];
                                        function_returns = VoidType };
                                    span = fn.span };
@@ -729,6 +730,7 @@ functor
             let sign =
               { value =
                   { function_attributes;
+                    function_is_type = f.is_type_function;
                     function_params = param_bindings;
                     function_returns = fn_returns };
                 span = f.function_def_span }
@@ -1212,6 +1214,7 @@ functor
                        { function_signature =
                            { value =
                                { function_attributes = [];
+                                 function_is_type = false;
                                  function_params =
                                    [ ( builtin_located "v",
                                        expr_to_type program case ) ];

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -175,6 +175,10 @@ functor
     and value =
       | Void
       | Struct of (expr * (string * expr) list)
+      | TypedCall of
+          { func : function_;
+            args : value list;
+            out : value [@equal.ignore] [@compare.ignore] }
       | UnionVariant of (value * int)
       | Function of function_
       | Integer of (Zint.t[@visitors.name "z"])
@@ -309,6 +313,7 @@ functor
 
     and function_signature_kind =
       { function_attributes : attribute list; [@sexp.list]
+        function_is_type : bool; [@sexp.bool]
         function_params : (string located * type_) list;
         function_returns : type_ }
 

--- a/lib/lang_types.ml
+++ b/lib/lang_types.ml
@@ -319,7 +319,7 @@ functor
 
     and function_impl = Fn of stmt | BuiltinFn of builtin_fn
 
-    and function_call = expr * expr list
+    and function_call = expr * expr list * (bool[@sexp.bool])
 
     and intf_method_call =
       { intf_instance : expr;
@@ -433,14 +433,15 @@ functor
           type_of_type program t
       | Hole ->
           HoleType
-      | FunctionCall (f, args) -> (
+      | FunctionCall (f, args, is_ty) -> (
           let f' = type_of program f in
           match f' with
           | FunctionType sign ->
               type_of_call
                 ~self_ty:
                   (Some
-                     (ExprType {value = FunctionCall (f, args); span = expr.span}
+                     (ExprType
+                        {value = FunctionCall (f, args, is_ty); span = expr.span}
                      ) )
                 program args sign.value.function_params
                 sign.value.function_returns
@@ -699,7 +700,7 @@ functor
           self#with_arguments [branch_var.value] (fun _ ->
               self#visit_stmt env branch_stmt )
 
-        method! visit_function_call ctx (f, args) =
+        method! visit_function_call ctx (f, args, _) =
           let is_args_immediate = self#visit_list self#visit_expr ctx args in
           let is_f_immediate =
             match self#visit_expr ctx f with

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -43,7 +43,8 @@
                               ~function_body: (make_function_body ~function_stmt:({value=Return (expr); span = expr.span}) ()) 
                               ()
                     )) ();
-      arguments = [expr]
+      arguments = [expr];
+      is_type_func_call = false
     }) ()
 
 %}
@@ -250,10 +251,10 @@ let function_param ==
 let function_call :=
   | fn = located(fexpr);
   arguments = delimited_separated_trailing_list(LPAREN, located(expr), COMMA, RPAREN);
-  { FunctionCall (make_function_call ~fn: fn ~arguments: arguments ()) }
+  { FunctionCall (make_function_call ~fn: fn ~arguments: arguments () ~is_type_func_call:false) }
   | fn = located(fexpr);
   arguments = delimited_separated_trailing_list(LBRACKET, located(expr), COMMA, RBRACKET);
-  { FunctionCall (make_function_call ~fn: fn ~arguments: arguments ()) }
+  { FunctionCall (make_function_call ~fn: fn ~arguments: arguments () ~is_type_func_call:true) }
 
 
 let else_ :=

--- a/lib/partial_evaluator.ml
+++ b/lib/partial_evaluator.ml
@@ -119,7 +119,11 @@ functor
           {switch_condition = cond; branches}
 
         method! visit_function_signature env
-            { value = {function_attributes; function_params; function_returns};
+            { value =
+                { function_attributes;
+                  function_params;
+                  function_returns;
+                  function_is_type };
               span } =
           let function_params =
             self#visit_list
@@ -130,7 +134,11 @@ functor
           let function_returns =
             self#with_vars vars (fun _ -> self#visit_type_ env function_returns)
           in
-          { value = {function_attributes; function_params; function_returns};
+          { value =
+              { function_attributes;
+                function_params;
+                function_returns;
+                function_is_type };
             span }
 
         method! visit_function_ env f =

--- a/lib/partial_evaluator.ml
+++ b/lib/partial_evaluator.ml
@@ -185,7 +185,8 @@ functor
                   in
                   FunctionCall
                     ( {value = Value (Function method_); span = call.intf_loc},
-                      args )
+                      args,
+                      method_.value.function_signature.value.function_is_type )
               | None ->
                   ice "Type-check bug" )
           | false ->
@@ -249,17 +250,17 @@ functor
           in
           UnionVariant (expr, new_id)
 
-        method! visit_FunctionCall env (f, args) =
+        method! visit_FunctionCall env (f, args, is_ty) =
           let f = self#visit_expr env f in
           let args = self#visit_list self#visit_expr env args in
           if
             is_immediate_expr !(ctx.scope) ctx.program
-              {value = FunctionCall (f, args); span = f.span}
+              {value = FunctionCall (f, args, is_ty); span = f.span}
           then
             Value
               (self#with_interpreter env f.span (fun inter ->
-                   inter#interpret_fc (f, args) ) )
-          else FunctionCall (f, args)
+                   inter#interpret_fc (f, args, is_ty) ) )
+          else FunctionCall (f, args, is_ty)
 
         method! visit_StructSigMethodCall env call =
           let st_sig_instance = self#visit_expr env call.st_sig_call_instance in
@@ -289,7 +290,8 @@ functor
               FunctionCall
                 ( { value = Value (Function method_);
                     span = call.st_sig_call_span },
-                  args )
+                  args,
+                  method_.value.function_signature.value.function_is_type )
           | false ->
               StructSigMethodCall
                 { call with

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -364,4 +364,20 @@ functor
                   ) ];
               additional_msg = [] }
             code
+      | `ExpectedTypeFunction (is_type_fn, span) ->
+          let diagnostic_msg =
+            if is_type_fn then
+              "Function should be called using `[]` brackets but called with \
+               `()` parens."
+            else
+              "Function should be called using `()` brackets but called with \
+               `[]` parens."
+          in
+          DiagnosticMsg.show f
+            { severity = `Error;
+              diagnostic_id = 1;
+              diagnostic_msg;
+              spans = [(span, "When calling this function")];
+              additional_msg = [] }
+            code
   end

--- a/lib/show.ml
+++ b/lib/show.ml
@@ -28,13 +28,13 @@ functor
       match ex.value with
       | Value v ->
           pp_value f v
-      | FunctionCall (fname, args) ->
+      | FunctionCall (fname, args, is_ty) ->
           pp_expr f fname ;
-          pp_print_string f "(" ;
+          pp_print_string f (if is_ty then "[" else "(") ;
           list_iter args
             ~f:(fun e -> pp_expr f e ; pp_print_string f ", ")
             ~flast:(fun e -> pp_expr f e) ;
-          pp_print_string f ")"
+          pp_print_string f (if is_ty then "]" else ")")
       | Reference (name, _) | ResolvedReference (name, _) ->
           pp_print_string f name.value
       | StructField (s, field, _) ->

--- a/lib/std/std.tact
+++ b/lib/std/std.tact
@@ -147,7 +147,7 @@ struct Int[bits: Integer] {
     }
   }
 
-  impl From(Integer) {
+  impl From[Integer] {
     fn from(i: Integer) -> Self {
       Self { value: i }
     }
@@ -178,7 +178,7 @@ struct Uint[bits: Integer] {
     }
   }
 
-  impl From(Integer) {
+  impl From[Integer] {
     fn from(i: Integer) -> Self {
       Self { value: i }
     }

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -120,6 +120,7 @@ functor
     and function_definition =
       { function_attributes : attribute list; [@sexp.list]
         name : ident located option; [@sexp.option]
+        is_type_function : bool; [@sexp.bool]
         params : function_param located list; [@sexp.list]
         returns : expr located option; [@sexp.option]
         function_body : function_body option; [@sexp.option]

--- a/lib/syntax.ml
+++ b/lib/syntax.ml
@@ -39,7 +39,9 @@ functor
         interface_members : binding located list [@sexp.list] }
 
     and function_call =
-      {fn : expr located; arguments : expr located list [@sexp.list]}
+      { fn : expr located;
+        arguments : expr located list; [@sexp.list]
+        is_type_func_call : bool [@sexp.bool] }
 
     and method_call =
       { receiver : expr located;

--- a/lib/type_check.ml
+++ b/lib/type_check.ml
@@ -174,8 +174,8 @@ functor
                 Value
                   (inter#interpret_fc
                      ( from_intf,
-                       [{value = Value (Type actual); span = actual_value.span}]
-                     ) )
+                       [{value = Value (Type actual); span = actual_value.span}],
+                       true ) )
               in
               let impl =
                 Program.get_uty_details program ty

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -369,7 +369,7 @@ let%expect_test "demo struct serializer" =
         val a: Int[32]
         val b: Int[16]
       }
-      let T_serializer = serializer(T);
+      let T_serializer = serializer[T];
 
       fn test() {
         let b = Builder.new();
@@ -789,7 +789,7 @@ let%expect_test "from interface" =
     {|
       struct Value {
         val a: Integer
-        impl From(Integer) {
+        impl From[Integer] {
           fn from(x: Integer) -> Self {
             Self{a: x}
           }

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -67,7 +67,8 @@ let%expect_test "Int[bits] constructor" =
                        ((res
                          (FunctionCall
                           ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                           ((Reference (s (StructType 7))) (Value (Integer 257)))
+                           false)))))
                       (DestructuringLet
                        ((destructuring_let ((slice slice) (value value)))
                         (destructuring_let_expr (Reference (res (StructType 5))))
@@ -95,7 +96,8 @@ let%expect_test "Int[bits] constructor" =
                        ((Reference (builder (StructType 3)))
                         (StructField
                          ((Reference (self (StructType 125))) value IntegerType))
-                        (Value (Integer 257))))))))))
+                        (Value (Integer 257)))
+                       false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
@@ -123,7 +125,8 @@ let%expect_test "Int[bits] constructor" =
                           ((Reference (builder (StructType 3)))
                            (StructField
                             ((Reference (self (StructType 125))) value IntegerType))
-                           (Value (Integer 257)))))))))))))
+                           (Value (Integer 257)))
+                          false))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
@@ -138,7 +141,8 @@ let%expect_test "Int[bits] constructor" =
                             (FunctionCall
                              ((ResolvedReference (load_int <opaque>))
                               ((Reference (s (StructType 7)))
-                               (Value (Integer 257))))))))
+                               (Value (Integer 257)))
+                              false)))))
                          (DestructuringLet
                           ((destructuring_let ((slice slice) (value value)))
                            (destructuring_let_expr
@@ -203,7 +207,8 @@ let%expect_test "Int[bits] serializer" =
                    (FunctionCall
                     ((ResolvedReference (serialize <opaque>))
                      ((ResolvedReference (i <opaque>))
-                      (Reference (b (StructType 3)))))))))))))))))
+                      (Reference (b (StructType 3))))
+                     false)))))))))))))
         (structs
          ((126
            ((struct_fields
@@ -250,7 +255,8 @@ let%expect_test "Int[bits] serializer" =
                        ((res
                          (FunctionCall
                           ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                           ((Reference (s (StructType 7))) (Value (Integer 32)))
+                           false)))))
                       (DestructuringLet
                        ((destructuring_let ((slice slice) (value value)))
                         (destructuring_let_expr (Reference (res (StructType 5))))
@@ -278,7 +284,8 @@ let%expect_test "Int[bits] serializer" =
                        ((Reference (builder (StructType 3)))
                         (StructField
                          ((Reference (self (StructType 125))) value IntegerType))
-                        (Value (Integer 32))))))))))
+                        (Value (Integer 32)))
+                       false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
@@ -306,7 +313,8 @@ let%expect_test "Int[bits] serializer" =
                           ((Reference (builder (StructType 3)))
                            (StructField
                             ((Reference (self (StructType 125))) value IntegerType))
-                           (Value (Integer 32)))))))))))))
+                           (Value (Integer 32)))
+                          false))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
@@ -320,7 +328,8 @@ let%expect_test "Int[bits] serializer" =
                           ((res
                             (FunctionCall
                              ((ResolvedReference (load_int <opaque>))
-                              ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                              ((Reference (s (StructType 7))) (Value (Integer 32)))
+                              false)))))
                          (DestructuringLet
                           ((destructuring_let ((slice slice) (value value)))
                            (destructuring_let_expr
@@ -382,7 +391,8 @@ let%expect_test "demo struct serializer" =
                (Fn
                 (Block
                  ((Let
-                   ((b (FunctionCall ((ResolvedReference (new <opaque>)) ())))))
+                   ((b
+                     (FunctionCall ((ResolvedReference (new <opaque>)) () false)))))
                   (Return
                    (FunctionCall
                     ((ResolvedReference (T_serializer <opaque>))
@@ -399,7 +409,8 @@ let%expect_test "demo struct serializer" =
                             (Struct
                              ((Value (Type (StructType 127)))
                               ((value (Value (Integer 1))))))))))))
-                      (Reference (b (StructType 3)))))))))))))))
+                      (Reference (b (StructType 3))))
+                     false)))))))))))
           (T_serializer
            (Value
             (Function
@@ -427,10 +438,12 @@ let%expect_test "demo struct serializer" =
                                 (StructField
                                  ((Reference (self (StructType 125))) value
                                   IntegerType))
-                                (Value (Integer 32)))))))))))
+                                (Value (Integer 32)))
+                               false))))))))
                        ((StructField
                          ((Reference (self (StructType 130))) a (StructType 125)))
-                        (Reference (b (StructType 3)))))))))
+                        (Reference (b (StructType 3))))
+                       false)))))
                   (Let
                    ((b
                      (FunctionCall
@@ -449,10 +462,12 @@ let%expect_test "demo struct serializer" =
                                 (StructField
                                  ((Reference (self (StructType 127))) value
                                   IntegerType))
-                                (Value (Integer 16)))))))))))
+                                (Value (Integer 16)))
+                               false))))))))
                        ((StructField
                          ((Reference (self (StructType 130))) b (StructType 127)))
-                        (Reference (b (StructType 3)))))))))
+                        (Reference (b (StructType 3))))
+                       false)))))
                   (Return (Reference (b (StructType 3))))))))))))
           (T (Value (Type (StructType 130))))))
         (structs
@@ -507,7 +522,8 @@ let%expect_test "demo struct serializer" =
                        ((res
                          (FunctionCall
                           ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 7))) (Value (Integer 16))))))))
+                           ((Reference (s (StructType 7))) (Value (Integer 16)))
+                           false)))))
                       (DestructuringLet
                        ((destructuring_let ((slice slice) (value value)))
                         (destructuring_let_expr (Reference (res (StructType 5))))
@@ -535,7 +551,8 @@ let%expect_test "demo struct serializer" =
                        ((Reference (builder (StructType 3)))
                         (StructField
                          ((Reference (self (StructType 127))) value IntegerType))
-                        (Value (Integer 16))))))))))
+                        (Value (Integer 16)))
+                       false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
@@ -563,7 +580,8 @@ let%expect_test "demo struct serializer" =
                           ((Reference (builder (StructType 3)))
                            (StructField
                             ((Reference (self (StructType 127))) value IntegerType))
-                           (Value (Integer 16)))))))))))))
+                           (Value (Integer 16)))
+                          false))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
@@ -577,7 +595,8 @@ let%expect_test "demo struct serializer" =
                           ((res
                             (FunctionCall
                              ((ResolvedReference (load_int <opaque>))
-                              ((Reference (s (StructType 7))) (Value (Integer 16))))))))
+                              ((Reference (s (StructType 7))) (Value (Integer 16)))
+                              false)))))
                          (DestructuringLet
                           ((destructuring_let ((slice slice) (value value)))
                            (destructuring_let_expr
@@ -652,7 +671,8 @@ let%expect_test "demo struct serializer" =
                        ((res
                          (FunctionCall
                           ((ResolvedReference (load_int <opaque>))
-                           ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                           ((Reference (s (StructType 7))) (Value (Integer 32)))
+                           false)))))
                       (DestructuringLet
                        ((destructuring_let ((slice slice) (value value)))
                         (destructuring_let_expr (Reference (res (StructType 5))))
@@ -680,7 +700,8 @@ let%expect_test "demo struct serializer" =
                        ((Reference (builder (StructType 3)))
                         (StructField
                          ((Reference (self (StructType 125))) value IntegerType))
-                        (Value (Integer 32))))))))))
+                        (Value (Integer 32)))
+                       false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
@@ -708,7 +729,8 @@ let%expect_test "demo struct serializer" =
                           ((Reference (builder (StructType 3)))
                            (StructField
                             ((Reference (self (StructType 125))) value IntegerType))
-                           (Value (Integer 32)))))))))))))
+                           (Value (Integer 32)))
+                          false))))))))))
                 ((impl_interface -2)
                  (impl_methods
                   ((deserialize
@@ -722,7 +744,8 @@ let%expect_test "demo struct serializer" =
                           ((res
                             (FunctionCall
                              ((ResolvedReference (load_int <opaque>))
-                              ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                              ((Reference (s (StructType 7))) (Value (Integer 32)))
+                              false)))))
                          (DestructuringLet
                           ((destructuring_let ((slice slice) (value value)))
                            (destructuring_let_expr
@@ -859,7 +882,7 @@ let%expect_test "tensor2" =
                  ((x
                    (FunctionCall
                     ((ResolvedReference (builtin_divmod <opaque>))
-                     ((Value (Integer 10)) (Value (Integer 2))))))))))))))))
+                     ((Value (Integer 10)) (Value (Integer 2))) false)))))))))))))
         (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -892,12 +915,13 @@ let%expect_test "slice api" =
                    ((slice
                      (FunctionCall
                       ((ResolvedReference (parse <opaque>))
-                       ((Reference (cell (StructType 1)))))))))
+                       ((Reference (cell (StructType 1)))) false)))))
                   (Let
                    ((result
                      (FunctionCall
                       ((ResolvedReference (load_int <opaque>))
-                       ((Reference (slice (StructType 7))) (Value (Integer 10))))))))
+                       ((Reference (slice (StructType 7))) (Value (Integer 10)))
+                       false)))))
                   (Let
                    ((slice2
                      (FunctionCall
@@ -912,7 +936,8 @@ let%expect_test "slice api" =
                              ((Reference (result (StructType 5))) slice
                               (StructType 7))))))))
                        ((StructField
-                         ((Reference (result (StructType 5))) slice (StructType 7)))))))))
+                         ((Reference (result (StructType 5))) slice (StructType 7))))
+                       false)))))
                   (Let
                    ((int
                      (FunctionCall
@@ -927,7 +952,8 @@ let%expect_test "slice api" =
                              ((Reference (result (StructType 5))) value
                               IntegerType)))))))
                        ((StructField
-                         ((Reference (result (StructType 5))) value IntegerType))))))))))))))))))
+                         ((Reference (result (StructType 5))) value IntegerType)))
+                       false)))))))))))))))
         (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -972,7 +998,8 @@ let%expect_test "deserializer" =
                                (FunctionCall
                                 ((ResolvedReference (load_int <opaque>))
                                  ((Reference (s (StructType 7)))
-                                  (Value (Integer 9))))))))
+                                  (Value (Integer 9)))
+                                 false)))))
                             (DestructuringLet
                              ((destructuring_let ((slice slice) (value value)))
                               (destructuring_let_expr
@@ -988,7 +1015,7 @@ let%expect_test "deserializer" =
                                    (Struct
                                     ((Value (Type (StructType 25)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
-                     ((Reference (slice (StructType 7)))))))
+                     ((Reference (slice (StructType 7)))) false)))
                   (destructuring_let_rest false)))
                 (DestructuringLet
                  ((destructuring_let ((slice slice) (value value2)))
@@ -1007,7 +1034,8 @@ let%expect_test "deserializer" =
                                (FunctionCall
                                 ((ResolvedReference (load_int <opaque>))
                                  ((Reference (s (StructType 7)))
-                                  (Value (Integer 256))))))))
+                                  (Value (Integer 256)))
+                                 false)))))
                             (DestructuringLet
                              ((destructuring_let ((slice slice) (value value)))
                               (destructuring_let_expr
@@ -1023,7 +1051,7 @@ let%expect_test "deserializer" =
                                    (Struct
                                     ((Value (Type (StructType 38)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
-                     ((Reference (slice (StructType 7)))))))
+                     ((Reference (slice (StructType 7)))) false)))
                   (destructuring_let_rest false)))
                 (Return
                  (Value
@@ -1130,14 +1158,17 @@ let%expect_test "derive Serialize" =
                                           (StructField
                                            ((Reference (self (StructType 25)))
                                             value IntegerType))
-                                          (Value (Integer 9)))))))))))
+                                          (Value (Integer 9)))
+                                         false))))))))
                                  ((StructField
                                    ((Reference (self (StructType 126))) value1
                                     (StructType 25)))
-                                  (Reference (b (StructType 3)))))))))
+                                  (Reference (b (StructType 3))))
+                                 false)))))
                             (Return (Reference (b (StructType 3)))))))))))
                      ((Reference (self (StructType 126)))
-                      (Reference (b (StructType 3)))))))))))))
+                      (Reference (b (StructType 3))))
+                     false)))))))))
             (uty_impls
              (((impl_interface -1)
                (impl_methods
@@ -1179,14 +1210,17 @@ let%expect_test "derive Serialize" =
                                              (StructField
                                               ((Reference (self (StructType 25)))
                                                value IntegerType))
-                                             (Value (Integer 9)))))))))))
+                                             (Value (Integer 9)))
+                                            false))))))))
                                     ((StructField
                                       ((Reference (self (StructType 126))) value1
                                        (StructType 25)))
-                                     (Reference (b (StructType 3)))))))))
+                                     (Reference (b (StructType 3))))
+                                    false)))))
                                (Return (Reference (b (StructType 3)))))))))))
                         ((Reference (self (StructType 126)))
-                         (Reference (b (StructType 3))))))))))))))))
+                         (Reference (b (StructType 3))))
+                        false))))))))))))
             (uty_id 126) (uty_base_id 125)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
@@ -1244,7 +1278,8 @@ let%expect_test "Deserialize Unions" =
                                  ((StructField
                                    ((Reference (self (StructType 7))) s
                                     (BuiltinType Slice)))
-                                  (Reference (bits IntegerType))))))))
+                                  (Reference (bits IntegerType)))
+                                 false)))))
                             (Let
                              ((slice
                                (Value
@@ -1266,9 +1301,10 @@ let%expect_test "Deserialize Unions" =
                                 ((slice
                                   (FunctionCall
                                    ((ResolvedReference (believe_me <opaque>))
-                                    ((Reference (slice (StructType 7)))))))
+                                    ((Reference (slice (StructType 7)))) false)))
                                  (value (Reference (int IntegerType)))))))))))))))
-                     ((Reference (slice (StructType 7))) (Value (Integer 1))))))))
+                     ((Reference (slice (StructType 7))) (Value (Integer 1)))
+                     false)))))
                 (If
                  ((if_condition
                    (FunctionCall
@@ -1287,7 +1323,8 @@ let%expect_test "Deserialize Unions" =
                                (Reference (i2 IntegerType))))))))))))
                      ((StructField
                        ((Reference (res_discr (StructType 5))) value IntegerType))
-                      (Value (Integer 0))))))
+                      (Value (Integer 0)))
+                     false)))
                   (if_then
                    (Block
                     ((Let
@@ -1306,7 +1343,8 @@ let%expect_test "Deserialize Unions" =
                                     (FunctionCall
                                      ((ResolvedReference (load_int <opaque>))
                                       ((Reference (s (StructType 7)))
-                                       (Value (Integer 8))))))))
+                                       (Value (Integer 8)))
+                                      false)))))
                                  (DestructuringLet
                                   ((destructuring_let
                                     ((slice slice) (value value)))
@@ -1326,7 +1364,8 @@ let%expect_test "Deserialize Unions" =
                                             (Reference (value IntegerType))))))))))))))))))))
                           ((StructField
                             ((Reference (res_discr (StructType 5))) slice
-                             (StructType 7)))))))))
+                             (StructType 7))))
+                          false)))))
                      (Return
                       (FunctionCall
                        ((Value
@@ -1348,7 +1387,8 @@ let%expect_test "Deserialize Unions" =
                            (StructType 7)))
                          (StructField
                           ((Reference (res (StructType 129))) value
-                           (StructType 36))))))))))
+                           (StructType 36))))
+                        true))))))
                   (if_else
                    ((Block
                      ((Let
@@ -1371,7 +1411,8 @@ let%expect_test "Deserialize Unions" =
                                        ((StructField
                                          ((Reference (self (StructType 7))) s
                                           (BuiltinType Slice)))
-                                        (Reference (bits IntegerType))))))))
+                                        (Reference (bits IntegerType)))
+                                       false)))))
                                   (Let
                                    ((slice
                                      (Value
@@ -1394,12 +1435,14 @@ let%expect_test "Deserialize Unions" =
                                         (FunctionCall
                                          ((ResolvedReference
                                            (believe_me <opaque>))
-                                          ((Reference (slice (StructType 7)))))))
+                                          ((Reference (slice (StructType 7))))
+                                          false)))
                                        (value (Reference (int IntegerType)))))))))))))))
                            ((StructField
                              ((Reference (res_discr (StructType 5))) slice
                               (StructType 7)))
-                            (Value (Integer 1))))))))
+                            (Value (Integer 1)))
+                           false)))))
                       (If
                        ((if_condition
                          (FunctionCall
@@ -1420,7 +1463,8 @@ let%expect_test "Deserialize Unions" =
                            ((StructField
                              ((Reference (res_discr (StructType 5))) value
                               IntegerType))
-                            (Value (Integer 1))))))
+                            (Value (Integer 1)))
+                           false)))
                         (if_then
                          (Block
                           ((Let
@@ -1440,7 +1484,8 @@ let%expect_test "Deserialize Unions" =
                                            ((ResolvedReference
                                              (load_int <opaque>))
                                             ((Reference (s (StructType 7)))
-                                             (Value (Integer 9))))))))
+                                             (Value (Integer 9)))
+                                            false)))))
                                        (DestructuringLet
                                         ((destructuring_let
                                           ((slice slice) (value value)))
@@ -1461,7 +1506,8 @@ let%expect_test "Deserialize Unions" =
                                                   (Reference (value IntegerType))))))))))))))))))))
                                 ((StructField
                                   ((Reference (res_discr (StructType 5))) slice
-                                   (StructType 7)))))))))
+                                   (StructType 7))))
+                                false)))))
                            (Return
                             (FunctionCall
                              ((Value
@@ -1483,7 +1529,8 @@ let%expect_test "Deserialize Unions" =
                                  (StructType 7)))
                                (StructField
                                 ((Reference (res (StructType 129))) value
-                                 (StructType 25))))))))))
+                                 (StructType 25))))
+                              true))))))
                         (if_else
                          ((Expr
                            (Primitive

--- a/test/codegen_func.ml
+++ b/test/codegen_func.ml
@@ -216,11 +216,11 @@ let%expect_test "demo struct serializer" =
         val a: Int[32]
         val b: Int[16]
       }
-      let T_serializer = serializer(T);
+      let T_serializer = serializer[T];
 
       fn test() {
         let b = Builder.new();
-        T_serializer(T{a: Int(32).new(0), b: Int(16).new(1)}, b);
+        T_serializer(T{a: Int[32].new(0), b: Int[16].new(1)}, b);
       }
     |}
   in
@@ -372,7 +372,7 @@ let%expect_test "demo struct serializer 2" =
         val a: Int[32]
         val b: Int[16]
       }
-      let serialize_foo = serializer(Foo);
+      let serialize_foo = serializer[Foo];
 
       fn test() -> Builder {
         let b = Builder.new();
@@ -536,21 +536,21 @@ let%expect_test "true and false" =
   pp_codegen source ~strip_defaults:true ;
   [%expect
     {|
-         forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
-           (Value1 value, _) = tensor;
-           return value;
-         }
-         forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
-           (_, Value2 value) = tensor;
-           return value;
-         }
-         int test(int flag) {
-           if (flag) {
-           return 0;
-         } else
-         {
-           return -1;
-         }} |}]
+    forall Value1, Value2 -> Value1 tensor2_value1((Value1, Value2) tensor) {
+      (Value1 value, _) = tensor;
+      return value;
+    }
+    forall Value1, Value2 -> Value2 tensor2_value2((Value1, Value2) tensor) {
+      (_, Value2 value) = tensor;
+      return value;
+    }
+    int test(int flag) {
+      if (flag) {
+      return 0;
+    } else
+    {
+      return -1;
+    }} |}]
 
 let%expect_test "if/then/else" =
   let source =

--- a/test/errors.ml
+++ b/test/errors.ml
@@ -276,7 +276,7 @@ let%expect_test "uninterpretable statement" =
                                (ResolvedReference
                                 (((span (pos pos)) (value builtin_begin_cell))
                                  <opaque>))))
-                             ())))))))))))))))))))
+                             () false)))))))))))))))))))
           (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
           (struct_signs (0 ())) (union_signs (0 ())) (attr_executors <opaque>))) |}]
 

--- a/test/errors.ml
+++ b/test/errors.ml
@@ -126,7 +126,7 @@ let%expect_test "duplicate variant" =
         case Integer
         case T
       }
-      let _ = Test2(Integer);
+      let _ = Test2[Integer];
     |}
   in
   pp source ;
@@ -140,7 +140,7 @@ let%expect_test "duplicate variant" =
     Error[1]: Duplicate variant with type Integer
     File: "":11:14
        |
-    11 |       let _ = Test2(Integer);
+    11 |       let _ = Test2[Integer];
        |               ^^^^^^^^^^^^^ Duplicated variant in this union |}]
 
 let%expect_test "type errors" =
@@ -341,3 +341,20 @@ let%expect_test "Case Not Found Error" =
       |
     9 |           case Int[123] _ => { return 123; }
       |                         ^ Type of this variable is not found in the condition union |}]
+
+let%expect_test "Expected Type Function" =
+  let source =
+    {|
+      union Test[X: Type] {}
+
+      let _ = Test(Integer);
+    |}
+  in
+  pp source ;
+  [%expect
+    {|
+    Error[1]: Function should be called using `[]` brackets but called with `()` parens.
+    File: "":4:14
+      |
+    4 |       let _ = Test(Integer);
+      |               ^^^^^^^^^^^^ When calling this function |}]

--- a/test/immediacy_check.ml
+++ b/test/immediacy_check.ml
@@ -212,7 +212,8 @@ let%expect_test "Immediacy Checks Function Call WITHOUT Primitive" =
                                    bl
                                    @@ Expr (bl @@ Reference (bl "arg", VoidType))
                                  ] ) } ) ),
-           [] )
+           [],
+           false )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
   [%expect {| true |}]
@@ -242,7 +243,8 @@ let%expect_test "Immediacy Checks Function Call WITH Primitive" =
                                         @@ Primitive
                                              (Prim {name = ""; exprs = []}) ) ]
                             ) } ) ),
-           [] )
+           [],
+           false )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
   [%expect {| false |}]
@@ -288,7 +290,8 @@ let%expect_test "Immediacy Checks Function Call that contains function with \
                             ( bl
                             @@ Block [bl @@ Let [(bl "_", f_with_primitive)]] )
                       } ) ),
-           [] )
+           [],
+           false )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
   [%expect {| true |}]
@@ -316,9 +319,11 @@ let%expect_test "Immediacy Checks Function Call that Call function with \
                                  [ bl
                                    @@ Expr
                                         ( bl
-                                        @@ FunctionCall (f_with_primitive, [])
-                                        ) ] ) } ) ),
-           [] )
+                                        @@ FunctionCall
+                                             (f_with_primitive, [], false) ) ]
+                            ) } ) ),
+           [],
+           false )
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
   [%expect {| false |}]
@@ -350,7 +355,7 @@ let%expect_test "Immediacy Checks Struct Sig" =
 let%expect_test "Immediacy Checks Self Type" =
   let scope = [] in
   let expr =
-    bl @@ FunctionCall (bl @@ Value Void, [bl @@ Value (Type SelfType)])
+    bl @@ FunctionCall (bl @@ Value Void, [bl @@ Value (Type SelfType)], false)
   in
   pp_sexp @@ sexp_of_bool @@ is_immediate_expr scope (default_program ()) expr ;
   [%expect {| false |}]

--- a/test/immediacy_check.ml
+++ b/test/immediacy_check.ml
@@ -105,6 +105,7 @@ let%expect_test "Immediacy Checks Empty Function" =
             @@ { function_signature =
                    bl
                    @@ { function_attributes = [];
+                        function_is_type = false;
                         function_params = [];
                         function_returns = VoidType };
                  function_impl = Fn (bl @@ Block []) } ) )
@@ -123,6 +124,7 @@ let%expect_test "Immediacy Checks Function Argument" =
                    bl
                    @@ { function_attributes = [];
                         function_params = [(bl "arg", VoidType)];
+                        function_is_type = false;
                         function_returns = VoidType };
                  function_impl =
                    Fn
@@ -144,6 +146,7 @@ let%expect_test "Immediacy Checks Let Argument" =
                    bl
                    @@ { function_attributes = [];
                         function_params = [];
+                        function_is_type = false;
                         function_returns = VoidType };
                  function_impl =
                    Fn
@@ -167,6 +170,7 @@ let%expect_test "Immediacy Checks Destructuring Let" =
                    bl
                    @@ { function_attributes = [];
                         function_params = [];
+                        function_is_type = false;
                         function_returns = VoidType };
                  function_impl =
                    Fn
@@ -198,6 +202,7 @@ let%expect_test "Immediacy Checks Function Call WITHOUT Primitive" =
                           bl
                           @@ { function_attributes = [];
                                function_params = [];
+                               function_is_type = false;
                                function_returns = VoidType };
                         function_impl =
                           Fn
@@ -225,6 +230,7 @@ let%expect_test "Immediacy Checks Function Call WITH Primitive" =
                           bl
                           @@ { function_attributes = [];
                                function_params = [];
+                               function_is_type = false;
                                function_returns = VoidType };
                         function_impl =
                           Fn
@@ -250,6 +256,7 @@ let f_with_primitive =
                  bl
                  @@ { function_attributes = [];
                       function_params = [];
+                      function_is_type = false;
                       function_returns = VoidType };
                function_impl =
                  Fn
@@ -273,6 +280,7 @@ let%expect_test "Immediacy Checks Function Call that contains function with \
                    @@ { function_signature =
                           bl
                           @@ { function_attributes = [];
+                               function_is_type = false;
                                function_params = [];
                                function_returns = VoidType };
                         function_impl =
@@ -298,6 +306,7 @@ let%expect_test "Immediacy Checks Function Call that Call function with \
                    @@ { function_signature =
                           bl
                           @@ { function_attributes = [];
+                               function_is_type = false;
                                function_params = [];
                                function_returns = VoidType };
                         function_impl =
@@ -324,6 +333,7 @@ let%expect_test "Immediacy Checks Top Level Fn With Sign" =
             @@ { function_signature =
                    bl
                    @@ { function_attributes = [];
+                        function_is_type = false;
                         function_params = [];
                         function_returns = StructSig 0 };
                  function_impl = Fn (bl @@ Block []) } ) )

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -9,6 +9,7 @@ let add_bin_op_intf p =
         [ ( "op",
             bl
               { function_attributes = [];
+                function_is_type = false;
                 function_params =
                   [(bl "left", IntegerType); (bl "right", IntegerType)];
                 function_returns = IntegerType } ) ] }
@@ -1284,7 +1285,7 @@ let%expect_test "parametric struct instantiation" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((A (TypeN 0))))
+             ((function_is_type) (function_params ((A (TypeN 0))))
               (function_returns (StructSig 83))))
             (function_impl
              (Fn
@@ -3630,7 +3631,8 @@ let%expect_test "unions duplicate variant" =
                         ((Value
                           (Function
                            ((function_signature
-                             ((function_params ((T (TypeN 0))))
+                             ((function_is_type)
+                              (function_params ((T (TypeN 0))))
                               (function_returns HoleType)))
                             (function_impl (BuiltinFn (<fun> <opaque>))))))
                          ((Value (Type (ExprType (Reference (T (TypeN 0))))))))))
@@ -5279,7 +5281,7 @@ let%expect_test "struct signatures" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((n IntegerType)))
+             ((function_is_type) (function_params ((n IntegerType)))
               (function_returns
                (FunctionType
                 ((function_params
@@ -5316,7 +5318,7 @@ let%expect_test "struct signatures" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((bits IntegerType)))
+             ((function_is_type) (function_params ((bits IntegerType)))
               (function_returns (StructSig 83))))
             (function_impl
              (Fn
@@ -5436,7 +5438,8 @@ let%expect_test "Deserilize intf with constraints" =
                            ((Value
                              (Function
                               ((function_signature
-                                ((function_params ((X (TypeN 0))))
+                                ((function_is_type)
+                                 (function_params ((X (TypeN 0))))
                                  (function_returns (StructSig 1))))
                                (function_impl
                                 (Fn
@@ -5458,7 +5461,7 @@ let%expect_test "Deserilize intf with constraints" =
                        ((Value
                          (Function
                           ((function_signature
-                            ((function_params ((X (TypeN 0))))
+                            ((function_is_type) (function_params ((X (TypeN 0))))
                              (function_returns (StructSig 1))))
                            (function_impl
                             (Fn
@@ -5476,7 +5479,8 @@ let%expect_test "Deserilize intf with constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((X (TypeN 0)))) (function_returns (StructSig 1))))
+             ((function_is_type) (function_params ((X (TypeN 0))))
+              (function_returns (StructSig 1))))
             (function_impl
              (Fn
               (Return
@@ -5529,7 +5533,7 @@ let%expect_test "Deserilize intf with constraints" =
                  ((Value
                    (Function
                     ((function_signature
-                      ((function_params ((X (TypeN 0))))
+                      ((function_is_type) (function_params ((X (TypeN 0))))
                        (function_returns (StructSig 1))))
                      (function_impl
                       (Fn
@@ -5598,7 +5602,7 @@ let%expect_test "Interface inner constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((X (InterfaceType 0))))
+             ((function_is_type) (function_params ((X (InterfaceType 0))))
               (function_returns
                (FunctionType
                 ((function_params
@@ -5655,7 +5659,7 @@ let%expect_test "Interface inner constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((X (InterfaceType 0))))
+             ((function_is_type) (function_params ((X (InterfaceType 0))))
               (function_returns (StructSig 1))))
             (function_impl
              (Fn
@@ -5902,7 +5906,7 @@ let%expect_test "attributes" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((X IntegerType)))
+             ((function_is_type) (function_params ((X IntegerType)))
               (function_returns (StructSig 84))))
             (function_impl
              (Fn

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -2651,9 +2651,9 @@ let%expect_test "type check error" =
   let source =
     {|
       {
-        fn foo(x: Int(99)) { return x; }
+        fn foo(x: Int[99]) { return x; }
 
-        let a = foo(Int(10).new(1))
+        let a = foo(Int[10].new(1))
       }
     |}
   in
@@ -3080,8 +3080,8 @@ let%expect_test "implement interface op" =
 let%expect_test "serializer inner struct" =
   let source =
     {|
-      struct Inner { val x: Int(32) }
-      struct Outer { val y: Int(32) val z: Inner }
+      struct Inner { val x: Int[32] }
+      struct Outer { val y: Int[32] val z: Inner }
       let serialize_outer = serializer[Outer];
     |}
   in
@@ -3342,7 +3342,7 @@ let%expect_test "dependent types" =
         f
       }
       fn test(Y: Type) {
-        identity[Y]
+        identity(Y)
       }
     |}
   in
@@ -3365,7 +3365,7 @@ let%expect_test "dependent types" =
               (Return
                (FunctionCall
                 ((ResolvedReference (identity <opaque>))
-                 ((Reference (Y (TypeN 0)))) true)))))))))
+                 ((Reference (Y (TypeN 0)))) false)))))))))
         (identity
          (Value
           (Function
@@ -3402,7 +3402,7 @@ let%expect_test "TypeN" =
   let source =
     {|
       fn id(X: Type) { X }
-      let must_fail = id[Type];
+      let must_fail = id(Type);
     |}
   in
   pp_compile source ;
@@ -3650,11 +3650,9 @@ let%expect_test "union variants constructing" =
 let%expect_test "unions duplicate variant" =
   let source =
     {|
-      fn Test(T: Type) {
-        union {
-          case Integer
-          case T
-        }
+      union Test[T: Type] {
+        case Integer
+        case T
       }
       let a = Test[builtin_Builder]; // should be OK
       let b = Test[Integer]; // should fail
@@ -3670,7 +3668,8 @@ let%expect_test "unions duplicate variant" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (TypeN 0)))) (function_returns (UnionSig 5))))
+             ((function_is_type) (function_params ((T (TypeN 0))))
+              (function_returns (UnionSig 5))))
             (function_impl
              (Fn
               (Return
@@ -4175,11 +4174,11 @@ let%expect_test "methods monomorphization" =
           fn id(self: Self, x: X) -> X { x }
         }
       }
-      let foo = Foo[Integer] {};
+      let foo = Foo(Integer) {};
       let x = foo.id(10);
 
       struct Empty {}
-      let foo_empty = Foo[Empty] {};
+      let foo_empty = Foo(Empty) {};
       let y = foo_empty.id(Empty{});
     |}
   in
@@ -5358,7 +5357,7 @@ let%expect_test "struct signatures" =
            Self { value: i }
          }
        }
-       fn extract_value[n: Integer](x: Int2(n)) -> Integer {
+       fn extract_value[n: Integer](x: Int2[n]) -> Integer {
          x.value
        }
        let five = extract_value[10](Int2[10].new(5));
@@ -5383,7 +5382,7 @@ let%expect_test "struct signatures" =
                     (ExprType
                      (FunctionCall
                       ((ResolvedReference (Int2 <opaque>))
-                       ((Reference (n IntegerType))) false))))))
+                       ((Reference (n IntegerType))) true))))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -5395,7 +5394,7 @@ let%expect_test "struct signatures" =
                       (ExprType
                        (FunctionCall
                         ((ResolvedReference (Int2 <opaque>))
-                         ((Reference (n IntegerType))) false))))))
+                         ((Reference (n IntegerType))) true))))))
                    (function_returns IntegerType)))
                  (function_impl
                   (Fn
@@ -5406,7 +5405,7 @@ let%expect_test "struct signatures" =
                         (ExprType
                          (FunctionCall
                           ((ResolvedReference (Int2 <opaque>))
-                           ((Reference (n IntegerType))) false)))))
+                           ((Reference (n IntegerType))) true)))))
                       value IntegerType))))))))))))))
         (Int2
          (Value
@@ -5485,7 +5484,7 @@ let%expect_test "Deserilize intf with constraints" =
     {|
       struct Container[X: Type] { val x: X }
       interface Deserialize2 {
-        fn deserialize() -> Container(Self)
+        fn deserialize() -> Container[Self]
       }
       fn test(Y: Deserialize2) -> Y {
         let v = Y.deserialize();
@@ -5544,7 +5543,7 @@ let%expect_test "Deserilize intf with constraints" =
                                     (mk_struct_details
                                      ((mk_methods ()) (mk_impls ()) (mk_id 0)
                                       (mk_sig 1) (mk_span <opaque>)))))))))))
-                            ((ResolvedReference (Self <opaque>))) false)))))))
+                            ((ResolvedReference (Self <opaque>))) true)))))))
                      (intf_args ()) (intf_loc <opaque>))))))
                 (Return
                  (StructField
@@ -5566,7 +5565,7 @@ let%expect_test "Deserilize intf with constraints" =
                                 (mk_struct_details
                                  ((mk_methods ()) (mk_impls ()) (mk_id 0)
                                   (mk_sig 1) (mk_span <opaque>)))))))))))
-                        ((ResolvedReference (Self <opaque>))) false)))))
+                        ((ResolvedReference (Self <opaque>))) true)))))
                    x (ExprType (Reference (Y (InterfaceType 1)))))))))))))))
         (Deserialize2 (Value (Type (InterfaceType 1))))
         (Container
@@ -5637,7 +5636,7 @@ let%expect_test "Deserilize intf with constraints" =
                           (mk_struct_details
                            ((mk_methods ()) (mk_impls ()) (mk_id 0) (mk_sig 1)
                             (mk_span <opaque>)))))))))))
-                  ((ResolvedReference (Self <opaque>))) false))))))))))))
+                  ((ResolvedReference (Self <opaque>))) true))))))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (4

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -133,7 +133,8 @@ let%expect_test "scope resolution" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -161,7 +162,8 @@ let%expect_test "scope resolution" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -189,7 +191,8 @@ let%expect_test "scope resolution" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -204,7 +207,8 @@ let%expect_test "scope resolution" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -292,7 +296,8 @@ let%expect_test "binding resolution" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -320,7 +325,8 @@ let%expect_test "binding resolution" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -348,7 +354,8 @@ let%expect_test "binding resolution" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -363,7 +370,8 @@ let%expect_test "binding resolution" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -465,7 +473,8 @@ let%expect_test "scope resolution after let binding" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -493,7 +502,8 @@ let%expect_test "scope resolution after let binding" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -521,7 +531,8 @@ let%expect_test "scope resolution after let binding" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -536,7 +547,8 @@ let%expect_test "scope resolution after let binding" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -628,7 +640,8 @@ let%expect_test "basic struct definition" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -656,7 +669,8 @@ let%expect_test "basic struct definition" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -684,7 +698,8 @@ let%expect_test "basic struct definition" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -699,7 +714,8 @@ let%expect_test "basic struct definition" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -807,7 +823,8 @@ let%expect_test "Tact function evaluation" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -835,7 +852,8 @@ let%expect_test "Tact function evaluation" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -863,7 +881,8 @@ let%expect_test "Tact function evaluation" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -878,7 +897,8 @@ let%expect_test "Tact function evaluation" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -976,7 +996,8 @@ let%expect_test "struct definition" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -1004,7 +1025,8 @@ let%expect_test "struct definition" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -1032,7 +1054,8 @@ let%expect_test "struct definition" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -1047,7 +1070,8 @@ let%expect_test "struct definition" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -1158,7 +1182,8 @@ let%expect_test "duplicate type field" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -1186,7 +1211,8 @@ let%expect_test "duplicate type field" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -1214,7 +1240,8 @@ let%expect_test "duplicate type field" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -1229,7 +1256,8 @@ let%expect_test "duplicate type field" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -1345,7 +1373,8 @@ let%expect_test "parametric struct instantiation" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -1373,7 +1402,8 @@ let%expect_test "parametric struct instantiation" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 126))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -1401,7 +1431,8 @@ let%expect_test "parametric struct instantiation" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 126))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -1416,7 +1447,8 @@ let%expect_test "parametric struct instantiation" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -1549,7 +1581,8 @@ let%expect_test "scoping that `let` introduces in code" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -1577,7 +1610,8 @@ let%expect_test "scoping that `let` introduces in code" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -1605,7 +1639,8 @@ let%expect_test "scoping that `let` introduces in code" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -1620,7 +1655,8 @@ let%expect_test "scoping that `let` introduces in code" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -1685,13 +1721,15 @@ let%expect_test "reference in function bodies" =
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
                      ((Reference (x (StructType 125)))
-                      (Reference (x (StructType 125)))))))))
+                      (Reference (x (StructType 125))))
+                     false)))))
                 (Let
                  ((b
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
                      ((Reference (a (StructType 125)))
-                      (Reference (a (StructType 125)))))))))))))))))
+                      (Reference (a (StructType 125))))
+                     false)))))))))))))
         (op
          (Value
           (Function
@@ -1745,7 +1783,8 @@ let%expect_test "reference in function bodies" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -1773,7 +1812,8 @@ let%expect_test "reference in function bodies" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -1801,7 +1841,8 @@ let%expect_test "reference in function bodies" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -1816,7 +1857,8 @@ let%expect_test "reference in function bodies" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2230,7 +2272,8 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 64)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2258,7 +2301,8 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 127))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 64)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -2286,7 +2330,8 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 127))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 64)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2300,7 +2345,8 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 64)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2375,7 +2421,8 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 32)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2403,7 +2450,8 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 32)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -2431,7 +2479,8 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 32)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2445,7 +2494,8 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 32)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2659,7 +2709,8 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 10))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 10)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2687,7 +2738,8 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 127))) value IntegerType))
-                      (Value (Integer 10))))))))))
+                      (Value (Integer 10)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -2715,7 +2767,8 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 127))) value IntegerType))
-                         (Value (Integer 10)))))))))))))
+                         (Value (Integer 10)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2729,7 +2782,8 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 10))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 10)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -2804,7 +2858,8 @@ let%expect_test "type check error" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 99))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 99)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -2832,7 +2887,8 @@ let%expect_test "type check error" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 99))))))))))
+                      (Value (Integer 99)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -2860,7 +2916,8 @@ let%expect_test "type check error" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 99)))))))))))))
+                         (Value (Integer 99)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -2874,7 +2931,8 @@ let%expect_test "type check error" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 99))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 99)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -3059,10 +3117,12 @@ let%expect_test "serializer inner struct" =
                               (StructField
                                ((Reference (self (StructType 125))) value
                                 IntegerType))
-                              (Value (Integer 32)))))))))))
+                              (Value (Integer 32)))
+                             false))))))))
                      ((StructField
                        ((Reference (self (StructType 130))) y (StructType 125)))
-                      (Reference (b (StructType 3)))))))))
+                      (Reference (b (StructType 3))))
+                     false)))))
                 (Return (Reference (b (StructType 3))))))))))))
         (Outer (Value (Type (StructType 130))))
         (Inner (Value (Type (StructType 128))))))
@@ -3122,7 +3182,8 @@ let%expect_test "serializer inner struct" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 32)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -3150,7 +3211,8 @@ let%expect_test "serializer inner struct" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 32)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -3178,7 +3240,8 @@ let%expect_test "serializer inner struct" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 32)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -3192,7 +3255,8 @@ let%expect_test "serializer inner struct" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 32)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -3301,7 +3365,7 @@ let%expect_test "dependent types" =
               (Return
                (FunctionCall
                 ((ResolvedReference (identity <opaque>))
-                 ((Reference (Y (TypeN 0)))))))))))))
+                 ((Reference (Y (TypeN 0)))) true)))))))))
         (identity
          (Value
           (Function
@@ -3437,7 +3501,8 @@ let%expect_test "union variants constructing" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 32)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -3465,7 +3530,8 @@ let%expect_test "union variants constructing" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 32)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -3493,7 +3559,8 @@ let%expect_test "union variants constructing" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 32)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -3507,7 +3574,8 @@ let%expect_test "union variants constructing" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 32)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -3635,7 +3703,8 @@ let%expect_test "unions duplicate variant" =
                               (function_params ((T (TypeN 0))))
                               (function_returns HoleType)))
                             (function_impl (BuiltinFn (<fun> <opaque>))))))
-                         ((Value (Type (ExprType (Reference (T (TypeN 0))))))))))
+                         ((Value (Type (ExprType (Reference (T (TypeN 0)))))))
+                         false)))
                       (mk_impl_methods
                        ((from
                          (Value
@@ -3786,7 +3855,8 @@ let%expect_test "unions" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 64)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -3814,7 +3884,8 @@ let%expect_test "unions" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 127))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 64)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -3842,7 +3913,8 @@ let%expect_test "unions" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 127))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 64)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -3856,7 +3928,8 @@ let%expect_test "unions" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 64)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -3931,7 +4004,8 @@ let%expect_test "unions" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -3959,7 +4033,8 @@ let%expect_test "unions" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -3987,7 +4062,8 @@ let%expect_test "unions" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4002,7 +4078,8 @@ let%expect_test "unions" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4267,7 +4344,8 @@ let%expect_test "switch statement" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 64)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4295,7 +4373,8 @@ let%expect_test "switch statement" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 127))) value IntegerType))
-                      (Value (Integer 64))))))))))
+                      (Value (Integer 64)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -4323,7 +4402,8 @@ let%expect_test "switch statement" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 127))) value IntegerType))
-                         (Value (Integer 64)))))))))))))
+                         (Value (Integer 64)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4337,7 +4417,8 @@ let%expect_test "switch statement" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 64))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 64)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4412,7 +4493,8 @@ let%expect_test "switch statement" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 32)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4440,7 +4522,8 @@ let%expect_test "switch statement" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 32)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -4468,7 +4551,8 @@ let%expect_test "switch statement" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 32)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4482,7 +4566,8 @@ let%expect_test "switch statement" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 32)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4591,7 +4676,7 @@ let%expect_test "partial evaluation of a function" =
               (Return
                (FunctionCall
                 ((ResolvedReference (left <opaque>))
-                 ((Value (Integer 10)) (Reference (y IntegerType))))))))))))
+                 ((Value (Integer 10)) (Reference (y IntegerType))) false)))))))))
         (test
          (Value
           (Function
@@ -4613,7 +4698,8 @@ let%expect_test "partial evaluation of a function" =
                    (Return
                     (FunctionCall
                      ((ResolvedReference (left <opaque>))
-                      ((Reference (x IntegerType)) (Reference (y IntegerType)))))))))))))))))
+                      ((Reference (x IntegerType)) (Reference (y IntegerType)))
+                      false))))))))))))))
         (left
          (Value
           (Function
@@ -4688,7 +4774,8 @@ let%expect_test "let binding with type" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 32)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4716,7 +4803,8 @@ let%expect_test "let binding with type" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 127))) value IntegerType))
-                      (Value (Integer 32))))))))))
+                      (Value (Integer 32)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -4744,7 +4832,8 @@ let%expect_test "let binding with type" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 127))) value IntegerType))
-                         (Value (Integer 32)))))))))))))
+                         (Value (Integer 32)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4758,7 +4847,8 @@ let%expect_test "let binding with type" =
                         ((res
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
-                            ((Reference (s (StructType 7))) (Value (Integer 32))))))))
+                            ((Reference (s (StructType 7))) (Value (Integer 32)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4833,7 +4923,8 @@ let%expect_test "let binding with type" =
                      ((res
                        (FunctionCall
                         ((ResolvedReference (load_int <opaque>))
-                         ((Reference (s (StructType 7))) (Value (Integer 257))))))))
+                         ((Reference (s (StructType 7))) (Value (Integer 257)))
+                         false)))))
                     (DestructuringLet
                      ((destructuring_let ((slice slice) (value value)))
                       (destructuring_let_expr (Reference (res (StructType 5))))
@@ -4861,7 +4952,8 @@ let%expect_test "let binding with type" =
                      ((Reference (builder (StructType 3)))
                       (StructField
                        ((Reference (self (StructType 125))) value IntegerType))
-                      (Value (Integer 257))))))))))
+                      (Value (Integer 257)))
+                     false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
@@ -4889,7 +4981,8 @@ let%expect_test "let binding with type" =
                         ((Reference (builder (StructType 3)))
                          (StructField
                           ((Reference (self (StructType 125))) value IntegerType))
-                         (Value (Integer 257)))))))))))))
+                         (Value (Integer 257)))
+                        false))))))))))
               ((impl_interface -2)
                (impl_methods
                 ((deserialize
@@ -4904,7 +4997,8 @@ let%expect_test "let binding with type" =
                           (FunctionCall
                            ((ResolvedReference (load_int <opaque>))
                             ((Reference (s (StructType 7)))
-                             (Value (Integer 257))))))))
+                             (Value (Integer 257)))
+                            false)))))
                        (DestructuringLet
                         ((destructuring_let ((slice slice) (value value)))
                          (destructuring_let_expr
@@ -4989,7 +5083,7 @@ let%expect_test "interface constraints" =
                      ((function_params ((self (StructType 127))))
                       (function_returns IntegerType)))
                     (function_impl (Fn (Return (Value (Integer 1))))))))
-                 ((Reference (t (StructType 127)))))))))))))
+                 ((Reference (t (StructType 127)))) false)))))))))
         (test
          (Value
           (Function
@@ -5289,7 +5383,7 @@ let%expect_test "struct signatures" =
                     (ExprType
                      (FunctionCall
                       ((ResolvedReference (Int2 <opaque>))
-                       ((Reference (n IntegerType)))))))))
+                       ((Reference (n IntegerType))) false))))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -5301,7 +5395,7 @@ let%expect_test "struct signatures" =
                       (ExprType
                        (FunctionCall
                         ((ResolvedReference (Int2 <opaque>))
-                         ((Reference (n IntegerType)))))))))
+                         ((Reference (n IntegerType))) false))))))
                    (function_returns IntegerType)))
                  (function_impl
                   (Fn
@@ -5312,7 +5406,7 @@ let%expect_test "struct signatures" =
                         (ExprType
                          (FunctionCall
                           ((ResolvedReference (Int2 <opaque>))
-                           ((Reference (n IntegerType))))))))
+                           ((Reference (n IntegerType))) false)))))
                       value IntegerType))))))))))))))
         (Int2
          (Value
@@ -5450,7 +5544,7 @@ let%expect_test "Deserilize intf with constraints" =
                                     (mk_struct_details
                                      ((mk_methods ()) (mk_impls ()) (mk_id 0)
                                       (mk_sig 1) (mk_span <opaque>)))))))))))
-                            ((ResolvedReference (Self <opaque>))))))))))
+                            ((ResolvedReference (Self <opaque>))) false)))))))
                      (intf_args ()) (intf_loc <opaque>))))))
                 (Return
                  (StructField
@@ -5472,7 +5566,7 @@ let%expect_test "Deserilize intf with constraints" =
                                 (mk_struct_details
                                  ((mk_methods ()) (mk_impls ()) (mk_id 0)
                                   (mk_sig 1) (mk_span <opaque>)))))))))))
-                        ((ResolvedReference (Self <opaque>))))))))
+                        ((ResolvedReference (Self <opaque>))) false)))))
                    x (ExprType (Reference (Y (InterfaceType 1)))))))))))))))
         (Deserialize2 (Value (Type (InterfaceType 1))))
         (Container
@@ -5543,7 +5637,7 @@ let%expect_test "Deserilize intf with constraints" =
                           (mk_struct_details
                            ((mk_methods ()) (mk_impls ()) (mk_id 0) (mk_sig 1)
                             (mk_span <opaque>)))))))))))
-                  ((ResolvedReference (Self <opaque>)))))))))))))))
+                  ((ResolvedReference (Self <opaque>))) false))))))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (4
@@ -5557,7 +5651,7 @@ let%expect_test "Deserilize intf with constraints" =
                (ExprType
                 (FunctionCall
                  ((ResolvedReference (Container <opaque>))
-                  ((Reference (Self (StructSig 3))))))))))))
+                  ((Reference (Self (StructSig 3)))) true))))))))
           (st_sig_base_id 2) (st_sig_id 3))
          ((st_sig_fields ((x (ResolvedReference (Self <opaque>)))))
           (st_sig_methods ()) (st_sig_base_id 0) (st_sig_id 2))
@@ -5625,7 +5719,7 @@ let%expect_test "Interface inner constraints" =
                          (Struct
                           ((FunctionCall
                             ((ResolvedReference (Test <opaque>))
-                             ((Reference (X (InterfaceType 0))))))
+                             ((Reference (X (InterfaceType 0)))) true))
                            ((x
                              (Reference
                               (value
@@ -5635,7 +5729,7 @@ let%expect_test "Interface inner constraints" =
                        ((st_sig_call_instance
                          (FunctionCall
                           ((ResolvedReference (Test <opaque>))
-                           ((Reference (X (InterfaceType 0)))))))
+                           ((Reference (X (InterfaceType 0)))) true)))
                         (st_sig_call_def 1)
                         (st_sig_call_method
                          (do_stuff
@@ -5644,7 +5738,7 @@ let%expect_test "Interface inner constraints" =
                               (ExprType
                                (FunctionCall
                                 ((ResolvedReference (Test <opaque>))
-                                 ((Reference (X (InterfaceType 0))))))))))
+                                 ((Reference (X (InterfaceType 0)))) true))))))
                            (function_returns HoleType))))
                         (st_sig_call_args
                          ((Reference
@@ -5652,7 +5746,7 @@ let%expect_test "Interface inner constraints" =
                             (ExprType
                              (FunctionCall
                               ((ResolvedReference (Test <opaque>))
-                               ((Reference (X (InterfaceType 0)))))))))))
+                               ((Reference (X (InterfaceType 0)))) true)))))))
                         (st_sig_call_span <opaque>)
                         (st_sig_call_kind StructSigKind)))))))))))))))))
         (Test
@@ -5740,7 +5834,8 @@ let%expect_test "Interface inner constraints" =
                           (function_returns IntegerType)))
                         (function_impl (Fn (Return (Value (Integer 1))))))))
                      ((StructField
-                       ((Reference (self (StructType 4))) x (StructType 3)))))))))))))
+                       ((Reference (self (StructType 4))) x (StructType 3))))
+                     false)))))))))
             (uty_impls
              (((impl_interface 0)
                (impl_methods
@@ -5759,7 +5854,8 @@ let%expect_test "Interface inner constraints" =
                              (function_returns IntegerType)))
                            (function_impl (Fn (Return (Value (Integer 1))))))))
                         ((StructField
-                          ((Reference (self (StructType 4))) x (StructType 3))))))))))))))))
+                          ((Reference (self (StructType 4))) x (StructType 3))))
+                        false))))))))))))
             (uty_id 4) (uty_base_id 1)))))
         (3
          ((struct_fields ())
@@ -6175,7 +6271,7 @@ let%expect_test "methods incrementally added" =
                          ((function_params ((self (StructType 1))))
                           (function_returns HoleType)))
                         (function_impl (Fn (Block ()))))))
-                     ((Reference (self (StructType 1)))))))))))))
+                     ((Reference (self (StructType 1)))) false)))))))))
             (uty_impls ()) (uty_id 1) (uty_base_id 0)))))))
       (unions
        ((3
@@ -6201,7 +6297,7 @@ let%expect_test "methods incrementally added" =
                          ((function_params ((self (UnionType 3))))
                           (function_returns HoleType)))
                         (function_impl (Fn (Block ()))))))
-                     ((Reference (self (UnionType 3)))))))))))))
+                     ((Reference (self (UnionType 3)))) false)))))))))
             (uty_impls ()) (uty_id 3) (uty_base_id 2)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs

--- a/test/lang_types.ml
+++ b/test/lang_types.ml
@@ -69,6 +69,7 @@ let%test "builtin function equality" =
     { function_signature =
         bl
           { function_attributes = [];
+            function_is_type = false;
             function_params = [];
             function_returns = VoidType };
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Void)) }
@@ -76,6 +77,7 @@ let%test "builtin function equality" =
     { function_signature =
         bl
           { function_attributes = [];
+            function_is_type = false;
             function_params = [];
             function_returns = VoidType };
       function_impl = BuiltinFn (builtin_fun (fun _ _ -> Void)) }

--- a/test/lang_types.ml
+++ b/test/lang_types.ml
@@ -9,7 +9,7 @@ let find scope name =
 
 let%test "aliased structures equality" =
   let source = {|
-  struct T { val a: Int(257) }
+  struct T { val a: Int[257] }
   let T1 = T; 
   |} in
   Alcotest.(check bool)
@@ -24,8 +24,8 @@ let%test "aliased structures equality" =
 let%test "carbon copy structure equality" =
   let source =
     {|
-  struct T { val a: Int(257) }
-  struct T1 { val a: Int(257) }
+  struct T { val a: Int[257] }
+  struct T1 { val a: Int[257] }
   |}
   in
   Alcotest.(check bool)
@@ -41,9 +41,9 @@ let%test "parameterized structure equality" =
   let source =
     {|
   struct T[X: Type] { val a: X }
-  let T1 = T(Int(257));
-  let T2 = T(Bool);
-  let T3 = T(Int(257));
+  let T1 = T[Int[257]];
+  let T2 = T[Bool];
+  let T3 = T[Int[257]];
   |}
   in
   Alcotest.(check bool)

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -137,7 +137,7 @@ let%expect_test "parameterized struct shorthand" =
         ((binding_name (Ident MyType))
          (binding_expr
           (Function
-           ((params (((Ident T) (Reference (Ident Type)))))
+           ((is_type_function) (params (((Ident T) (Reference (Ident Type)))))
             (function_body
              ((function_stmt (Expr (Struct ((struct_span <opaque>)))))))
             (function_def_span <opaque>))))))))) |}]
@@ -608,7 +608,8 @@ let%expect_test "struct construction over an anonymous type's function call" =
              (FunctionCall
               ((fn
                 (Function
-                 ((params (((Ident T) (Reference (Ident Type)))))
+                 ((is_type_function)
+                  (params (((Ident T) (Reference (Ident Type)))))
                   (function_body
                    ((function_stmt
                      (Expr
@@ -776,7 +777,7 @@ let%expect_test "parameterized union definition" =
         ((binding_name (Ident Option))
          (binding_expr
           (Function
-           ((params (((Ident T) (Reference (Ident Type)))))
+           ((is_type_function) (params (((Ident T) (Reference (Ident Type)))))
             (function_body
              ((function_stmt
                (Expr
@@ -1185,7 +1186,7 @@ let%expect_test "attributes" =
         ((binding_name (Ident Ta))
          (binding_expr
           (Function
-           ((params (((Ident X) (Reference (Ident Integer)))))
+           ((is_type_function) (params (((Ident X) (Reference (Ident Integer)))))
             (function_body
              ((function_stmt
                (Expr

--- a/test/syntax.ml
+++ b/test/syntax.ml
@@ -112,11 +112,13 @@ let%expect_test "struct construction" =
                (((field_name (Ident a))
                  (field_type
                   (FunctionCall
-                   ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))
+                   ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                    (is_type_func_call)))))
                 ((field_name (Ident b))
                  (field_type
                   (FunctionCall
-                   ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))
+                   ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                    (is_type_func_call)))))))
               (struct_span <opaque>))))))
          (Let
           ((binding_name (Ident my))
@@ -163,7 +165,8 @@ let%expect_test "struct fields" =
              (((field_name (Ident a))
                (field_type
                 (FunctionCall
-                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))
+                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                  (is_type_func_call)))))
               ((field_name (Ident f))
                (field_type (FunctionCall ((fn (Reference (Ident get_type)))))))))
             (struct_span <opaque>))))))))) |}]
@@ -184,7 +187,8 @@ let%expect_test "struct fields with semicolons" =
              (((field_name (Ident a))
                (field_type
                 (FunctionCall
-                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))
+                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                  (is_type_func_call)))))
               ((field_name (Ident f))
                (field_type (FunctionCall ((fn (Reference (Ident get_type)))))))))
             (struct_span <opaque>))))))))) |}]
@@ -218,7 +222,8 @@ let%expect_test "struct methods" =
                 (Function
                  ((returns
                    (FunctionCall
-                    ((fn (Reference (Ident Int))) (arguments ((Int 257))))))
+                    ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                     (is_type_func_call))))
                   (function_def_span <opaque>)))))))
             (struct_span <opaque>))))))))) |}]
 
@@ -243,7 +248,8 @@ let%expect_test "struct with fields and methods" =
              (((field_name (Ident a))
                (field_type
                 (FunctionCall
-                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))
+                 ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                  (is_type_func_call)))))))
             (struct_bindings
              (((binding_name (Ident test))
                (binding_expr
@@ -308,7 +314,8 @@ let%expect_test "function without a return type" =
            ((params
              (((Ident t)
                (FunctionCall
-                ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))
+                ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                 (is_type_func_call))))))
             (function_def_span <opaque>))))))
        (Let
         ((binding_name (Ident f2))
@@ -317,7 +324,8 @@ let%expect_test "function without a return type" =
            ((params
              (((Ident t)
                (FunctionCall
-                ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))
+                ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                 (is_type_func_call))))))
             (function_body ((function_stmt (CodeBlock ()))))
             (function_def_span <opaque>))))))
        (Let
@@ -327,7 +335,8 @@ let%expect_test "function without a return type" =
            ((params
              (((Ident t)
                (FunctionCall
-                ((fn (Reference (Ident Int))) (arguments ((Int 257))))))))
+                ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                 (is_type_func_call))))))
             (function_body ((function_stmt (CodeBlock ()))))
             (function_def_span <opaque>))))))))) |}]
 
@@ -586,7 +595,8 @@ let%expect_test "struct construction over an anonymous type" =
                 (((field_name (Ident field))
                   (field_type
                    (FunctionCall
-                    ((fn (Reference (Ident Int))) (arguments ((Int 257)))))))))
+                    ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                     (is_type_func_call)))))))
                (struct_span <opaque>))))
             (fields_construction (((Ident field) (Reference (Ident value))))))))))))) |}]
 
@@ -733,7 +743,8 @@ let%expect_test "union definition" =
           (Union
            ((union_members
              ((FunctionCall
-               ((fn (Reference (Ident Int))) (arguments ((Int 257)))))
+               ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                (is_type_func_call)))
               (Reference (Ident Bool))))
             (union_span <opaque>))))))))) |}]
 
@@ -756,7 +767,8 @@ let%expect_test "union definition using let binding" =
           (Union
            ((union_members
              ((FunctionCall
-               ((fn (Reference (Ident Int))) (arguments ((Int 257)))))
+               ((fn (Reference (Ident Int))) (arguments ((Int 257)))
+                (is_type_func_call)))
               (Reference (Ident Bool))))
             (union_span <opaque>))))))))) |}]
 
@@ -997,7 +1009,8 @@ let%expect_test "switch statement with a default case" =
                        (((ty
                           (FunctionCall
                            ((fn (Reference (Ident Type)))
-                            (arguments ((Reference (Ident T)))))))
+                            (arguments ((Reference (Ident T))))
+                            (is_type_func_call))))
                          (var (Ident vax))
                          (stmt
                           (CodeBlock


### PR DESCRIPTION
This PR add special type of function - "type functions" which should be called using `[]` brackets instead of `()` parens.