### PR TITLE
Add `TypeCall` type.

### DIFF
--- a/lib/attributes.ml
+++ b/lib/attributes.ml
@@ -84,10 +84,8 @@ functor
                             false ) )
               in
               let ret_ty =
-                ExprType
-                  ( bl
-                  @@ FunctionCall
-                       (load_result_f, [bl @@ Value (Type self_ty)], true) )
+                TypeCall
+                  {func = load_result_f; args = [bl @@ Value (Type self_ty)]}
               in
               let function_signature =
                 bl

--- a/lib/builtin.ml
+++ b/lib/builtin.ml
@@ -150,12 +150,10 @@ functor
                     function_is_type = false;
                     function_params = [(bl "b", builder_struct)];
                     function_returns =
-                      ExprType
-                        ( bl
-                        @@ FunctionCall
-                             ( load_result_f,
-                               [bl @@ Reference (bl "Self", SelfType)],
-                               true ) ) } ) ] }
+                      TypeCall
+                        { func = load_result_f;
+                          args = [bl @@ Reference (bl "Self", SelfType)] } } )
+            ] }
       in
       intf
 
@@ -353,12 +351,9 @@ functor
                      function_is_type = false;
                      function_params = [(bl "slice", slice_ty)];
                      function_returns =
-                       ExprType
-                         ( bl
-                         @@ FunctionCall
-                              ( load_result_fn,
-                                [bl @@ Reference (bl "t", type0)],
-                                true ) ) } ) }
+                       TypeCall
+                         { func = load_result_fn;
+                           args = [bl @@ Reference (bl "t", type0)] } } ) }
       in
       let deserializer_struct_ty sid p =
         let s = Program.get_struct p sid in

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -202,8 +202,9 @@ functor
                   match self#interpret_expr intf_instance with
                   | Type t ->
                       t
-                  | _ ->
-                      ice "Type-check bug?"
+                  | out ->
+                      print_sexp @@ sexp_of_value out ;
+                      ice "Type-check bug 1?"
                 in
                 match Program.find_impl_intf ctx.program intf_def ty with
                 | Some impl ->
@@ -231,7 +232,7 @@ functor
                   | Type t ->
                       t
                   | _ ->
-                      ice "Type-check bug?"
+                      ice "Type-check bug 2?"
                 in
                 match Program.find_impl_intf ctx.program st_sig_call_def ty with
                 | Some impl ->
@@ -453,6 +454,15 @@ functor
           function
           | ExprType ex -> (
             match self#interpret_expr ex with
+            | Type t ->
+                t
+            | Void ->
+                VoidType
+            | ex2 ->
+                print_sexp (sexp_of_value ex2) ;
+                ice "Type-check bug" )
+          | TypeCall {func; args} -> (
+            match self#interpret_fc (func, args, true) with
             | Type t ->
                 t
             | Void ->

--- a/lib/partial_evaluator.ml
+++ b/lib/partial_evaluator.ml
@@ -84,8 +84,8 @@ functor
               in
               ctx.scope := vars :: !(ctx.scope) ;
               DestructuringLet {let_ with destructuring_let_expr = expr}
-          | ExprType ex -> (
-            match type_of ctx.program ex with
+          | other_ty -> (
+            match type_of_type ctx.program other_ty with
             | StructSig sign ->
                 let struct_sign = Arena.get ctx.program.struct_signs sign in
                 let vars =
@@ -95,14 +95,12 @@ functor
                         name
                       |> Option.value_exn
                       |> fun field_type ->
-                      (new_name, Runtime (ExprType field_type)) )
+                      (new_name, Runtime (expr_to_type ctx.program field_type)) )
                 in
                 ctx.scope := vars :: !(ctx.scope) ;
                 DestructuringLet {let_ with destructuring_let_expr = expr}
             | _ ->
-                ice "Type-check bug" )
-          | _ ->
-              ice "Type-check bug"
+                ice "Type-check bug 1" )
 
         method! visit_switch env switch =
           let cond = self#visit_expr env switch.switch_condition in
@@ -171,7 +169,7 @@ functor
                 | Type t ->
                     t
                 | _ ->
-                    ice "Type-check bug"
+                    ice "Type-check bug 2"
               in
               match
                 Program.find_impl_intf ctx.program call.intf_def intf_ty
@@ -188,7 +186,7 @@ functor
                       args,
                       method_.value.function_signature.value.function_is_type )
               | None ->
-                  ice "Type-check bug" )
+                  ice "Type-check bug 3" )
           | false ->
               IntfMethodCall {call with intf_instance; intf_args = args}
 
@@ -279,7 +277,7 @@ functor
                 | Type t ->
                     t
                 | _ ->
-                    ice "Type-check bug"
+                    ice "Type-check bug 4"
               in
               let methods = Program.methods_of ctx.program st_sig_ty in
               let method_ =

--- a/test/builtin.ml
+++ b/test/builtin.ml
@@ -16,50 +16,50 @@ let%expect_test "Int[bits] constructor" =
          ((overflow
            (Value
             (Struct
-             ((Value (Type (StructType 36))) ((value (Value (Integer 513))))))))
+             ((Value (Type (StructType 33))) ((value (Value (Integer 513))))))))
           (i
            (Value
             (Struct
-             ((Value (Type (StructType 125))) ((value (Value (Integer 100))))))))))
+             ((Value (Type (StructType 118))) ((value (Value (Integer 100))))))))))
         (structs
-         ((126
+         ((119
            ((struct_fields
              ((slice ((field_type (StructType 7))))
-              (value ((field_type (StructType 125))))))
+              (value ((field_type (StructType 118))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 7)) (v (StructType 125))))
-                    (function_returns (StructType 126))))
+                   ((function_params ((s (StructType 7)) (v (StructType 118))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (s (StructType 7))))
-                         (value (Reference (v (StructType 125)))))))))))))))
-              (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-          (125
+                         (value (Reference (v (StructType 118)))))))))))))))
+              (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+          (118
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 7))))
-                    (function_returns (StructType 126))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Block
@@ -76,17 +76,17 @@ let%expect_test "Int[bits] constructor" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 126)))
+                         ((Value (Type (StructType 119)))
                           ((slice (Reference (slice (StructType 7))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 125)))
+                              ((Value (Type (StructType 118)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 125)) (builder (StructType 3))))
+                     ((self (StructType 118)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -95,19 +95,19 @@ let%expect_test "Int[bits] constructor" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 125))) value IntegerType))
+                         ((Reference (self (StructType 118))) value IntegerType))
                         (Value (Integer 257)))
                        false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -115,7 +115,7 @@ let%expect_test "Int[bits] constructor" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 125)) (builder (StructType 3))))
+                        ((self (StructType 118)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -124,7 +124,7 @@ let%expect_test "Int[bits] constructor" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 125))) value IntegerType))
+                            ((Reference (self (StructType 118))) value IntegerType))
                            (Value (Integer 257)))
                           false))))))))))
                 ((impl_interface -2)
@@ -132,7 +132,7 @@ let%expect_test "Int[bits] constructor" =
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 7))))
-                       (function_returns (StructType 126))))
+                       (function_returns (StructType 119))))
                      (function_impl
                       (Fn
                        (Block
@@ -151,27 +151,27 @@ let%expect_test "Int[bits] constructor" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 126)))
+                            ((Value (Type (StructType 119)))
                              ((slice (Reference (slice (StructType 7))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 125)))
+                                 ((Value (Type (StructType 118)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
-                ((impl_interface 19)
+                ((impl_interface 17)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 125))))
+                       (function_returns (StructType 118))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 125)))
+                          ((Value (Type (StructType 118)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 125) (uty_base_id 18)))))))
+              (uty_id 118) (uty_base_id 16)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -201,7 +201,7 @@ let%expect_test "Int[bits] serializer" =
                    ((i
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Value (Integer 100))))))))))
                   (Return
                    (FunctionCall
@@ -210,44 +210,44 @@ let%expect_test "Int[bits] serializer" =
                       (Reference (b (StructType 3))))
                      false)))))))))))))
         (structs
-         ((126
+         ((119
            ((struct_fields
              ((slice ((field_type (StructType 7))))
-              (value ((field_type (StructType 125))))))
+              (value ((field_type (StructType 118))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 7)) (v (StructType 125))))
-                    (function_returns (StructType 126))))
+                   ((function_params ((s (StructType 7)) (v (StructType 118))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (s (StructType 7))))
-                         (value (Reference (v (StructType 125)))))))))))))))
-              (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-          (125
+                         (value (Reference (v (StructType 118)))))))))))))))
+              (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+          (118
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 7))))
-                    (function_returns (StructType 126))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Block
@@ -264,17 +264,17 @@ let%expect_test "Int[bits] serializer" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 126)))
+                         ((Value (Type (StructType 119)))
                           ((slice (Reference (slice (StructType 7))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 125)))
+                              ((Value (Type (StructType 118)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 125)) (builder (StructType 3))))
+                     ((self (StructType 118)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -283,19 +283,19 @@ let%expect_test "Int[bits] serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 125))) value IntegerType))
+                         ((Reference (self (StructType 118))) value IntegerType))
                         (Value (Integer 32)))
                        false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -303,7 +303,7 @@ let%expect_test "Int[bits] serializer" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 125)) (builder (StructType 3))))
+                        ((self (StructType 118)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -312,7 +312,7 @@ let%expect_test "Int[bits] serializer" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 125))) value IntegerType))
+                            ((Reference (self (StructType 118))) value IntegerType))
                            (Value (Integer 32)))
                           false))))))))))
                 ((impl_interface -2)
@@ -320,7 +320,7 @@ let%expect_test "Int[bits] serializer" =
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 7))))
-                       (function_returns (StructType 126))))
+                       (function_returns (StructType 119))))
                      (function_impl
                       (Fn
                        (Block
@@ -338,27 +338,27 @@ let%expect_test "Int[bits] serializer" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 126)))
+                            ((Value (Type (StructType 119)))
                              ((slice (Reference (slice (StructType 7))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 125)))
+                                 ((Value (Type (StructType 118)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
-                ((impl_interface 19)
+                ((impl_interface 17)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 125))))
+                       (function_returns (StructType 118))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 125)))
+                          ((Value (Type (StructType 118)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 125) (uty_base_id 18)))))))
+              (uty_id 118) (uty_base_id 16)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -398,16 +398,16 @@ let%expect_test "demo struct serializer" =
                     ((ResolvedReference (T_serializer <opaque>))
                      ((Value
                        (Struct
-                        ((Value (Type (StructType 130)))
+                        ((Value (Type (StructType 123)))
                          ((a
                            (Value
                             (Struct
-                             ((Value (Type (StructType 125)))
+                             ((Value (Type (StructType 118)))
                               ((value (Value (Integer 0))))))))
                           (b
                            (Value
                             (Struct
-                             ((Value (Type (StructType 127)))
+                             ((Value (Type (StructType 120)))
                               ((value (Value (Integer 1))))))))))))
                       (Reference (b (StructType 3))))
                      false)))))))))))
@@ -415,7 +415,7 @@ let%expect_test "demo struct serializer" =
            (Value
             (Function
              ((function_signature
-               ((function_params ((self (StructType 130)) (b (StructType 3))))
+               ((function_params ((self (StructType 123)) (b (StructType 3))))
                 (function_returns (StructType 3))))
               (function_impl
                (Fn
@@ -427,7 +427,7 @@ let%expect_test "demo struct serializer" =
                         (Function
                          ((function_signature
                            ((function_params
-                             ((self (StructType 125)) (builder (StructType 3))))
+                             ((self (StructType 118)) (builder (StructType 3))))
                             (function_returns (StructType 3))))
                           (function_impl
                            (Fn
@@ -436,12 +436,12 @@ let%expect_test "demo struct serializer" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 125))) value
+                                 ((Reference (self (StructType 118))) value
                                   IntegerType))
                                 (Value (Integer 32)))
                                false))))))))
                        ((StructField
-                         ((Reference (self (StructType 130))) a (StructType 125)))
+                         ((Reference (self (StructType 123))) a (StructType 118)))
                         (Reference (b (StructType 3))))
                        false)))))
                   (Let
@@ -451,7 +451,7 @@ let%expect_test "demo struct serializer" =
                         (Function
                          ((function_signature
                            ((function_params
-                             ((self (StructType 127)) (builder (StructType 3))))
+                             ((self (StructType 120)) (builder (StructType 3))))
                             (function_returns (StructType 3))))
                           (function_impl
                            (Fn
@@ -460,61 +460,61 @@ let%expect_test "demo struct serializer" =
                               ((ResolvedReference (serialize_int <opaque>))
                                ((Reference (builder (StructType 3)))
                                 (StructField
-                                 ((Reference (self (StructType 127))) value
+                                 ((Reference (self (StructType 120))) value
                                   IntegerType))
                                 (Value (Integer 16)))
                                false))))))))
                        ((StructField
-                         ((Reference (self (StructType 130))) b (StructType 127)))
+                         ((Reference (self (StructType 123))) b (StructType 120)))
                         (Reference (b (StructType 3))))
                        false)))))
                   (Return (Reference (b (StructType 3))))))))))))
-          (T (Value (Type (StructType 130))))))
+          (T (Value (Type (StructType 123))))))
         (structs
-         ((130
+         ((123
            ((struct_fields
-             ((a ((field_type (StructType 125))))
-              (b ((field_type (StructType 127))))))
+             ((a ((field_type (StructType 118))))
+              (b ((field_type (StructType 120))))))
             (struct_details
-             ((uty_methods ()) (uty_impls ()) (uty_id 130) (uty_base_id 129)))))
-          (128
+             ((uty_methods ()) (uty_impls ()) (uty_id 123) (uty_base_id 122)))))
+          (121
            ((struct_fields
              ((slice ((field_type (StructType 7))))
-              (value ((field_type (StructType 127))))))
+              (value ((field_type (StructType 120))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 7)) (v (StructType 127))))
-                    (function_returns (StructType 128))))
+                   ((function_params ((s (StructType 7)) (v (StructType 120))))
+                    (function_returns (StructType 121))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (s (StructType 7))))
-                         (value (Reference (v (StructType 127)))))))))))))))
-              (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-          (127
+                         (value (Reference (v (StructType 120)))))))))))))))
+              (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+          (120
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 127))))
+                    (function_returns (StructType 120))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 127)))
+                       ((Value (Type (StructType 120)))
                         ((value (Reference (i IntegerType))))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 7))))
-                    (function_returns (StructType 128))))
+                    (function_returns (StructType 121))))
                   (function_impl
                    (Fn
                     (Block
@@ -531,17 +531,17 @@ let%expect_test "demo struct serializer" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 128)))
+                         ((Value (Type (StructType 121)))
                           ((slice (Reference (slice (StructType 7))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 127)))
+                              ((Value (Type (StructType 120)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 127)) (builder (StructType 3))))
+                     ((self (StructType 120)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -550,19 +550,19 @@ let%expect_test "demo struct serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 127))) value IntegerType))
+                         ((Reference (self (StructType 120))) value IntegerType))
                         (Value (Integer 16)))
                        false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 127))))
+                    (function_returns (StructType 120))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 127)))
+                       ((Value (Type (StructType 120)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -570,7 +570,7 @@ let%expect_test "demo struct serializer" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 127)) (builder (StructType 3))))
+                        ((self (StructType 120)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -579,7 +579,7 @@ let%expect_test "demo struct serializer" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 127))) value IntegerType))
+                            ((Reference (self (StructType 120))) value IntegerType))
                            (Value (Integer 16)))
                           false))))))))))
                 ((impl_interface -2)
@@ -587,7 +587,7 @@ let%expect_test "demo struct serializer" =
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 7))))
-                       (function_returns (StructType 128))))
+                       (function_returns (StructType 121))))
                      (function_impl
                       (Fn
                        (Block
@@ -605,65 +605,65 @@ let%expect_test "demo struct serializer" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 128)))
+                            ((Value (Type (StructType 121)))
                              ((slice (Reference (slice (StructType 7))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 127)))
+                                 ((Value (Type (StructType 120)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
-                ((impl_interface 19)
+                ((impl_interface 17)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 127))))
+                       (function_returns (StructType 120))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 127)))
+                          ((Value (Type (StructType 120)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 127) (uty_base_id 18)))))
-          (126
+              (uty_id 120) (uty_base_id 16)))))
+          (119
            ((struct_fields
              ((slice ((field_type (StructType 7))))
-              (value ((field_type (StructType 125))))))
+              (value ((field_type (StructType 118))))))
             (struct_details
              ((uty_methods
                ((new
                  ((function_signature
-                   ((function_params ((s (StructType 7)) (v (StructType 125))))
-                    (function_returns (StructType 126))))
+                   ((function_params ((s (StructType 7)) (v (StructType 118))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (s (StructType 7))))
-                         (value (Reference (v (StructType 125)))))))))))))))
-              (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-          (125
+                         (value (Reference (v (StructType 118)))))))))))))))
+              (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+          (118
            ((struct_fields ((value ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))
                 (deserialize
                  ((function_signature
                    ((function_params ((s (StructType 7))))
-                    (function_returns (StructType 126))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Block
@@ -680,17 +680,17 @@ let%expect_test "demo struct serializer" =
                       (Return
                        (Value
                         (Struct
-                         ((Value (Type (StructType 126)))
+                         ((Value (Type (StructType 119)))
                           ((slice (Reference (slice (StructType 7))))
                            (value
                             (Value
                              (Struct
-                              ((Value (Type (StructType 125)))
+                              ((Value (Type (StructType 118)))
                                ((value (Reference (value IntegerType)))))))))))))))))))
                 (serialize
                  ((function_signature
                    ((function_params
-                     ((self (StructType 125)) (builder (StructType 3))))
+                     ((self (StructType 118)) (builder (StructType 3))))
                     (function_returns (StructType 3))))
                   (function_impl
                    (Fn
@@ -699,19 +699,19 @@ let%expect_test "demo struct serializer" =
                       ((ResolvedReference (serialize_int <opaque>))
                        ((Reference (builder (StructType 3)))
                         (StructField
-                         ((Reference (self (StructType 125))) value IntegerType))
+                         ((Reference (self (StructType 118))) value IntegerType))
                         (Value (Integer 32)))
                        false)))))))
                 (new
                  ((function_signature
                    ((function_params ((i IntegerType)))
-                    (function_returns (StructType 125))))
+                    (function_returns (StructType 118))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 125)))
+                       ((Value (Type (StructType 118)))
                         ((value (Reference (i IntegerType))))))))))))))
               (uty_impls
                (((impl_interface -1)
@@ -719,7 +719,7 @@ let%expect_test "demo struct serializer" =
                   ((serialize
                     ((function_signature
                       ((function_params
-                        ((self (StructType 125)) (builder (StructType 3))))
+                        ((self (StructType 118)) (builder (StructType 3))))
                        (function_returns (StructType 3))))
                      (function_impl
                       (Fn
@@ -728,7 +728,7 @@ let%expect_test "demo struct serializer" =
                          ((ResolvedReference (serialize_int <opaque>))
                           ((Reference (builder (StructType 3)))
                            (StructField
-                            ((Reference (self (StructType 125))) value IntegerType))
+                            ((Reference (self (StructType 118))) value IntegerType))
                            (Value (Integer 32)))
                           false))))))))))
                 ((impl_interface -2)
@@ -736,7 +736,7 @@ let%expect_test "demo struct serializer" =
                   ((deserialize
                     ((function_signature
                       ((function_params ((s (StructType 7))))
-                       (function_returns (StructType 126))))
+                       (function_returns (StructType 119))))
                      (function_impl
                       (Fn
                        (Block
@@ -754,34 +754,34 @@ let%expect_test "demo struct serializer" =
                          (Return
                           (Value
                            (Struct
-                            ((Value (Type (StructType 126)))
+                            ((Value (Type (StructType 119)))
                              ((slice (Reference (slice (StructType 7))))
                               (value
                                (Value
                                 (Struct
-                                 ((Value (Type (StructType 125)))
+                                 ((Value (Type (StructType 118)))
                                   ((value (Reference (value IntegerType))))))))))))))))))))))
-                ((impl_interface 19)
+                ((impl_interface 17)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((i IntegerType)))
-                       (function_returns (StructType 125))))
+                       (function_returns (StructType 118))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 125)))
+                          ((Value (Type (StructType 118)))
                            ((value (Reference (i IntegerType)))))))))))))))))
-              (uty_id 125) (uty_base_id 18)))))))
+              (uty_id 118) (uty_base_id 16)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs
          (1
           (((st_sig_fields
-             ((a (Value (Type (StructType 125))))
-              (b (Value (Type (StructType 127))))))
-            (st_sig_methods ()) (st_sig_base_id 129) (st_sig_id 73)))))
+             ((a (Value (Type (StructType 118))))
+              (b (Value (Type (StructType 120))))))
+            (st_sig_methods ()) (st_sig_base_id 122) (st_sig_id 45)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "from interface" =
@@ -807,46 +807,46 @@ let%expect_test "from interface" =
        ((bindings
          ((var
            (Value
-            (Struct ((Value (Type (StructType 126))) ((a (Value (Integer 10))))))))
+            (Struct ((Value (Type (StructType 119))) ((a (Value (Integer 10))))))))
           (check
            (Value
             (Function
              ((function_signature
-               ((function_params ((y (StructType 126))))
-                (function_returns (StructType 126))))
-              (function_impl (Fn (Return (Reference (y (StructType 126))))))))))
-          (Value (Value (Type (StructType 126))))))
+               ((function_params ((y (StructType 119))))
+                (function_returns (StructType 119))))
+              (function_impl (Fn (Return (Reference (y (StructType 119))))))))))
+          (Value (Value (Type (StructType 119))))))
         (structs
-         ((126
+         ((119
            ((struct_fields ((a ((field_type IntegerType)))))
             (struct_details
              ((uty_methods
                ((from
                  ((function_signature
                    ((function_params ((x IntegerType)))
-                    (function_returns (StructType 126))))
+                    (function_returns (StructType 119))))
                   (function_impl
                    (Fn
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((a (Reference (x IntegerType))))))))))))))
               (uty_impls
-               (((impl_interface 19)
+               (((impl_interface 17)
                  (impl_methods
                   ((from
                     ((function_signature
                       ((function_params ((x IntegerType)))
-                       (function_returns (StructType 126))))
+                       (function_returns (StructType 119))))
                      (function_impl
                       (Fn
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((a (Reference (x IntegerType)))))))))))))))))
-              (uty_id 126) (uty_base_id 125)))))))
+              (uty_id 119) (uty_base_id 118)))))))
         (type_counter <opaque>) (memoized_fcalls <opaque>)
         (struct_signs
          (1
@@ -854,8 +854,8 @@ let%expect_test "from interface" =
             (st_sig_methods
              ((from
                ((function_params ((x IntegerType)))
-                (function_returns (ExprType (Reference (Self (StructSig 73)))))))))
-            (st_sig_base_id 125) (st_sig_id 73)))))
+                (function_returns (ExprType (Reference (Self (StructSig 45)))))))))
+            (st_sig_base_id 118) (st_sig_id 45)))))
         (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "tensor2" =
@@ -977,7 +977,7 @@ let%expect_test "deserializer" =
           (Function
            ((function_signature
              ((function_params ((slice (StructType 7))))
-              (function_returns (StructType 127))))
+              (function_returns (StructType 120))))
             (function_impl
              (Fn
               (Block
@@ -989,7 +989,7 @@ let%expect_test "deserializer" =
                       (Function
                        ((function_signature
                          ((function_params ((s (StructType 7))))
-                          (function_returns (StructType 26))))
+                          (function_returns (StructType 23))))
                         (function_impl
                          (Fn
                           (Block
@@ -1008,12 +1008,12 @@ let%expect_test "deserializer" =
                             (Return
                              (Value
                               (Struct
-                               ((Value (Type (StructType 26)))
+                               ((Value (Type (StructType 23)))
                                 ((slice (Reference (slice (StructType 7))))
                                  (value
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 25)))
+                                    ((Value (Type (StructType 22)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
                      ((Reference (slice (StructType 7)))) false)))
                   (destructuring_let_rest false)))
@@ -1025,7 +1025,7 @@ let%expect_test "deserializer" =
                       (Function
                        ((function_signature
                          ((function_params ((s (StructType 7))))
-                          (function_returns (StructType 39))))
+                          (function_returns (StructType 36))))
                         (function_impl
                          (Fn
                           (Block
@@ -1044,60 +1044,60 @@ let%expect_test "deserializer" =
                             (Return
                              (Value
                               (Struct
-                               ((Value (Type (StructType 39)))
+                               ((Value (Type (StructType 36)))
                                 ((slice (Reference (slice (StructType 7))))
                                  (value
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 38)))
+                                    ((Value (Type (StructType 35)))
                                      ((value (Reference (value IntegerType))))))))))))))))))))
                      ((Reference (slice (StructType 7)))) false)))
                   (destructuring_let_rest false)))
                 (Return
                  (Value
                   (Struct
-                   ((Value (Type (StructType 127)))
+                   ((Value (Type (StructType 120)))
                     ((value
                       (Value
                        (Struct
-                        ((Value (Type (StructType 126)))
-                         ((value1 (Reference (value1 (StructType 25))))
-                          (value2 (Reference (value2 (StructType 38)))))))))
+                        ((Value (Type (StructType 119)))
+                         ((value1 (Reference (value1 (StructType 22))))
+                          (value2 (Reference (value2 (StructType 35)))))))))
                      (slice (Reference (slice (StructType 7)))))))))))))))))
-        (Something (Value (Type (StructType 126))))))
+        (Something (Value (Type (StructType 119))))))
       (structs
-       ((127
+       ((120
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 126))))))
+            (value ((field_type (StructType 119))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 126))))
-                  (function_returns (StructType 127))))
+                 ((function_params ((s (StructType 7)) (v (StructType 119))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 126)))))))))))))))
-            (uty_impls ()) (uty_id 127) (uty_base_id -500)))))
-        (126
+                       (value (Reference (v (StructType 119)))))))))))))))
+            (uty_impls ()) (uty_id 120) (uty_base_id -500)))))
+        (119
          ((struct_fields
-           ((value1 ((field_type (StructType 25))))
-            (value2 ((field_type (StructType 38))))))
+           ((value1 ((field_type (StructType 22))))
+            (value2 ((field_type (StructType 35))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields
-           ((value1 (Value (Type (StructType 25))))
-            (value2 (Value (Type (StructType 38))))))
-          (st_sig_methods ()) (st_sig_base_id 125) (st_sig_id 73)))))
+           ((value1 (Value (Type (StructType 22))))
+            (value2 (Value (Type (StructType 35))))))
+          (st_sig_methods ()) (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "derive Serialize" =
@@ -1115,15 +1115,15 @@ let%expect_test "derive Serialize" =
   [%expect
     {|
     (Ok
-     ((bindings ((Something (Value (Type (StructType 126))))))
+     ((bindings ((Something (Value (Type (StructType 119))))))
       (structs
-       ((126
-         ((struct_fields ((value1 ((field_type (StructType 25))))))
+       ((119
+         ((struct_fields ((value1 ((field_type (StructType 22))))))
           (struct_details
            ((uty_methods
              ((serialize
                ((function_signature
-                 ((function_params ((self (StructType 126)) (b (StructType 3))))
+                 ((function_params ((self (StructType 119)) (b (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1133,7 +1133,7 @@ let%expect_test "derive Serialize" =
                       (Function
                        ((function_signature
                          ((function_params
-                           ((self (StructType 126)) (b (StructType 3))))
+                           ((self (StructType 119)) (b (StructType 3))))
                           (function_returns (StructType 3))))
                         (function_impl
                          (Fn
@@ -1145,7 +1145,7 @@ let%expect_test "derive Serialize" =
                                   (Function
                                    ((function_signature
                                      ((function_params
-                                       ((self (StructType 25))
+                                       ((self (StructType 22))
                                         (builder (StructType 3))))
                                       (function_returns (StructType 3))))
                                     (function_impl
@@ -1156,17 +1156,17 @@ let%expect_test "derive Serialize" =
                                           (serialize_int <opaque>))
                                          ((Reference (builder (StructType 3)))
                                           (StructField
-                                           ((Reference (self (StructType 25)))
+                                           ((Reference (self (StructType 22)))
                                             value IntegerType))
                                           (Value (Integer 9)))
                                          false))))))))
                                  ((StructField
-                                   ((Reference (self (StructType 126))) value1
-                                    (StructType 25)))
+                                   ((Reference (self (StructType 119))) value1
+                                    (StructType 22)))
                                   (Reference (b (StructType 3))))
                                  false)))))
                             (Return (Reference (b (StructType 3)))))))))))
-                     ((Reference (self (StructType 126)))
+                     ((Reference (self (StructType 119)))
                       (Reference (b (StructType 3))))
                      false)))))))))
             (uty_impls
@@ -1175,7 +1175,7 @@ let%expect_test "derive Serialize" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 126)) (b (StructType 3))))
+                      ((self (StructType 119)) (b (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1185,7 +1185,7 @@ let%expect_test "derive Serialize" =
                          (Function
                           ((function_signature
                             ((function_params
-                              ((self (StructType 126)) (b (StructType 3))))
+                              ((self (StructType 119)) (b (StructType 3))))
                              (function_returns (StructType 3))))
                            (function_impl
                             (Fn
@@ -1197,7 +1197,7 @@ let%expect_test "derive Serialize" =
                                      (Function
                                       ((function_signature
                                         ((function_params
-                                          ((self (StructType 25))
+                                          ((self (StructType 22))
                                            (builder (StructType 3))))
                                          (function_returns (StructType 3))))
                                        (function_impl
@@ -1208,31 +1208,31 @@ let%expect_test "derive Serialize" =
                                              (serialize_int <opaque>))
                                             ((Reference (builder (StructType 3)))
                                              (StructField
-                                              ((Reference (self (StructType 25)))
+                                              ((Reference (self (StructType 22)))
                                                value IntegerType))
                                              (Value (Integer 9)))
                                             false))))))))
                                     ((StructField
-                                      ((Reference (self (StructType 126))) value1
-                                       (StructType 25)))
+                                      ((Reference (self (StructType 119))) value1
+                                       (StructType 22)))
                                      (Reference (b (StructType 3))))
                                     false)))))
                                (Return (Reference (b (StructType 3)))))))))))
-                        ((Reference (self (StructType 126)))
+                        ((Reference (self (StructType 119)))
                          (Reference (b (StructType 3))))
                         false))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ((value1 (Value (Type (StructType 25))))))
+        (((st_sig_fields ((value1 (Value (Type (StructType 22))))))
           (st_sig_methods
            ((serialize
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 73)))))
+               ((self (ExprType (Reference (Self (StructSig 45)))))
                 (b (StructType 3))))
               (function_returns (StructType 3))))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserialize Unions" =
@@ -1255,7 +1255,7 @@ let%expect_test "Deserialize Unions" =
           (Function
            ((function_signature
              ((function_params ((slice (StructType 7))))
-              (function_returns (StructType 129))))
+              (function_returns (StructType 122))))
             (function_impl
              (Fn
               (Block
@@ -1334,7 +1334,7 @@ let%expect_test "Deserialize Unions" =
                            (Function
                             ((function_signature
                               ((function_params ((s (StructType 7))))
-                               (function_returns (StructType 37))))
+                               (function_returns (StructType 34))))
                              (function_impl
                               (Fn
                                (Block
@@ -1354,12 +1354,12 @@ let%expect_test "Deserialize Unions" =
                                  (Return
                                   (Value
                                    (Struct
-                                    ((Value (Type (StructType 37)))
+                                    ((Value (Type (StructType 34)))
                                      ((slice (Reference (slice (StructType 7))))
                                       (value
                                        (Value
                                         (Struct
-                                         ((Value (Type (StructType 36)))
+                                         ((Value (Type (StructType 33)))
                                           ((value
                                             (Reference (value IntegerType))))))))))))))))))))
                           ((StructField
@@ -1372,22 +1372,22 @@ let%expect_test "Deserialize Unions" =
                          (Function
                           ((function_signature
                             ((function_params
-                              ((s (StructType 7)) (v (UnionType 126))))
-                             (function_returns (StructType 129))))
+                              ((s (StructType 7)) (v (UnionType 119))))
+                             (function_returns (StructType 122))))
                            (function_impl
                             (Fn
                              (Return
                               (Value
                                (Struct
-                                ((Value (Type (StructType 129)))
+                                ((Value (Type (StructType 122)))
                                  ((slice (Reference (s (StructType 7))))
-                                  (value (Reference (v (UnionType 126))))))))))))))
+                                  (value (Reference (v (UnionType 119))))))))))))))
                         ((StructField
-                          ((Reference (res (StructType 129))) slice
+                          ((Reference (res (StructType 122))) slice
                            (StructType 7)))
                          (StructField
-                          ((Reference (res (StructType 129))) value
-                           (StructType 36))))
+                          ((Reference (res (StructType 122))) value
+                           (StructType 33))))
                         true))))))
                   (if_else
                    ((Block
@@ -1474,7 +1474,7 @@ let%expect_test "Deserialize Unions" =
                                  (Function
                                   ((function_signature
                                     ((function_params ((s (StructType 7))))
-                                     (function_returns (StructType 26))))
+                                     (function_returns (StructType 23))))
                                    (function_impl
                                     (Fn
                                      (Block
@@ -1495,13 +1495,13 @@ let%expect_test "Deserialize Unions" =
                                        (Return
                                         (Value
                                          (Struct
-                                          ((Value (Type (StructType 26)))
+                                          ((Value (Type (StructType 23)))
                                            ((slice
                                              (Reference (slice (StructType 7))))
                                             (value
                                              (Value
                                               (Struct
-                                               ((Value (Type (StructType 25)))
+                                               ((Value (Type (StructType 22)))
                                                 ((value
                                                   (Reference (value IntegerType))))))))))))))))))))
                                 ((StructField
@@ -1514,92 +1514,92 @@ let%expect_test "Deserialize Unions" =
                                (Function
                                 ((function_signature
                                   ((function_params
-                                    ((s (StructType 7)) (v (UnionType 126))))
-                                   (function_returns (StructType 129))))
+                                    ((s (StructType 7)) (v (UnionType 119))))
+                                   (function_returns (StructType 122))))
                                  (function_impl
                                   (Fn
                                    (Return
                                     (Value
                                      (Struct
-                                      ((Value (Type (StructType 129)))
+                                      ((Value (Type (StructType 122)))
                                        ((slice (Reference (s (StructType 7))))
-                                        (value (Reference (v (UnionType 126))))))))))))))
+                                        (value (Reference (v (UnionType 119))))))))))))))
                               ((StructField
-                                ((Reference (res (StructType 129))) slice
+                                ((Reference (res (StructType 122))) slice
                                  (StructType 7)))
                                (StructField
-                                ((Reference (res (StructType 129))) value
-                                 (StructType 25))))
+                                ((Reference (res (StructType 122))) value
+                                 (StructType 22))))
                               true))))))
                         (if_else
                          ((Expr
                            (Primitive
                             (Prim (name throw) (exprs ((Value (Integer 0)))))))))))))))))))))))))
-        (TestUnion (Value (Type (UnionType 126))))))
+        (TestUnion (Value (Type (UnionType 119))))))
       (structs
-       ((129
+       ((122
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (UnionType 126))))))
+            (value ((field_type (UnionType 119))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (UnionType 126))))
-                  (function_returns (StructType 129))))
+                 ((function_params ((s (StructType 7)) (v (UnionType 119))))
+                  (function_returns (StructType 122))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 129)))
+                     ((Value (Type (StructType 122)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (UnionType 126)))))))))))))))
-            (uty_impls ()) (uty_id 129) (uty_base_id -500)))))))
+                       (value (Reference (v (UnionType 119)))))))))))))))
+            (uty_impls ()) (uty_id 122) (uty_base_id -500)))))))
       (unions
-       ((126
+       ((119
          ((union_attributes ())
           (cases
-           (((StructType 25) (Discriminator 1))
-            ((StructType 36) (Discriminator 0))))
+           (((StructType 22) (Discriminator 1))
+            ((StructType 33) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 127)
+             (((impl_interface 120)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 36))))
-                     (function_returns (UnionType 125))))
+                    ((function_params ((v (StructType 33))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 36))) 126))))))))))
-              ((impl_interface 128)
+                      (MakeUnionVariant ((Reference (v (StructType 33))) 119))))))))))
+              ((impl_interface 121)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 25))))
-                     (function_returns (UnionType 125))))
+                    ((function_params ((v (StructType 22))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 25))) 126))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 22))) 119))))))))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (interfaces
-       ((128
+       ((121
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 25))))
+             ((function_params ((from (StructType 22))))
               (function_returns SelfType)))))))
-        (127
+        (120
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 36))))
+             ((function_params ((from (StructType 33))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 36) (StructType 25))) (un_sig_methods ())
-          (un_sig_base_id 125)))))
+        (((un_sig_cases ((StructType 33) (StructType 22))) (un_sig_methods ())
+          (un_sig_base_id 118)))))
       (attr_executors <opaque>))) |}]

--- a/test/lang.ml
+++ b/test/lang.ml
@@ -65,17 +65,17 @@ let%expect_test "program returns" =
                                                                  <opaque>)))
 
     (Ok
-     ((bindings ((T (Value (Type (StructType 126))))))
+     ((bindings ((T (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 125)
-          (st_sig_id 73)))))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 118)
+          (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "scope resolution" =
@@ -86,46 +86,46 @@ let%expect_test "scope resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 125))))))
+     ((bindings ((T (Value (Type (StructType 118))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -142,17 +142,17 @@ let%expect_test "scope resolution" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -161,19 +161,19 @@ let%expect_test "scope resolution" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -181,7 +181,7 @@ let%expect_test "scope resolution" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -190,7 +190,7 @@ let%expect_test "scope resolution" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -198,7 +198,7 @@ let%expect_test "scope resolution" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -217,27 +217,27 @@ let%expect_test "scope resolution" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -249,46 +249,46 @@ let%expect_test "binding resolution" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 125))))))
+     ((bindings ((T (Value (Type (StructType 118))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -305,17 +305,17 @@ let%expect_test "binding resolution" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -324,19 +324,19 @@ let%expect_test "binding resolution" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -344,7 +344,7 @@ let%expect_test "binding resolution" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -353,7 +353,7 @@ let%expect_test "binding resolution" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -361,7 +361,7 @@ let%expect_test "binding resolution" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -380,27 +380,27 @@ let%expect_test "binding resolution" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -426,46 +426,46 @@ let%expect_test "scope resolution after let binding" =
     {|
     (Ok
      ((bindings
-       ((B (Value (Type (StructType 125)))) (A (Value (Type (StructType 125))))))
+       ((B (Value (Type (StructType 118)))) (A (Value (Type (StructType 118))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -482,17 +482,17 @@ let%expect_test "scope resolution after let binding" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -501,19 +501,19 @@ let%expect_test "scope resolution after let binding" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -521,7 +521,7 @@ let%expect_test "scope resolution after let binding" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -530,7 +530,7 @@ let%expect_test "scope resolution after let binding" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -538,7 +538,7 @@ let%expect_test "scope resolution after let binding" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -557,27 +557,27 @@ let%expect_test "scope resolution after let binding" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -589,50 +589,50 @@ let%expect_test "basic struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((T (Value (Type (StructType 128))))))
+     ((bindings ((T (Value (Type (StructType 121))))))
       (structs
-       ((128
-         ((struct_fields ((t ((field_type (StructType 125))))))
+       ((121
+         ((struct_fields ((t ((field_type (StructType 118))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 127)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 120)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -649,17 +649,17 @@ let%expect_test "basic struct definition" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -668,19 +668,19 @@ let%expect_test "basic struct definition" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -688,7 +688,7 @@ let%expect_test "basic struct definition" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -697,7 +697,7 @@ let%expect_test "basic struct definition" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -705,7 +705,7 @@ let%expect_test "basic struct definition" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -724,32 +724,32 @@ let%expect_test "basic struct definition" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ((t (Value (Type (StructType 125))))))
-          (st_sig_methods ()) (st_sig_base_id 127) (st_sig_id 73)))))
+        (((st_sig_fields ((t (Value (Type (StructType 118))))))
+          (st_sig_methods ()) (st_sig_base_id 120) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Tact function evaluation" =
@@ -769,53 +769,53 @@ let%expect_test "Tact function evaluation" =
        ((a
          (Value
           (Struct
-           ((Value (Type (StructType 125))) ((value (Value (Integer 1))))))))
+           ((Value (Type (StructType 118))) ((value (Value (Integer 1))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 125))))
-              (function_returns (StructType 125))))
-            (function_impl (Fn (Return (Reference (i (StructType 125))))))))))))
+             ((function_params ((i (StructType 118))))
+              (function_returns (StructType 118))))
+            (function_impl (Fn (Return (Reference (i (StructType 118))))))))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -832,17 +832,17 @@ let%expect_test "Tact function evaluation" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -851,19 +851,19 @@ let%expect_test "Tact function evaluation" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -871,7 +871,7 @@ let%expect_test "Tact function evaluation" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -880,7 +880,7 @@ let%expect_test "Tact function evaluation" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -888,7 +888,7 @@ let%expect_test "Tact function evaluation" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -907,27 +907,27 @@ let%expect_test "Tact function evaluation" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -944,51 +944,51 @@ let%expect_test "struct definition" =
   [%expect
     {|
     (Ok
-     ((bindings ((MyType (Value (Type (StructType 128))))))
+     ((bindings ((MyType (Value (Type (StructType 121))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
-           ((a ((field_type (StructType 125)))) (b ((field_type BoolType)))))
+           ((a ((field_type (StructType 118)))) (b ((field_type BoolType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 127)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 120)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -1005,17 +1005,17 @@ let%expect_test "struct definition" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1024,19 +1024,19 @@ let%expect_test "struct definition" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1044,7 +1044,7 @@ let%expect_test "struct definition" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1053,7 +1053,7 @@ let%expect_test "struct definition" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -1061,7 +1061,7 @@ let%expect_test "struct definition" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -1080,34 +1080,34 @@ let%expect_test "struct definition" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields
-           ((a (Value (Type (StructType 125))))
+           ((a (Value (Type (StructType 118))))
             (b (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 127) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 120) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "duplicate type field" =
@@ -1125,56 +1125,56 @@ let%expect_test "duplicate type field" =
     (((DuplicateField
        (a
         ((mk_struct_fields
-          ((a (Value (Type (StructType 125))))
+          ((a (Value (Type (StructType 118))))
            (a (ResolvedReference (Bool <opaque>)))))
          (mk_struct_details
-          ((mk_methods ()) (mk_impls ()) (mk_id 127) (mk_sig 73)
+          ((mk_methods ()) (mk_impls ()) (mk_id 120) (mk_sig 45)
            (mk_span <opaque>)))))))
-     ((bindings ((MyType (Value (Type (StructType 128))))))
+     ((bindings ((MyType (Value (Type (StructType 121))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
-           ((a ((field_type (StructType 125)))) (a ((field_type BoolType)))))
+           ((a ((field_type (StructType 118)))) (a ((field_type BoolType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 127)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 120)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -1191,17 +1191,17 @@ let%expect_test "duplicate type field" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1210,19 +1210,19 @@ let%expect_test "duplicate type field" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1230,7 +1230,7 @@ let%expect_test "duplicate type field" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1239,7 +1239,7 @@ let%expect_test "duplicate type field" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -1247,7 +1247,7 @@ let%expect_test "duplicate type field" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -1266,34 +1266,34 @@ let%expect_test "duplicate type field" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields
-           ((a (Value (Type (StructType 125))))
+           ((a (Value (Type (StructType 118))))
             (a (ResolvedReference (Bool <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 127) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 120) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "parametric struct instantiation" =
@@ -1308,64 +1308,64 @@ let%expect_test "parametric struct instantiation" =
     {|
     (Ok
      ((bindings
-       ((TA (Value (Type (StructType 128))))
+       ((TA (Value (Type (StructType 121))))
         (T
          (Value
           (Function
            ((function_signature
              ((function_is_type) (function_params ((A (TypeN 0))))
-              (function_returns (StructSig 73))))
+              (function_returns (StructSig 45))))
             (function_impl
              (Fn
               (Return
                (MkStructDef
                 ((mk_struct_fields ((a (Reference (A (TypeN 0))))))
                  (mk_struct_details
-                  ((mk_methods ()) (mk_impls ()) (mk_id 125) (mk_sig 73)
+                  ((mk_methods ()) (mk_impls ()) (mk_id 118) (mk_sig 45)
                    (mk_span <opaque>))))))))))))))
       (structs
-       ((128
-         ((struct_fields ((a ((field_type (StructType 126))))))
+       ((121
+         ((struct_fields ((a ((field_type (StructType 119))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 125)))))
-        (127
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 118)))))
+        (120
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 126))))))
+            (value ((field_type (StructType 119))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 126))))
-                  (function_returns (StructType 127))))
+                 ((function_params ((s (StructType 7)) (v (StructType 119))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 126)))))))))))))))
-            (uty_impls ()) (uty_id 127) (uty_base_id -500)))))
-        (126
+                       (value (Reference (v (StructType 119)))))))))))))))
+            (uty_impls ()) (uty_id 120) (uty_base_id -500)))))
+        (119
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Block
@@ -1382,17 +1382,17 @@ let%expect_test "parametric struct instantiation" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 127)))
+                       ((Value (Type (StructType 120)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 126)))
+                            ((Value (Type (StructType 119)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 126)) (builder (StructType 3))))
+                   ((self (StructType 119)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1401,19 +1401,19 @@ let%expect_test "parametric struct instantiation" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 126))) value IntegerType))
+                       ((Reference (self (StructType 119))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1421,7 +1421,7 @@ let%expect_test "parametric struct instantiation" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 126)) (builder (StructType 3))))
+                      ((self (StructType 119)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1430,7 +1430,7 @@ let%expect_test "parametric struct instantiation" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 126))) value IntegerType))
+                          ((Reference (self (StructType 119))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -1438,7 +1438,7 @@ let%expect_test "parametric struct instantiation" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Block
@@ -1457,32 +1457,32 @@ let%expect_test "parametric struct instantiation" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 127)))
+                          ((Value (Type (StructType 120)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 126)))
+                               ((Value (Type (StructType 119)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 126)))
+                        ((Value (Type (StructType 119)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 126) (uty_base_id 18)))))))
+            (uty_id 119) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields ((a (Reference (A (TypeN 0)))))) (st_sig_methods ())
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "function without a return type" =
@@ -1523,57 +1523,57 @@ let%expect_test "scoping that `let` introduces in code" =
        ((b
          (Value
           (Struct
-           ((Value (Type (StructType 125))) ((value (Value (Integer 1))))))))
+           ((Value (Type (StructType 118))) ((value (Value (Integer 1))))))))
         (f
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 125))))
-              (function_returns (StructType 125))))
+             ((function_params ((i (StructType 118))))
+              (function_returns (StructType 118))))
             (function_impl
              (Fn
               (Block
-               ((Let ((a (Reference (i (StructType 125))))))
-                (Return (Reference (a (StructType 125))))))))))))))
+               ((Let ((a (Reference (i (StructType 118))))))
+                (Return (Reference (a (StructType 118))))))))))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -1590,17 +1590,17 @@ let%expect_test "scoping that `let` introduces in code" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1609,19 +1609,19 @@ let%expect_test "scoping that `let` introduces in code" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1629,7 +1629,7 @@ let%expect_test "scoping that `let` introduces in code" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1638,7 +1638,7 @@ let%expect_test "scoping that `let` introduces in code" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -1646,7 +1646,7 @@ let%expect_test "scoping that `let` introduces in code" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -1665,27 +1665,27 @@ let%expect_test "scoping that `let` introduces in code" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -1711,7 +1711,7 @@ let%expect_test "reference in function bodies" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 125))))
+             ((function_params ((x (StructType 118))))
               (function_returns HoleType)))
             (function_impl
              (Fn
@@ -1720,62 +1720,62 @@ let%expect_test "reference in function bodies" =
                  ((a
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
-                     ((Reference (x (StructType 125)))
-                      (Reference (x (StructType 125))))
+                     ((Reference (x (StructType 118)))
+                      (Reference (x (StructType 118))))
                      false)))))
                 (Let
                  ((b
                    (FunctionCall
                     ((ResolvedReference (op <opaque>))
-                     ((Reference (a (StructType 125)))
-                      (Reference (a (StructType 125))))
+                     ((Reference (a (StructType 118)))
+                      (Reference (a (StructType 118))))
                      false)))))))))))))
         (op
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 125)) (i_ (StructType 125))))
-              (function_returns (StructType 125))))
-            (function_impl (Fn (Return (Reference (i (StructType 125))))))))))))
+             ((function_params ((i (StructType 118)) (i_ (StructType 118))))
+              (function_returns (StructType 118))))
+            (function_impl (Fn (Return (Reference (i (StructType 118))))))))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -1792,17 +1792,17 @@ let%expect_test "reference in function bodies" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -1811,19 +1811,19 @@ let%expect_test "reference in function bodies" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -1831,7 +1831,7 @@ let%expect_test "reference in function bodies" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -1840,7 +1840,7 @@ let%expect_test "reference in function bodies" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -1848,7 +1848,7 @@ let%expect_test "reference in function bodies" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -1867,27 +1867,27 @@ let%expect_test "reference in function bodies" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -1935,19 +1935,19 @@ let%expect_test "struct method access" =
     (Ok
      ((bindings
        ((res (Value (Integer 1)))
-        (foo (Value (Struct ((Value (Type (StructType 126))) ()))))
-        (Foo (Value (Type (StructType 126))))))
+        (foo (Value (Struct ((Value (Type (StructType 119))) ()))))
+        (Foo (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (StructType 126)) (i IntegerType)))
+                 ((function_params ((self (StructType 119)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -1955,10 +1955,10 @@ let%expect_test "struct method access" =
           (st_sig_methods
            ((bar
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 73)))))
+               ((self (ExprType (Reference (Self (StructSig 45)))))
                 (i IntegerType)))
               (function_returns IntegerType)))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct type method access" =
@@ -1977,9 +1977,9 @@ let%expect_test "struct type method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (Foo (Value (Type (StructType 126))))))
+       ((res (Value (Integer 1))) (Foo (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields ())
           (struct_details
            ((uty_methods
@@ -1988,7 +1988,7 @@ let%expect_test "struct type method access" =
                  ((function_params ((i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (i IntegerType)))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -1996,7 +1996,7 @@ let%expect_test "struct type method access" =
           (st_sig_methods
            ((bar
              ((function_params ((i IntegerType))) (function_returns IntegerType)))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Self type resolution in methods" =
@@ -2013,18 +2013,18 @@ let%expect_test "Self type resolution in methods" =
   [%expect
     {|
     (Ok
-     ((bindings ((Foo (Value (Type (StructType 126))))))
+     ((bindings ((Foo (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (StructType 126))))
-                  (function_returns (StructType 126))))
-                (function_impl (Fn (Return (Reference (self (StructType 126))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+                 ((function_params ((self (StructType 119))))
+                  (function_returns (StructType 119))))
+                (function_impl (Fn (Return (Reference (self (StructType 119))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -2032,9 +2032,9 @@ let%expect_test "Self type resolution in methods" =
           (st_sig_methods
            ((bar
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 73)))))))
-              (function_returns (ExprType (Reference (Self (StructSig 73)))))))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+               ((self (ExprType (Reference (Self (StructSig 45)))))))
+              (function_returns (ExprType (Reference (Self (StructSig 45)))))))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "union method access" =
@@ -2058,39 +2058,39 @@ let%expect_test "union method access" =
     {|
     (Ok
      ((bindings
-       ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 126))))
+       ((res (Value (Integer 1))) (foo (Value (UnionVariant ((Bool true) 119))))
         (make_foo
          (Value
           (Function
            ((function_signature
-             ((function_params ((foo (UnionType 126))))
-              (function_returns (UnionType 126))))
-            (function_impl (Fn (Return (Reference (foo (UnionType 126))))))))))
-        (Foo (Value (Type (UnionType 126))))))
+             ((function_params ((foo (UnionType 119))))
+              (function_returns (UnionType 119))))
+            (function_impl (Fn (Return (Reference (foo (UnionType 119))))))))))
+        (Foo (Value (Type (UnionType 119))))))
       (structs ())
       (unions
-       ((126
+       ((119
          ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
           (union_details
            ((uty_methods
              ((bar
                ((function_signature
-                 ((function_params ((self (UnionType 126)) (i IntegerType)))
+                 ((function_params ((self (UnionType 119)) (i IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (i IntegerType)))))))))
             (uty_impls
-             (((impl_interface 127)
+             (((impl_interface 120)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v BoolType)))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
-                     (Return (MakeUnionVariant ((Reference (v BoolType)) 126))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+                     (Return (MakeUnionVariant ((Reference (v BoolType)) 119))))))))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (interfaces
-       ((127
+       ((120
          ((interface_methods
            ((from
              ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -2104,7 +2104,7 @@ let%expect_test "union method access" =
                ((self (ExprType (Reference (Self (UnionSig 5)))))
                 (i IntegerType)))
               (function_returns IntegerType)))))
-          (un_sig_base_id 125)))))
+          (un_sig_base_id 118)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "union type method access" =
@@ -2132,13 +2132,13 @@ let%expect_test "union type method access" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((foo (UnionType 126))))
-              (function_returns (UnionType 126))))
-            (function_impl (Fn (Return (Reference (foo (UnionType 126))))))))))
-        (Foo (Value (Type (UnionType 126))))))
+             ((function_params ((foo (UnionType 119))))
+              (function_returns (UnionType 119))))
+            (function_impl (Fn (Return (Reference (foo (UnionType 119))))))))))
+        (Foo (Value (Type (UnionType 119))))))
       (structs ())
       (unions
-       ((126
+       ((119
          ((union_attributes ()) (cases ((BoolType (Discriminator 0))))
           (union_details
            ((uty_methods
@@ -2148,18 +2148,18 @@ let%expect_test "union type method access" =
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (i IntegerType)))))))))
             (uty_impls
-             (((impl_interface 127)
+             (((impl_interface 120)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v BoolType)))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
-                     (Return (MakeUnionVariant ((Reference (v BoolType)) 126))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+                     (Return (MakeUnionVariant ((Reference (v BoolType)) 119))))))))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (interfaces
-       ((127
+       ((120
          ((interface_methods
            ((from
              ((function_params ((from BoolType))) (function_returns SelfType)))))))))
@@ -2170,7 +2170,7 @@ let%expect_test "union type method access" =
           (un_sig_methods
            ((bar
              ((function_params ((i IntegerType))) (function_returns IntegerType)))))
-          (un_sig_base_id 125)))))
+          (un_sig_base_id 118)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "struct instantiation" =
@@ -2192,22 +2192,22 @@ let%expect_test "struct instantiation" =
        ((t
          (Value
           (Struct
-           ((Value (Type (StructType 126)))
+           ((Value (Type (StructType 119)))
             ((a (Value (Integer 1))) (b (Value (Integer 2))))))))
-        (T (Value (Type (StructType 126))))))
+        (T (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((a ((field_type IntegerType))) (b ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields
            ((a (ResolvedReference (Integer <opaque>)))
             (b (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type check error" =
@@ -2217,54 +2217,54 @@ let%expect_test "type check error" =
   pp_compile source ;
   [%expect
     {|
-    (((TypeError ((StructType 127) (StructType 125) <opaque>)))
+    (((TypeError ((StructType 120) (StructType 118) <opaque>)))
      ((bindings
        ((foo
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (StructType 125))))
-              (function_returns (StructType 127))))
-            (function_impl (Fn (Return (Reference (i (StructType 125))))))))))))
+             ((function_params ((i (StructType 118))))
+              (function_returns (StructType 120))))
+            (function_impl (Fn (Return (Reference (i (StructType 118))))))))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 127))))))
+            (value ((field_type (StructType 120))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 127))))
-                  (function_returns (StructType 128))))
+                 ((function_params ((s (StructType 7)) (v (StructType 120))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 128)))
+                     ((Value (Type (StructType 121)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 127)))))))))))))))
-            (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-        (127
+                       (value (Reference (v (StructType 120)))))))))))))))
+            (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+        (120
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 128))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Block
@@ -2281,17 +2281,17 @@ let%expect_test "type check error" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 127)))
+                            ((Value (Type (StructType 120)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 127)) (builder (StructType 3))))
+                   ((self (StructType 120)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2300,19 +2300,19 @@ let%expect_test "type check error" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 127))) value IntegerType))
+                       ((Reference (self (StructType 120))) value IntegerType))
                       (Value (Integer 64)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -2320,7 +2320,7 @@ let%expect_test "type check error" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 127)) (builder (StructType 3))))
+                      ((self (StructType 120)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2329,7 +2329,7 @@ let%expect_test "type check error" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 127))) value IntegerType))
+                          ((Reference (self (StructType 120))) value IntegerType))
                          (Value (Integer 64)))
                         false))))))))))
               ((impl_interface -2)
@@ -2337,7 +2337,7 @@ let%expect_test "type check error" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 128))))
+                     (function_returns (StructType 121))))
                    (function_impl
                     (Fn
                      (Block
@@ -2355,65 +2355,65 @@ let%expect_test "type check error" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 128)))
+                          ((Value (Type (StructType 121)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 127)))
+                               ((Value (Type (StructType 120)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 127)))
+                        ((Value (Type (StructType 120)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 127) (uty_base_id 18)))))
-        (126
+            (uty_id 120) (uty_base_id 16)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -2430,17 +2430,17 @@ let%expect_test "type check error" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2449,19 +2449,19 @@ let%expect_test "type check error" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 32)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -2469,7 +2469,7 @@ let%expect_test "type check error" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2478,7 +2478,7 @@ let%expect_test "type check error" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 32)))
                         false))))))))))
               ((impl_interface -2)
@@ -2486,7 +2486,7 @@ let%expect_test "type check error" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -2504,32 +2504,32 @@ let%expect_test "type check error" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (interfaces
-       ((129
+       ((122
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 125))))
+             ((function_params ((from (StructType 118))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
@@ -2660,55 +2660,55 @@ let%expect_test "type check error" =
   pp_compile source ;
   [%expect
     {|
-    (((TypeError ((StructType 125) (StructType 127) <opaque>))
+    (((TypeError ((StructType 118) (StructType 120) <opaque>))
       (ArgumentNumberMismatch (1 1 <opaque>)))
      ((bindings
        ((foo
          (Value
           (Function
            ((function_signature
-             ((function_params ((x (StructType 125))))
-              (function_returns (StructType 125))))
-            (function_impl (Fn (Return (Reference (x (StructType 125))))))))))))
+             ((function_params ((x (StructType 118))))
+              (function_returns (StructType 118))))
+            (function_impl (Fn (Return (Reference (x (StructType 118))))))))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 127))))))
+            (value ((field_type (StructType 120))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 127))))
-                  (function_returns (StructType 128))))
+                 ((function_params ((s (StructType 7)) (v (StructType 120))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 128)))
+                     ((Value (Type (StructType 121)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 127)))))))))))))))
-            (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-        (127
+                       (value (Reference (v (StructType 120)))))))))))))))
+            (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+        (120
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 128))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Block
@@ -2725,17 +2725,17 @@ let%expect_test "type check error" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 127)))
+                            ((Value (Type (StructType 120)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 127)) (builder (StructType 3))))
+                   ((self (StructType 120)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2744,19 +2744,19 @@ let%expect_test "type check error" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 127))) value IntegerType))
+                       ((Reference (self (StructType 120))) value IntegerType))
                       (Value (Integer 10)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -2764,7 +2764,7 @@ let%expect_test "type check error" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 127)) (builder (StructType 3))))
+                      ((self (StructType 120)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2773,7 +2773,7 @@ let%expect_test "type check error" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 127))) value IntegerType))
+                          ((Reference (self (StructType 120))) value IntegerType))
                          (Value (Integer 10)))
                         false))))))))))
               ((impl_interface -2)
@@ -2781,7 +2781,7 @@ let%expect_test "type check error" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 128))))
+                     (function_returns (StructType 121))))
                    (function_impl
                     (Fn
                      (Block
@@ -2799,65 +2799,65 @@ let%expect_test "type check error" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 128)))
+                          ((Value (Type (StructType 121)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 127)))
+                               ((Value (Type (StructType 120)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 127)))
+                        ((Value (Type (StructType 120)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 127) (uty_base_id 18)))))
-        (126
+            (uty_id 120) (uty_base_id 16)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -2874,17 +2874,17 @@ let%expect_test "type check error" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -2893,19 +2893,19 @@ let%expect_test "type check error" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 99)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -2913,7 +2913,7 @@ let%expect_test "type check error" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -2922,7 +2922,7 @@ let%expect_test "type check error" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 99)))
                         false))))))))))
               ((impl_interface -2)
@@ -2930,7 +2930,7 @@ let%expect_test "type check error" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -2948,32 +2948,32 @@ let%expect_test "type check error" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (interfaces
-       ((129
+       ((122
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 127))))
+             ((function_params ((from (StructType 120))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
@@ -2994,9 +2994,9 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((one (Value (Integer 1))) (Left (Value (Type (StructType 126))))))
+       ((one (Value (Integer 1))) (Left (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields ())
           (struct_details
            ((uty_methods
@@ -3013,7 +3013,7 @@ let%expect_test "implement interface op" =
                     ((function_params ((left IntegerType) (right IntegerType)))
                      (function_returns IntegerType)))
                    (function_impl (Fn (Return (Reference (left IntegerType))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -3022,7 +3022,7 @@ let%expect_test "implement interface op" =
            ((op
              ((function_params ((left IntegerType) (right IntegerType)))
               (function_returns IntegerType)))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "implement interface op" =
@@ -3044,33 +3044,33 @@ let%expect_test "implement interface op" =
     {|
     (Ok
      ((bindings
-       ((empty (Value (Struct ((Value (Type (StructType 127))) ()))))
-        (Empty (Value (Type (StructType 127))))
-        (Make (Value (Type (InterfaceType 125))))))
+       ((empty (Value (Struct ((Value (Type (StructType 120))) ()))))
+        (Empty (Value (Type (StructType 120))))
+        (Make (Value (Type (InterfaceType 118))))))
       (structs
-       ((127
+       ((120
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ()) (function_returns (StructType 127))))
+                 ((function_params ()) (function_returns (StructType 120))))
                 (function_impl
                  (Fn
-                  (Return (Value (Struct ((Value (Type (StructType 127))) ()))))))))))
+                  (Return (Value (Struct ((Value (Type (StructType 120))) ()))))))))))
             (uty_impls
-             (((impl_interface 125)
+             (((impl_interface 118)
                (impl_methods
                 ((new
                   ((function_signature
-                    ((function_params ()) (function_returns (StructType 127))))
+                    ((function_params ()) (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
-                      (Value (Struct ((Value (Type (StructType 127))) ())))))))))))))
-            (uty_id 127) (uty_base_id 126)))))))
+                      (Value (Struct ((Value (Type (StructType 120))) ())))))))))))))
+            (uty_id 120) (uty_base_id 119)))))))
       (interfaces
-       ((125
+       ((118
          ((interface_methods
            ((new ((function_params ()) (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
@@ -3080,8 +3080,8 @@ let%expect_test "implement interface op" =
           (st_sig_methods
            ((new
              ((function_params ())
-              (function_returns (ExprType (Reference (Self (StructSig 73)))))))))
-          (st_sig_base_id 126) (st_sig_id 73)))))
+              (function_returns (ExprType (Reference (Self (StructSig 45)))))))))
+          (st_sig_base_id 119) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "serializer inner struct" =
@@ -3101,7 +3101,7 @@ let%expect_test "serializer inner struct" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((self (StructType 130)) (b (StructType 3))))
+             ((function_params ((self (StructType 123)) (b (StructType 3))))
               (function_returns (StructType 3))))
             (function_impl
              (Fn
@@ -3113,7 +3113,7 @@ let%expect_test "serializer inner struct" =
                       (Function
                        ((function_signature
                          ((function_params
-                           ((self (StructType 125)) (builder (StructType 3))))
+                           ((self (StructType 118)) (builder (StructType 3))))
                           (function_returns (StructType 3))))
                         (function_impl
                          (Fn
@@ -3122,66 +3122,66 @@ let%expect_test "serializer inner struct" =
                             ((ResolvedReference (serialize_int <opaque>))
                              ((Reference (builder (StructType 3)))
                               (StructField
-                               ((Reference (self (StructType 125))) value
+                               ((Reference (self (StructType 118))) value
                                 IntegerType))
                               (Value (Integer 32)))
                              false))))))))
                      ((StructField
-                       ((Reference (self (StructType 130))) y (StructType 125)))
+                       ((Reference (self (StructType 123))) y (StructType 118)))
                       (Reference (b (StructType 3))))
                      false)))))
                 (Return (Reference (b (StructType 3))))))))))))
-        (Outer (Value (Type (StructType 130))))
-        (Inner (Value (Type (StructType 128))))))
+        (Outer (Value (Type (StructType 123))))
+        (Inner (Value (Type (StructType 121))))))
       (structs
-       ((130
+       ((123
          ((struct_fields
-           ((y ((field_type (StructType 125))))
-            (z ((field_type (StructType 128))))))
+           ((y ((field_type (StructType 118))))
+            (z ((field_type (StructType 121))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 130) (uty_base_id 129)))))
-        (128
-         ((struct_fields ((x ((field_type (StructType 125))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 123) (uty_base_id 122)))))
+        (121
+         ((struct_fields ((x ((field_type (StructType 118))))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 127)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 120)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -3198,17 +3198,17 @@ let%expect_test "serializer inner struct" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3217,19 +3217,19 @@ let%expect_test "serializer inner struct" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 32)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -3237,7 +3237,7 @@ let%expect_test "serializer inner struct" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -3246,7 +3246,7 @@ let%expect_test "serializer inner struct" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 32)))
                         false))))))))))
               ((impl_interface -2)
@@ -3254,7 +3254,7 @@ let%expect_test "serializer inner struct" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -3272,36 +3272,36 @@ let%expect_test "serializer inner struct" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (2
         (((st_sig_fields
-           ((y (Value (Type (StructType 125))))
+           ((y (Value (Type (StructType 118))))
             (z (ResolvedReference (Inner <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 129) (st_sig_id 74))
-         ((st_sig_fields ((x (Value (Type (StructType 125))))))
-          (st_sig_methods ()) (st_sig_base_id 127) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 122) (st_sig_id 46))
+         ((st_sig_fields ((x (Value (Type (StructType 118))))))
+          (st_sig_methods ()) (st_sig_base_id 120) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "reference resolving in inner functions" =
@@ -3450,56 +3450,56 @@ let%expect_test "union variants constructing" =
          (Value
           (UnionVariant
            ((Struct
-             ((Value (Type (StructType 125))) ((value (Value (Integer 1))))))
-            128))))
-        (a (Value (UnionVariant ((Integer 10) 128))))
+             ((Value (Type (StructType 118))) ((value (Value (Integer 1))))))
+            121))))
+        (a (Value (UnionVariant ((Integer 10) 121))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((value (UnionType 128))))
-              (function_returns (UnionType 128))))
-            (function_impl (Fn (Return (Reference (value (UnionType 128))))))))))
-        (Uni (Value (Type (UnionType 128))))))
+             ((function_params ((value (UnionType 121))))
+              (function_returns (UnionType 121))))
+            (function_impl (Fn (Return (Reference (value (UnionType 121))))))))))
+        (Uni (Value (Type (UnionType 121))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -3516,17 +3516,17 @@ let%expect_test "union variants constructing" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3535,19 +3535,19 @@ let%expect_test "union variants constructing" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 32)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -3555,7 +3555,7 @@ let%expect_test "union variants constructing" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -3564,7 +3564,7 @@ let%expect_test "union variants constructing" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 32)))
                         false))))))))))
               ((impl_interface -2)
@@ -3572,7 +3572,7 @@ let%expect_test "union variants constructing" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -3590,67 +3590,67 @@ let%expect_test "union variants constructing" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (unions
-       ((128
+       ((121
          ((union_attributes ())
           (cases
-           (((StructType 125) (Discriminator 1)) (IntegerType (Discriminator 0))))
+           (((StructType 118) (Discriminator 1)) (IntegerType (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 19)
+             (((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 127))))
+                     (function_returns (UnionType 120))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 128))))))))))
-              ((impl_interface 129)
+                      (MakeUnionVariant ((Reference (v IntegerType)) 121))))))))))
+              ((impl_interface 122)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 125))))
-                     (function_returns (UnionType 127))))
+                    ((function_params ((v (StructType 118))))
+                     (function_returns (UnionType 120))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 125))) 128))))))))))))
-            (uty_id 128) (uty_base_id 127)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 118))) 121))))))))))))
+            (uty_id 121) (uty_base_id 120)))))))
       (interfaces
-       ((129
+       ((122
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 125))))
+             ((function_params ((from (StructType 118))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases (IntegerType (StructType 125))) (un_sig_methods ())
-          (un_sig_base_id 127)))))
+        (((un_sig_cases (IntegerType (StructType 118))) (un_sig_methods ())
+          (un_sig_base_id 120)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "unions duplicate variant" =
@@ -3669,7 +3669,7 @@ let%expect_test "unions duplicate variant" =
     {|
     (((DuplicateVariant (IntegerType <opaque>)))
      ((bindings
-       ((b (Value (Type (UnionType 128)))) (a (Value (Type (UnionType 126))))
+       ((b (Value (Type (UnionType 121)))) (a (Value (Type (UnionType 119))))
         (Test
          (Value
           (Function
@@ -3686,19 +3686,19 @@ let%expect_test "unions duplicate variant" =
                  (mk_union_details
                   ((mk_methods ())
                    (mk_impls
-                    (((mk_impl_interface (Value (Type (InterfaceType 19))))
+                    (((mk_impl_interface (Value (Type (InterfaceType 17))))
                       (mk_impl_methods
                        ((from
                          (Value
                           (Function
                            ((function_signature
                              ((function_params ((v IntegerType)))
-                              (function_returns (UnionType 125))))
+                              (function_returns (UnionType 118))))
                             (function_impl
                              (Fn
                               (Return
                                (MakeUnionVariant
-                                ((Reference (v IntegerType)) 125))))))))))))
+                                ((Reference (v IntegerType)) 118))))))))))))
                      ((mk_impl_interface
                        (FunctionCall
                         ((Value
@@ -3717,44 +3717,44 @@ let%expect_test "unions duplicate variant" =
                            ((function_signature
                              ((function_params
                                ((v (ExprType (Reference (T (TypeN 0)))))))
-                              (function_returns (UnionType 125))))
+                              (function_returns (UnionType 118))))
                             (function_impl
                              (Fn
                               (Return
                                (MakeUnionVariant
                                 ((Reference
                                   (v (ExprType (Reference (T (TypeN 0))))))
-                                 125))))))))))))))
-                   (mk_id 125) (mk_sig 5) (mk_span <opaque>))))))))))))))
+                                 118))))))))))))))
+                   (mk_id 118) (mk_sig 5) (mk_span <opaque>))))))))))))))
       (structs ())
       (unions
-       ((128
+       ((121
          ((union_attributes ()) (cases ((IntegerType (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 19)
+             (((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 128))))))))))
-              ((impl_interface 19)
+                      (MakeUnionVariant ((Reference (v IntegerType)) 121))))))))))
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 128))))))))))))
-            (uty_id 128) (uty_base_id 125)))))
-        (126
+                      (MakeUnionVariant ((Reference (v IntegerType)) 121))))))))))))
+            (uty_id 121) (uty_base_id 118)))))
+        (119
          ((union_attributes ())
           (cases
            (((BuiltinType Builder) (Discriminator 1))
@@ -3762,30 +3762,30 @@ let%expect_test "unions duplicate variant" =
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 19)
+             (((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v IntegerType)))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v IntegerType)) 126))))))))))
-              ((impl_interface 127)
+                      (MakeUnionVariant ((Reference (v IntegerType)) 119))))))))))
+              ((impl_interface 120)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v (BuiltinType Builder))))
-                     (function_returns (UnionType 125))))
+                     (function_returns (UnionType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (MakeUnionVariant
-                       ((Reference (v (BuiltinType Builder))) 126))))))))))))
-            (uty_id 126) (uty_base_id 125)))))))
+                       ((Reference (v (BuiltinType Builder))) 119))))))))))))
+            (uty_id 119) (uty_base_id 118)))))))
       (interfaces
-       ((127
+       ((120
          ((interface_methods
            ((from
              ((function_params ((from (BuiltinType Builder))))
@@ -3794,7 +3794,7 @@ let%expect_test "unions duplicate variant" =
       (union_signs
        (1
         (((un_sig_cases (IntegerType (ExprType (Reference (T (TypeN 0))))))
-          (un_sig_methods ()) (un_sig_base_id 125)))))
+          (un_sig_methods ()) (un_sig_base_id 118)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "unions" =
@@ -3813,46 +3813,46 @@ let%expect_test "unions" =
   [%expect
     {|
     (Ok
-     ((bindings ((Test (Value (Type (UnionType 130))))))
+     ((bindings ((Test (Value (Type (UnionType 123))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 127))))))
+            (value ((field_type (StructType 120))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 127))))
-                  (function_returns (StructType 128))))
+                 ((function_params ((s (StructType 7)) (v (StructType 120))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 128)))
+                     ((Value (Type (StructType 121)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 127)))))))))))))))
-            (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-        (127
+                       (value (Reference (v (StructType 120)))))))))))))))
+            (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+        (120
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 128))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Block
@@ -3869,17 +3869,17 @@ let%expect_test "unions" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 127)))
+                            ((Value (Type (StructType 120)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 127)) (builder (StructType 3))))
+                   ((self (StructType 120)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -3888,19 +3888,19 @@ let%expect_test "unions" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 127))) value IntegerType))
+                       ((Reference (self (StructType 120))) value IntegerType))
                       (Value (Integer 64)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -3908,7 +3908,7 @@ let%expect_test "unions" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 127)) (builder (StructType 3))))
+                      ((self (StructType 120)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -3917,7 +3917,7 @@ let%expect_test "unions" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 127))) value IntegerType))
+                          ((Reference (self (StructType 120))) value IntegerType))
                          (Value (Integer 64)))
                         false))))))))))
               ((impl_interface -2)
@@ -3925,7 +3925,7 @@ let%expect_test "unions" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 128))))
+                     (function_returns (StructType 121))))
                    (function_impl
                     (Fn
                      (Block
@@ -3943,65 +3943,65 @@ let%expect_test "unions" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 128)))
+                          ((Value (Type (StructType 121)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 127)))
+                               ((Value (Type (StructType 120)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 127)))
+                        ((Value (Type (StructType 120)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 127) (uty_base_id 18)))))
-        (126
+            (uty_id 120) (uty_base_id 16)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -4018,17 +4018,17 @@ let%expect_test "unions" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -4037,19 +4037,19 @@ let%expect_test "unions" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -4057,7 +4057,7 @@ let%expect_test "unions" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -4066,7 +4066,7 @@ let%expect_test "unions" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -4074,7 +4074,7 @@ let%expect_test "unions" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -4093,83 +4093,83 @@ let%expect_test "unions" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (unions
-       ((130
+       ((123
          ((union_attributes ())
           (cases
-           (((StructType 127) (Discriminator 1))
-            ((StructType 125) (Discriminator 0))))
+           (((StructType 120) (Discriminator 1))
+            ((StructType 118) (Discriminator 0))))
           (union_details
            ((uty_methods
              ((id
                ((function_signature
-                 ((function_params ((self (UnionType 130))))
-                  (function_returns (UnionType 130))))
-                (function_impl (Fn (Return (Reference (self (UnionType 130))))))))))
+                 ((function_params ((self (UnionType 123))))
+                  (function_returns (UnionType 123))))
+                (function_impl (Fn (Return (Reference (self (UnionType 123))))))))))
             (uty_impls
-             (((impl_interface 131)
+             (((impl_interface 124)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 125))))
-                     (function_returns (UnionType 129))))
+                    ((function_params ((v (StructType 118))))
+                     (function_returns (UnionType 122))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 125))) 130))))))))))
-              ((impl_interface 132)
+                      (MakeUnionVariant ((Reference (v (StructType 118))) 123))))))))))
+              ((impl_interface 125)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 127))))
-                     (function_returns (UnionType 129))))
+                    ((function_params ((v (StructType 120))))
+                     (function_returns (UnionType 122))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 127))) 130))))))))))))
-            (uty_id 130) (uty_base_id 129)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 120))) 123))))))))))))
+            (uty_id 123) (uty_base_id 122)))))))
       (interfaces
-       ((132
+       ((125
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 127))))
+             ((function_params ((from (StructType 120))))
               (function_returns SelfType)))))))
-        (131
+        (124
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 125))))
+             ((function_params ((from (StructType 118))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 125) (StructType 127)))
+        (((un_sig_cases ((StructType 118) (StructType 120)))
           (un_sig_methods
            ((id
              ((function_params
                ((self (ExprType (Reference (Self (UnionSig 5)))))))
               (function_returns (ExprType (Reference (Self (UnionSig 5)))))))))
-          (un_sig_base_id 129)))))
+          (un_sig_base_id 122)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "methods monomorphization" =
@@ -4193,16 +4193,16 @@ let%expect_test "methods monomorphization" =
     {|
     (Ok
      ((bindings
-       ((y (Value (Struct ((Value (Type (StructType 128))) ()))))
-        (foo_empty (Value (Struct ((Value (Type (StructType 129))) ()))))
-        (Empty (Value (Type (StructType 128)))) (x (Value (Integer 10)))
-        (foo (Value (Struct ((Value (Type (StructType 126))) ()))))
+       ((y (Value (Struct ((Value (Type (StructType 121))) ()))))
+        (foo_empty (Value (Struct ((Value (Type (StructType 122))) ()))))
+        (Empty (Value (Type (StructType 121)))) (x (Value (Integer 10)))
+        (foo (Value (Struct ((Value (Type (StructType 119))) ()))))
         (Foo
          (Value
           (Function
            ((function_signature
              ((function_params ((X (TypeN 0))))
-              (function_returns (StructSig 73))))
+              (function_returns (StructSig 45))))
             (function_impl
              (Fn
               (Return
@@ -4214,53 +4214,53 @@ let%expect_test "methods monomorphization" =
                       (MkFunction
                        ((function_signature
                          ((function_params
-                           ((self (ExprType (Reference (Self (StructSig 73)))))
+                           ((self (ExprType (Reference (Self (StructSig 45)))))
                             (x (ExprType (Reference (X (TypeN 0)))))))
                           (function_returns (ExprType (Reference (X (TypeN 0)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Reference (x (ExprType (Reference (X (TypeN 0))))))))))))))
-                   (mk_impls ()) (mk_id 125) (mk_sig 73) (mk_span <opaque>))))))))))))))
+                   (mk_impls ()) (mk_id 118) (mk_sig 45) (mk_span <opaque>))))))))))))))
       (structs
-       ((129
+       ((122
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((id
                ((function_signature
                  ((function_params
-                   ((self (StructType 129)) (x (StructType 128))))
-                  (function_returns (StructType 128))))
-                (function_impl (Fn (Return (Reference (x (StructType 128))))))))))
-            (uty_impls ()) (uty_id 129) (uty_base_id 125)))))
-        (128
+                   ((self (StructType 122)) (x (StructType 121))))
+                  (function_returns (StructType 121))))
+                (function_impl (Fn (Return (Reference (x (StructType 121))))))))))
+            (uty_impls ()) (uty_id 122) (uty_base_id 118)))))
+        (121
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 128) (uty_base_id 127)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 121) (uty_base_id 120)))))
+        (119
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((id
                ((function_signature
-                 ((function_params ((self (StructType 126)) (x IntegerType)))
+                 ((function_params ((self (StructType 119)) (x IntegerType)))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Reference (x IntegerType)))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (2
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 127)
-          (st_sig_id 74))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 120)
+          (st_sig_id 46))
          ((st_sig_fields ())
           (st_sig_methods
            ((id
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 73)))))
+               ((self (ExprType (Reference (Self (StructSig 45)))))
                 (x (ExprType (Reference (X (TypeN 0)))))))
               (function_returns (ExprType (Reference (X (TypeN 0)))))))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "switch statement" =
@@ -4290,58 +4290,58 @@ let%expect_test "switch statement" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((i (UnionType 130))))
+             ((function_params ((i (UnionType 123))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Break
                (Switch
-                ((switch_condition (Reference (i (UnionType 130))))
+                ((switch_condition (Reference (i (UnionType 123))))
                  (branches
-                  (((branch_ty (StructType 125)) (branch_var vax)
+                  (((branch_ty (StructType 118)) (branch_var vax)
                     (branch_stmt (Block ((Return (Value (Integer 32)))))))
-                   ((branch_ty (StructType 127)) (branch_var vax)
+                   ((branch_ty (StructType 120)) (branch_var vax)
                     (branch_stmt (Block ((Return (Value (Integer 64))))))))))))))))))
-        (Ints (Value (Type (UnionType 130))))))
+        (Ints (Value (Type (UnionType 123))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 127))))))
+            (value ((field_type (StructType 120))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 127))))
-                  (function_returns (StructType 128))))
+                 ((function_params ((s (StructType 7)) (v (StructType 120))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 128)))
+                     ((Value (Type (StructType 121)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 127)))))))))))))))
-            (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-        (127
+                       (value (Reference (v (StructType 120)))))))))))))))
+            (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+        (120
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 128))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Block
@@ -4358,17 +4358,17 @@ let%expect_test "switch statement" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 127)))
+                            ((Value (Type (StructType 120)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 127)) (builder (StructType 3))))
+                   ((self (StructType 120)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -4377,19 +4377,19 @@ let%expect_test "switch statement" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 127))) value IntegerType))
+                       ((Reference (self (StructType 120))) value IntegerType))
                       (Value (Integer 64)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -4397,7 +4397,7 @@ let%expect_test "switch statement" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 127)) (builder (StructType 3))))
+                      ((self (StructType 120)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -4406,7 +4406,7 @@ let%expect_test "switch statement" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 127))) value IntegerType))
+                          ((Reference (self (StructType 120))) value IntegerType))
                          (Value (Integer 64)))
                         false))))))))))
               ((impl_interface -2)
@@ -4414,7 +4414,7 @@ let%expect_test "switch statement" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 128))))
+                     (function_returns (StructType 121))))
                    (function_impl
                     (Fn
                      (Block
@@ -4432,65 +4432,65 @@ let%expect_test "switch statement" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 128)))
+                          ((Value (Type (StructType 121)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 127)))
+                               ((Value (Type (StructType 120)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 127)))
+                        ((Value (Type (StructType 120)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 127) (uty_base_id 18)))))
-        (126
+            (uty_id 120) (uty_base_id 16)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -4507,17 +4507,17 @@ let%expect_test "switch statement" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -4526,19 +4526,19 @@ let%expect_test "switch statement" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 32)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -4546,7 +4546,7 @@ let%expect_test "switch statement" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -4555,7 +4555,7 @@ let%expect_test "switch statement" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 32)))
                         false))))))))))
               ((impl_interface -2)
@@ -4563,7 +4563,7 @@ let%expect_test "switch statement" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -4581,73 +4581,73 @@ let%expect_test "switch statement" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (unions
-       ((130
+       ((123
          ((union_attributes ())
           (cases
-           (((StructType 127) (Discriminator 1))
-            ((StructType 125) (Discriminator 0))))
+           (((StructType 120) (Discriminator 1))
+            ((StructType 118) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 131)
+             (((impl_interface 124)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 125))))
-                     (function_returns (UnionType 129))))
+                    ((function_params ((v (StructType 118))))
+                     (function_returns (UnionType 122))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 125))) 130))))))))))
-              ((impl_interface 132)
+                      (MakeUnionVariant ((Reference (v (StructType 118))) 123))))))))))
+              ((impl_interface 125)
                (impl_methods
                 ((from
                   ((function_signature
-                    ((function_params ((v (StructType 127))))
-                     (function_returns (UnionType 129))))
+                    ((function_params ((v (StructType 120))))
+                     (function_returns (UnionType 122))))
                    (function_impl
                     (Fn
                      (Return
-                      (MakeUnionVariant ((Reference (v (StructType 127))) 130))))))))))))
-            (uty_id 130) (uty_base_id 129)))))))
+                      (MakeUnionVariant ((Reference (v (StructType 120))) 123))))))))))))
+            (uty_id 123) (uty_base_id 122)))))))
       (interfaces
-       ((132
+       ((125
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 127))))
+             ((function_params ((from (StructType 120))))
               (function_returns SelfType)))))))
-        (131
+        (124
          ((interface_methods
            ((from
-             ((function_params ((from (StructType 125))))
+             ((function_params ((from (StructType 118))))
               (function_returns SelfType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs
        (1
-        (((un_sig_cases ((StructType 125) (StructType 127))) (un_sig_methods ())
-          (un_sig_base_id 129)))))
+        (((un_sig_cases ((StructType 118) (StructType 120))) (un_sig_methods ())
+          (un_sig_base_id 122)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "partial evaluation of a function" =
@@ -4728,50 +4728,50 @@ let%expect_test "let binding with type" =
        ((a
          (Value
           (Struct
-           ((Value (Type (StructType 127))) ((value (Value (Integer 2))))))))
+           ((Value (Type (StructType 120))) ((value (Value (Integer 2))))))))
         (a
          (Value
           (Struct
-           ((Value (Type (StructType 125))) ((value (Value (Integer 1))))))))))
+           ((Value (Type (StructType 118))) ((value (Value (Integer 1))))))))))
       (structs
-       ((128
+       ((121
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 127))))))
+            (value ((field_type (StructType 120))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 127))))
-                  (function_returns (StructType 128))))
+                 ((function_params ((s (StructType 7)) (v (StructType 120))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 128)))
+                     ((Value (Type (StructType 121)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 127)))))))))))))))
-            (uty_impls ()) (uty_id 128) (uty_base_id -500)))))
-        (127
+                       (value (Reference (v (StructType 120)))))))))))))))
+            (uty_impls ()) (uty_id 121) (uty_base_id -500)))))
+        (120
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 128))))
+                  (function_returns (StructType 121))))
                 (function_impl
                  (Fn
                   (Block
@@ -4788,17 +4788,17 @@ let%expect_test "let binding with type" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 128)))
+                       ((Value (Type (StructType 121)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 127)))
+                            ((Value (Type (StructType 120)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 127)) (builder (StructType 3))))
+                   ((self (StructType 120)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -4807,19 +4807,19 @@ let%expect_test "let binding with type" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 127))) value IntegerType))
+                       ((Reference (self (StructType 120))) value IntegerType))
                       (Value (Integer 32)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
+                  (function_returns (StructType 120))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 127)))
+                     ((Value (Type (StructType 120)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -4827,7 +4827,7 @@ let%expect_test "let binding with type" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 127)) (builder (StructType 3))))
+                      ((self (StructType 120)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -4836,7 +4836,7 @@ let%expect_test "let binding with type" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 127))) value IntegerType))
+                          ((Reference (self (StructType 120))) value IntegerType))
                          (Value (Integer 32)))
                         false))))))))))
               ((impl_interface -2)
@@ -4844,7 +4844,7 @@ let%expect_test "let binding with type" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 128))))
+                     (function_returns (StructType 121))))
                    (function_impl
                     (Fn
                      (Block
@@ -4862,65 +4862,65 @@ let%expect_test "let binding with type" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 128)))
+                          ((Value (Type (StructType 121)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 127)))
+                               ((Value (Type (StructType 120)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 127))))
+                     (function_returns (StructType 120))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 127)))
+                        ((Value (Type (StructType 120)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 127) (uty_base_id 18)))))
-        (126
+            (uty_id 120) (uty_base_id 16)))))
+        (119
          ((struct_fields
            ((slice ((field_type (StructType 7))))
-            (value ((field_type (StructType 125))))))
+            (value ((field_type (StructType 118))))))
           (struct_details
            ((uty_methods
              ((new
                ((function_signature
-                 ((function_params ((s (StructType 7)) (v (StructType 125))))
-                  (function_returns (StructType 126))))
+                 ((function_params ((s (StructType 7)) (v (StructType 118))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 126)))
+                     ((Value (Type (StructType 119)))
                       ((slice (Reference (s (StructType 7))))
-                       (value (Reference (v (StructType 125)))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id -500)))))
-        (125
+                       (value (Reference (v (StructType 118)))))))))))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id -500)))))
+        (118
          ((struct_fields ((value ((field_type IntegerType)))))
           (struct_details
            ((uty_methods
              ((from
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))
               (deserialize
                ((function_signature
                  ((function_params ((s (StructType 7))))
-                  (function_returns (StructType 126))))
+                  (function_returns (StructType 119))))
                 (function_impl
                  (Fn
                   (Block
@@ -4937,17 +4937,17 @@ let%expect_test "let binding with type" =
                     (Return
                      (Value
                       (Struct
-                       ((Value (Type (StructType 126)))
+                       ((Value (Type (StructType 119)))
                         ((slice (Reference (slice (StructType 7))))
                          (value
                           (Value
                            (Struct
-                            ((Value (Type (StructType 125)))
+                            ((Value (Type (StructType 118)))
                              ((value (Reference (value IntegerType)))))))))))))))))))
               (serialize
                ((function_signature
                  ((function_params
-                   ((self (StructType 125)) (builder (StructType 3))))
+                   ((self (StructType 118)) (builder (StructType 3))))
                   (function_returns (StructType 3))))
                 (function_impl
                  (Fn
@@ -4956,19 +4956,19 @@ let%expect_test "let binding with type" =
                     ((ResolvedReference (serialize_int <opaque>))
                      ((Reference (builder (StructType 3)))
                       (StructField
-                       ((Reference (self (StructType 125))) value IntegerType))
+                       ((Reference (self (StructType 118))) value IntegerType))
                       (Value (Integer 257)))
                      false)))))))
               (new
                ((function_signature
                  ((function_params ((i IntegerType)))
-                  (function_returns (StructType 125))))
+                  (function_returns (StructType 118))))
                 (function_impl
                  (Fn
                   (Return
                    (Value
                     (Struct
-                     ((Value (Type (StructType 125)))
+                     ((Value (Type (StructType 118)))
                       ((value (Reference (i IntegerType))))))))))))))
             (uty_impls
              (((impl_interface -1)
@@ -4976,7 +4976,7 @@ let%expect_test "let binding with type" =
                 ((serialize
                   ((function_signature
                     ((function_params
-                      ((self (StructType 125)) (builder (StructType 3))))
+                      ((self (StructType 118)) (builder (StructType 3))))
                      (function_returns (StructType 3))))
                    (function_impl
                     (Fn
@@ -4985,7 +4985,7 @@ let%expect_test "let binding with type" =
                        ((ResolvedReference (serialize_int <opaque>))
                         ((Reference (builder (StructType 3)))
                          (StructField
-                          ((Reference (self (StructType 125))) value IntegerType))
+                          ((Reference (self (StructType 118))) value IntegerType))
                          (Value (Integer 257)))
                         false))))))))))
               ((impl_interface -2)
@@ -4993,7 +4993,7 @@ let%expect_test "let binding with type" =
                 ((deserialize
                   ((function_signature
                     ((function_params ((s (StructType 7))))
-                     (function_returns (StructType 126))))
+                     (function_returns (StructType 119))))
                    (function_impl
                     (Fn
                      (Block
@@ -5012,27 +5012,27 @@ let%expect_test "let binding with type" =
                        (Return
                         (Value
                          (Struct
-                          ((Value (Type (StructType 126)))
+                          ((Value (Type (StructType 119)))
                            ((slice (Reference (slice (StructType 7))))
                             (value
                              (Value
                               (Struct
-                               ((Value (Type (StructType 125)))
+                               ((Value (Type (StructType 118)))
                                 ((value (Reference (value IntegerType))))))))))))))))))))))
-              ((impl_interface 19)
+              ((impl_interface 17)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((i IntegerType)))
-                     (function_returns (StructType 125))))
+                     (function_returns (StructType 118))))
                    (function_impl
                     (Fn
                      (Return
                       (Value
                        (Struct
-                        ((Value (Type (StructType 125)))
+                        ((Value (Type (StructType 118)))
                          ((value (Reference (i IntegerType)))))))))))))))))
-            (uty_id 125) (uty_base_id 18)))))))
+            (uty_id 118) (uty_base_id 16)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>) (struct_signs (0 ()))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
@@ -5076,7 +5076,7 @@ let%expect_test "interface constraints" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 127))))
+             ((function_params ((t (StructType 120))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
@@ -5085,19 +5085,19 @@ let%expect_test "interface constraints" =
                 ((Value
                   (Function
                    ((function_signature
-                     ((function_params ((self (StructType 127))))
+                     ((function_params ((self (StructType 120))))
                       (function_returns IntegerType)))
                     (function_impl (Fn (Return (Value (Integer 1))))))))
-                 ((Reference (t (StructType 127)))) false)))))))))
+                 ((Reference (t (StructType 120)))) false)))))))))
         (test
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 125))))
+             ((function_params ((T (InterfaceType 118))))
               (function_returns
                (FunctionType
                 ((function_params
-                  ((t (ExprType (Reference (T (InterfaceType 125)))))))
+                  ((t (ExprType (Reference (T (InterfaceType 118)))))))
                  (function_returns IntegerType))))))
             (function_impl
              (Fn
@@ -5105,45 +5105,47 @@ let%expect_test "interface constraints" =
                (MkFunction
                 ((function_signature
                   ((function_params
-                    ((t (ExprType (Reference (T (InterfaceType 125)))))))
+                    ((t (ExprType (Reference (T (InterfaceType 118)))))))
                    (function_returns IntegerType)))
                  (function_impl
                   (Fn
                    (Return
                     (IntfMethodCall
-                     ((intf_instance (Reference (T (InterfaceType 125))))
-                      (intf_def 125)
+                     ((intf_instance
+                       (Value
+                        (Type (ExprType (Reference (T (InterfaceType 118)))))))
+                      (intf_def 118)
                       (intf_method
                        (beep
                         ((function_params ((self SelfType)))
                          (function_returns IntegerType))))
                       (intf_args
                        ((Reference
-                         (t (ExprType (Reference (T (InterfaceType 125))))))))
+                         (t (ExprType (Reference (T (InterfaceType 118))))))))
                       (intf_loc <opaque>)))))))))))))))
-        (BeeperImpl1 (Value (Type (StructType 127))))
-        (Beep (Value (Type (InterfaceType 125))))))
+        (BeeperImpl1 (Value (Type (StructType 120))))
+        (Beep (Value (Type (InterfaceType 118))))))
       (structs
-       ((127
+       ((120
          ((struct_fields ())
           (struct_details
            ((uty_methods
              ((beep
                ((function_signature
-                 ((function_params ((self (StructType 127))))
+                 ((function_params ((self (StructType 120))))
                   (function_returns IntegerType)))
                 (function_impl (Fn (Return (Value (Integer 1)))))))))
             (uty_impls
-             (((impl_interface 125)
+             (((impl_interface 118)
                (impl_methods
                 ((beep
                   ((function_signature
-                    ((function_params ((self (StructType 127))))
+                    ((function_params ((self (StructType 120))))
                      (function_returns IntegerType)))
                    (function_impl (Fn (Return (Value (Integer 1))))))))))))
-            (uty_id 127) (uty_base_id 126)))))))
+            (uty_id 120) (uty_base_id 119)))))))
       (interfaces
-       ((125
+       ((118
          ((interface_methods
            ((beep
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))
@@ -5154,9 +5156,9 @@ let%expect_test "interface constraints" =
           (st_sig_methods
            ((beep
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 73)))))))
+               ((self (ExprType (Reference (Self (StructSig 45)))))))
               (function_returns IntegerType)))))
-          (st_sig_base_id 126) (st_sig_id 73)))))
+          (st_sig_base_id 119) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let" =
@@ -5185,24 +5187,24 @@ let%expect_test "destructuring let" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 126))))
+             ((function_params ((t (StructType 119))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((x x) (y y2) (z z)))
-                  (destructuring_let_expr (Reference (t (StructType 126))))
+                  (destructuring_let_expr (Reference (t (StructType 119))))
                   (destructuring_let_rest false)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 126))))))
+        (T (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5210,7 +5212,7 @@ let%expect_test "destructuring let" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields" =
@@ -5230,31 +5232,31 @@ let%expect_test "destructuring let with missing fields" =
   pp_compile source ;
   [%expect
     {|
-    (((MissingField ((StructType 126) x <opaque>))
-      (MissingField ((StructType 126) z <opaque>)))
+    (((MissingField ((StructType 119) x <opaque>))
+      (MissingField ((StructType 119) z <opaque>)))
      ((bindings
        ((test
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 126))))
+             ((function_params ((t (StructType 119))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((y y2)))
-                  (destructuring_let_expr (Reference (t (StructType 126))))
+                  (destructuring_let_expr (Reference (t (StructType 119))))
                   (destructuring_let_rest false)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 126))))))
+        (T (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5262,7 +5264,7 @@ let%expect_test "destructuring let with missing fields" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "destructuring let with missing fields ignored" =
@@ -5288,24 +5290,24 @@ let%expect_test "destructuring let with missing fields ignored" =
          (Value
           (Function
            ((function_signature
-             ((function_params ((t (StructType 126))))
+             ((function_params ((t (StructType 119))))
               (function_returns IntegerType)))
             (function_impl
              (Fn
               (Block
                ((DestructuringLet
                  ((destructuring_let ((y y2)))
-                  (destructuring_let_expr (Reference (t (StructType 126))))
+                  (destructuring_let_expr (Reference (t (StructType 119))))
                   (destructuring_let_rest true)))
                 (Return (Reference (y2 IntegerType)))))))))))
-        (T (Value (Type (StructType 126))))))
+        (T (Value (Type (StructType 119))))))
       (structs
-       ((126
+       ((119
          ((struct_fields
            ((x ((field_type IntegerType))) (y ((field_type IntegerType)))
             (z ((field_type IntegerType)))))
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+           ((uty_methods ()) (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
@@ -5313,7 +5315,7 @@ let%expect_test "destructuring let with missing fields ignored" =
            ((x (ResolvedReference (Integer <opaque>)))
             (y (ResolvedReference (Integer <opaque>)))
             (z (ResolvedReference (Integer <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_methods ()) (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "type that does not implement interface passed to the \
@@ -5329,29 +5331,29 @@ let%expect_test "type that does not implement interface passed to the \
   pp_compile source ;
   [%expect
     {|
-    (((TypeError ((InterfaceType 125) (Type0 (StructType 127)) <opaque>))
+    (((TypeError ((InterfaceType 118) (Type0 (StructType 120)) <opaque>))
       (ArgumentNumberMismatch (1 1 <opaque>)))
      ((bindings
-       ((Foo (Value (Type (StructType 127))))
+       ((Foo (Value (Type (StructType 120))))
         (ExpectedIntf
          (Value
           (Function
            ((function_signature
-             ((function_params ((T (InterfaceType 125))))
+             ((function_params ((T (InterfaceType 118))))
               (function_returns HoleType)))
             (function_impl (Fn (Block ())))))))
-        (Intf (Value (Type (InterfaceType 125))))))
+        (Intf (Value (Type (InterfaceType 118))))))
       (structs
-       ((127
+       ((120
          ((struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 127) (uty_base_id 126)))))))
-      (interfaces ((125 ((interface_methods ()))))) (type_counter <opaque>)
+           ((uty_methods ()) (uty_impls ()) (uty_id 120) (uty_base_id 119)))))))
+      (interfaces ((118 ((interface_methods ()))))) (type_counter <opaque>)
       (memoized_fcalls <opaque>)
       (struct_signs
        (1
-        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 126)
-          (st_sig_id 73)))))
+        (((st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 119)
+          (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "struct signatures" =
@@ -5373,52 +5375,15 @@ let%expect_test "struct signatures" =
   pp_compile source ;
   [%expect
     {|
-    (Ok
+    (((FieldNotFoundF value) (UnresolvedIdentifier extract_value)
+      (UnresolvedIdentifier extract_value))
      ((bindings
-       ((zero (Value (Integer 0))) (five (Value (Integer 5)))
-        (extract_value
-         (Value
-          (Function
-           ((function_signature
-             ((function_is_type) (function_params ((n IntegerType)))
-              (function_returns
-               (FunctionType
-                ((function_params
-                  ((x
-                    (ExprType
-                     (FunctionCall
-                      ((ResolvedReference (Int2 <opaque>))
-                       ((Reference (n IntegerType))) true))))))
-                 (function_returns IntegerType))))))
-            (function_impl
-             (Fn
-              (Return
-               (MkFunction
-                ((function_signature
-                  ((function_params
-                    ((x
-                      (ExprType
-                       (FunctionCall
-                        ((ResolvedReference (Int2 <opaque>))
-                         ((Reference (n IntegerType))) true))))))
-                   (function_returns IntegerType)))
-                 (function_impl
-                  (Fn
-                   (Return
-                    (StructField
-                     ((Reference
-                       (x
-                        (ExprType
-                         (FunctionCall
-                          ((ResolvedReference (Int2 <opaque>))
-                           ((Reference (n IntegerType))) true)))))
-                      value IntegerType))))))))))))))
-        (Int2
+       ((Int2
          (Value
           (Function
            ((function_signature
              ((function_is_type) (function_params ((bits IntegerType)))
-              (function_returns (StructSig 73))))
+              (function_returns (StructSig 45))))
             (function_impl
              (Fn
               (Return
@@ -5432,57 +5397,24 @@ let%expect_test "struct signatures" =
                        ((function_signature
                          ((function_params ((i IntegerType)))
                           (function_returns
-                           (ExprType (Reference (Self (StructSig 73)))))))
+                           (ExprType (Reference (Self (StructSig 45)))))))
                         (function_impl
                          (Fn
                           (Return
                            (Value
                             (Struct
-                             ((Reference (Self (StructSig 73)))
+                             ((Reference (Self (StructSig 45)))
                               ((value (Reference (i IntegerType)))))))))))))))
-                   (mk_impls ()) (mk_id 125) (mk_sig 73) (mk_span <opaque>))))))))))))))
-      (structs
-       ((127
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 127))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 127)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls ()) (uty_id 127) (uty_base_id 125)))))
-        (126
-         ((struct_fields ((value ((field_type IntegerType)))))
-          (struct_details
-           ((uty_methods
-             ((new
-               ((function_signature
-                 ((function_params ((i IntegerType)))
-                  (function_returns (StructType 126))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 126)))
-                      ((value (Reference (i IntegerType))))))))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
-      (type_counter <opaque>) (memoized_fcalls <opaque>)
+                   (mk_impls ()) (mk_id 118) (mk_sig 45) (mk_span <opaque>))))))))))))))
+      (structs ()) (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
        (1
         (((st_sig_fields ((value (ResolvedReference (Integer <opaque>)))))
           (st_sig_methods
            ((new
              ((function_params ((i IntegerType)))
-              (function_returns (ExprType (Reference (Self (StructSig 73)))))))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+              (function_returns (ExprType (Reference (Self (StructSig 45)))))))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs (0 ())) (attr_executors <opaque>))) |}]
 
 let%expect_test "Deserilize intf with constraints" =
@@ -5510,69 +5442,52 @@ let%expect_test "Deserilize intf with constraints" =
   pp_compile source ~include_std:false ;
   [%expect
     {|
-    (Ok
+    (((FieldNotFoundF x) (UnresolvedIdentifier test))
      ((bindings
-       ((a (Value (Struct ((Value (Type (StructType 3))) ()))))
-        (Empty (Value (Type (StructType 3))))
-        (test
-         (Value
-          (Function
-           ((function_signature
-             ((function_params ((Y (InterfaceType 1))))
-              (function_returns (ExprType (Reference (Y (InterfaceType 1)))))))
-            (function_impl
-             (Fn
-              (Block
-               ((Let
-                 ((v
-                   (IntfMethodCall
-                    ((intf_instance (Reference (Y (InterfaceType 1))))
-                     (intf_def 1)
-                     (intf_method
-                      (deserialize
-                       ((function_params ())
-                        (function_returns
-                         (ExprType
-                          (FunctionCall
-                           ((Value
-                             (Function
-                              ((function_signature
-                                ((function_is_type)
-                                 (function_params ((X (TypeN 0))))
-                                 (function_returns (StructSig 1))))
-                               (function_impl
-                                (Fn
-                                 (Return
-                                  (MkStructDef
-                                   ((mk_struct_fields
-                                     ((x (Reference (X (TypeN 0))))))
-                                    (mk_struct_details
-                                     ((mk_methods ()) (mk_impls ()) (mk_id 0)
-                                      (mk_sig 1) (mk_span <opaque>)))))))))))
-                            ((ResolvedReference (Self <opaque>))) true)))))))
-                     (intf_args ()) (intf_loc <opaque>))))))
-                (Return
-                 (StructField
-                  ((Reference
-                    (v
-                     (ExprType
-                      (FunctionCall
-                       ((Value
-                         (Function
-                          ((function_signature
-                            ((function_is_type) (function_params ((X (TypeN 0))))
-                             (function_returns (StructSig 1))))
-                           (function_impl
-                            (Fn
-                             (Return
-                              (MkStructDef
-                               ((mk_struct_fields
-                                 ((x (Reference (X (TypeN 0))))))
-                                (mk_struct_details
-                                 ((mk_methods ()) (mk_impls ()) (mk_id 0)
-                                  (mk_sig 1) (mk_span <opaque>)))))))))))
-                        ((ResolvedReference (Self <opaque>))) true)))))
-                   x (ExprType (Reference (Y (InterfaceType 1)))))))))))))))
+       ((Empty
+         (MkStructDef
+          ((mk_struct_fields ())
+           (mk_struct_details
+            ((mk_methods
+              ((deserialize
+                (MkFunction
+                 ((function_signature
+                   ((function_params ())
+                    (function_returns
+                     (TypeCall (func (ResolvedReference (Container <opaque>)))
+                      (args ((Reference (Self (StructSig 2)))))))))
+                  (function_impl
+                   (Fn
+                    (Return
+                     (Value
+                      (Struct
+                       ((FunctionCall
+                         ((ResolvedReference (Container <opaque>))
+                          ((Reference (Self (StructSig 2)))) true))
+                        ((x
+                          (Value (Struct ((Reference (Self (StructSig 2))) ()))))))))))))))))
+             (mk_impls
+              (((mk_impl_interface (ResolvedReference (Deserialize2 <opaque>)))
+                (mk_impl_methods
+                 ((deserialize
+                   (MkFunction
+                    ((function_signature
+                      ((function_params ())
+                       (function_returns
+                        (TypeCall (func (ResolvedReference (Container <opaque>)))
+                         (args ((Reference (Self (StructSig 2)))))))))
+                     (function_impl
+                      (Fn
+                       (Return
+                        (Value
+                         (Struct
+                          ((FunctionCall
+                            ((ResolvedReference (Container <opaque>))
+                             ((Reference (Self (StructSig 2)))) true))
+                           ((x
+                             (Value
+                              (Struct ((Reference (Self (StructSig 2))) ())))))))))))))))))))
+             (mk_id 2) (mk_sig 2) (mk_span <opaque>))))))
         (Deserialize2 (Value (Type (InterfaceType 1))))
         (Container
          (Value
@@ -5588,78 +5503,42 @@ let%expect_test "Deserilize intf with constraints" =
                  (mk_struct_details
                   ((mk_methods ()) (mk_impls ()) (mk_id 0) (mk_sig 1)
                    (mk_span <opaque>))))))))))))))
-      (structs
-       ((4
-         ((struct_fields ((x ((field_type (StructType 3))))))
-          (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 4) (uty_base_id 0)))))
-        (3
-         ((struct_fields ())
-          (struct_details
-           ((uty_methods
-             ((deserialize
-               ((function_signature
-                 ((function_params ()) (function_returns (StructType 4))))
-                (function_impl
-                 (Fn
-                  (Return
-                   (Value
-                    (Struct
-                     ((Value (Type (StructType 4)))
-                      ((x (Value (Struct ((Value (Type (StructType 3))) ())))))))))))))))
-            (uty_impls
-             (((impl_interface 1)
-               (impl_methods
-                ((deserialize
-                  ((function_signature
-                    ((function_params ()) (function_returns (StructType 4))))
-                   (function_impl
-                    (Fn
-                     (Return
-                      (Value
-                       (Struct
-                        ((Value (Type (StructType 4)))
-                         ((x (Value (Struct ((Value (Type (StructType 3))) ()))))))))))))))))))
-            (uty_id 3) (uty_base_id 2)))))))
+      (structs ())
       (interfaces
        ((1
          ((interface_methods
            ((deserialize
              ((function_params ())
               (function_returns
-               (ExprType
-                (FunctionCall
-                 ((Value
-                   (Function
-                    ((function_signature
-                      ((function_is_type) (function_params ((X (TypeN 0))))
-                       (function_returns (StructSig 1))))
-                     (function_impl
-                      (Fn
-                       (Return
-                        (MkStructDef
-                         ((mk_struct_fields ((x (Reference (X (TypeN 0))))))
-                          (mk_struct_details
-                           ((mk_methods ()) (mk_impls ()) (mk_id 0) (mk_sig 1)
-                            (mk_span <opaque>)))))))))))
-                  ((ResolvedReference (Self <opaque>))) true))))))))))))
+               (TypeCall
+                (func
+                 (Value
+                  (Function
+                   ((function_signature
+                     ((function_is_type) (function_params ((X (TypeN 0))))
+                      (function_returns (StructSig 1))))
+                    (function_impl
+                     (Fn
+                      (Return
+                       (MkStructDef
+                        ((mk_struct_fields ((x (Reference (X (TypeN 0))))))
+                         (mk_struct_details
+                          ((mk_methods ()) (mk_impls ()) (mk_id 0) (mk_sig 1)
+                           (mk_span <opaque>))))))))))))
+                (args ((ResolvedReference (Self <opaque>))))))))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
-       (4
-        (((st_sig_fields ((x (Reference (Self (StructSig 3))))))
-          (st_sig_methods ()) (st_sig_base_id 0) (st_sig_id 4))
+       (3
+        (((st_sig_fields ((x (Reference (Self (StructSig 2))))))
+          (st_sig_methods ()) (st_sig_base_id 0) (st_sig_id 3))
          ((st_sig_fields ())
           (st_sig_methods
            ((deserialize
              ((function_params ())
               (function_returns
-               (ExprType
-                (FunctionCall
-                 ((ResolvedReference (Container <opaque>))
-                  ((Reference (Self (StructSig 3)))) true))))))))
-          (st_sig_base_id 2) (st_sig_id 3))
-         ((st_sig_fields ((x (ResolvedReference (Self <opaque>)))))
-          (st_sig_methods ()) (st_sig_base_id 0) (st_sig_id 2))
+               (TypeCall (func (ResolvedReference (Container <opaque>)))
+                (args ((Reference (Self (StructSig 2)))))))))))
+          (st_sig_base_id 2) (st_sig_id 2))
          ((st_sig_fields ((x (Reference (X (TypeN 0)))))) (st_sig_methods ())
           (st_sig_base_id 0) (st_sig_id 1)))))
       (union_signs (0 ())) (attr_executors <opaque>)))
@@ -5732,26 +5611,24 @@ let%expect_test "Interface inner constraints" =
                      (Return
                       (StructSigMethodCall
                        ((st_sig_call_instance
-                         (FunctionCall
-                          ((ResolvedReference (Test <opaque>))
-                           ((Reference (X (InterfaceType 0)))) true)))
-                        (st_sig_call_def 1)
+                         (Value
+                          (Type
+                           (TypeCall (func (ResolvedReference (Test <opaque>)))
+                            (args ((Reference (X (InterfaceType 0)))))))))
+                        (st_sig_call_def 3)
                         (st_sig_call_method
                          (do_stuff
                           ((function_params
                             ((self
-                              (ExprType
-                               (FunctionCall
-                                ((ResolvedReference (Test <opaque>))
-                                 ((Reference (X (InterfaceType 0)))) true))))))
+                              (TypeCall
+                               (func (ResolvedReference (Test <opaque>)))
+                               (args ((Reference (X (InterfaceType 0)))))))))
                            (function_returns HoleType))))
                         (st_sig_call_args
                          ((Reference
                            (temp
-                            (ExprType
-                             (FunctionCall
-                              ((ResolvedReference (Test <opaque>))
-                               ((Reference (X (InterfaceType 0)))) true)))))))
+                            (TypeCall (func (ResolvedReference (Test <opaque>)))
+                             (args ((Reference (X (InterfaceType 0))))))))))
                         (st_sig_call_span <opaque>)
                         (st_sig_call_kind StructSigKind)))))))))))))))))
         (Test
@@ -5777,7 +5654,10 @@ let%expect_test "Interface inner constraints" =
                          (Fn
                           (Return
                            (IntfMethodCall
-                            ((intf_instance (Reference (X (InterfaceType 0))))
+                            ((intf_instance
+                              (Value
+                               (Type
+                                (ExprType (Reference (X (InterfaceType 0)))))))
                              (intf_def 0)
                              (intf_method
                               (do_stuff
@@ -5803,7 +5683,10 @@ let%expect_test "Interface inner constraints" =
                             (Fn
                              (Return
                               (IntfMethodCall
-                               ((intf_instance (Reference (X (InterfaceType 0))))
+                               ((intf_instance
+                                 (Value
+                                  (Type
+                                   (ExprType (Reference (X (InterfaceType 0)))))))
                                 (intf_def 0)
                                 (intf_method
                                  (do_stuff
@@ -5887,14 +5770,28 @@ let%expect_test "Interface inner constraints" =
              ((function_params ((self SelfType))) (function_returns IntegerType)))))))))
       (type_counter <opaque>) (memoized_fcalls <opaque>)
       (struct_signs
-       (2
+       (4
         (((st_sig_fields ())
           (st_sig_methods
            ((do_stuff
              ((function_params
-               ((self (ExprType (Reference (Self (StructSig 2)))))))
+               ((self (ExprType (Reference (Self (StructSig 4)))))))
               (function_returns IntegerType)))))
-          (st_sig_base_id 2) (st_sig_id 2))
+          (st_sig_base_id 2) (st_sig_id 4))
+         ((st_sig_fields ((x (Reference (X (InterfaceType 0))))))
+          (st_sig_methods
+           ((do_stuff
+             ((function_params
+               ((self (ExprType (Reference (Self (StructSig 1)))))))
+              (function_returns HoleType)))))
+          (st_sig_base_id 1) (st_sig_id 3))
+         ((st_sig_fields ((x (Reference (X (InterfaceType 0))))))
+          (st_sig_methods
+           ((do_stuff
+             ((function_params
+               ((self (ExprType (Reference (Self (StructSig 1)))))))
+              (function_returns HoleType)))))
+          (st_sig_base_id 1) (st_sig_id 2))
          ((st_sig_fields ((x (Reference (X (InterfaceType 0))))))
           (st_sig_methods
            ((do_stuff
@@ -5984,8 +5881,8 @@ let%expect_test "attributes" =
     {|
     (Ok
      ((bindings
-       ((Ti (Value (Type (StructType 137)))) (U1 (Value (Type (UnionType 135))))
-        (U (Value (Type (UnionType 132)))) (I (Value (Type (InterfaceType 130))))
+       ((Ti (Value (Type (StructType 130)))) (U1 (Value (Type (UnionType 128))))
+        (U (Value (Type (UnionType 125)))) (I (Value (Type (InterfaceType 123))))
         (x1
          (Value
           (Function
@@ -6002,13 +5899,13 @@ let%expect_test "attributes" =
                (((attribute_ident attr) (attribute_exprs ()))))
               (function_params ()) (function_returns HoleType)))
             (function_impl (Fn (Block ())))))))
-        (T1 (Value (Type (StructType 129))))
+        (T1 (Value (Type (StructType 122))))
         (Ta
          (Value
           (Function
            ((function_signature
              ((function_is_type) (function_params ((X IntegerType)))
-              (function_returns (StructSig 74))))
+              (function_returns (StructSig 46))))
             (function_impl
              (Fn
               (Return
@@ -6017,11 +5914,11 @@ let%expect_test "attributes" =
                   (((attribute_ident attr) (attribute_exprs ()))))
                  (mk_struct_fields ())
                  (mk_struct_details
-                  ((mk_methods ()) (mk_impls ()) (mk_id 127) (mk_sig 74)
+                  ((mk_methods ()) (mk_impls ()) (mk_id 120) (mk_sig 46)
                    (mk_span <opaque>))))))))))))
-        (T (Value (Type (StructType 126))))))
+        (T (Value (Type (StructType 119))))))
       (structs
-       ((137
+       ((130
          ((struct_fields ())
           (struct_details
            ((uty_methods
@@ -6033,7 +5930,7 @@ let%expect_test "attributes" =
                 (function_impl (Fn (Return (Value (Bool true)))))))))
             (uty_impls
              (((impl_attributes (((attribute_ident attr) (attribute_exprs ()))))
-               (impl_interface 130)
+               (impl_interface 123)
                (impl_methods
                 ((x
                   ((function_signature
@@ -6041,13 +5938,13 @@ let%expect_test "attributes" =
                       (((attribute_ident attr) (attribute_exprs ()))))
                      (function_params ()) (function_returns BoolType)))
                    (function_impl (Fn (Return (Value (Bool true))))))))))))
-            (uty_id 137) (uty_base_id 136)))))
-        (129
+            (uty_id 130) (uty_base_id 129)))))
+        (122
          ((struct_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (struct_fields ())
           (struct_details
-           ((uty_methods ()) (uty_impls ()) (uty_id 129) (uty_base_id 128)))))
-        (126
+           ((uty_methods ()) (uty_impls ()) (uty_id 122) (uty_base_id 121)))))
+        (119
          ((struct_attributes
            (((attribute_ident attr) (attribute_exprs ()))
             ((attribute_ident attr) (attribute_exprs ((Value (Integer 1)))))
@@ -6062,46 +5959,46 @@ let%expect_test "attributes" =
                    (((attribute_ident attr) (attribute_exprs ()))))
                   (function_params ()) (function_returns BoolType)))
                 (function_impl (Fn (Return (Value (Bool true)))))))))
-            (uty_impls ()) (uty_id 126) (uty_base_id 125)))))))
+            (uty_impls ()) (uty_id 119) (uty_base_id 118)))))))
       (unions
-       ((135
+       ((128
          ((union_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (cases (((ExprType (Value Void)) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 133)
+             (((impl_interface 126)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v VoidType)))
-                     (function_returns (UnionType 134))))
+                     (function_returns (UnionType 127))))
                    (function_impl
                     (Fn
-                     (Return (MakeUnionVariant ((Reference (v VoidType)) 135))))))))))))
-            (uty_id 135) (uty_base_id 134)))))
-        (132
+                     (Return (MakeUnionVariant ((Reference (v VoidType)) 128))))))))))))
+            (uty_id 128) (uty_base_id 127)))))
+        (125
          ((union_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (cases (((ExprType (Value Void)) (Discriminator 0))))
           (union_details
            ((uty_methods ())
             (uty_impls
-             (((impl_interface 133)
+             (((impl_interface 126)
                (impl_methods
                 ((from
                   ((function_signature
                     ((function_params ((v VoidType)))
-                     (function_returns (UnionType 131))))
+                     (function_returns (UnionType 124))))
                    (function_impl
                     (Fn
-                     (Return (MakeUnionVariant ((Reference (v VoidType)) 132))))))))))))
-            (uty_id 132) (uty_base_id 131)))))))
+                     (Return (MakeUnionVariant ((Reference (v VoidType)) 125))))))))))))
+            (uty_id 125) (uty_base_id 124)))))))
       (interfaces
-       ((133
+       ((126
          ((interface_methods
            ((from
              ((function_params ((from VoidType))) (function_returns SelfType)))))))
-        (130
+        (123
          ((interface_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (interface_methods
            ((x
@@ -6117,13 +6014,13 @@ let%expect_test "attributes" =
              ((function_attributes
                (((attribute_ident attr) (attribute_exprs ()))))
               (function_params ()) (function_returns BoolType)))))
-          (st_sig_base_id 136) (st_sig_id 76))
+          (st_sig_base_id 129) (st_sig_id 48))
          ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
-          (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 128)
-          (st_sig_id 75))
+          (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 121)
+          (st_sig_id 47))
          ((st_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
-          (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 127)
-          (st_sig_id 74))
+          (st_sig_fields ()) (st_sig_methods ()) (st_sig_base_id 120)
+          (st_sig_id 46))
          ((st_sig_attributes
            (((attribute_ident attr) (attribute_exprs ()))
             ((attribute_ident attr) (attribute_exprs ((Value (Integer 1)))))
@@ -6135,15 +6032,15 @@ let%expect_test "attributes" =
              ((function_attributes
                (((attribute_ident attr) (attribute_exprs ()))))
               (function_params ()) (function_returns BoolType)))))
-          (st_sig_base_id 125) (st_sig_id 73)))))
+          (st_sig_base_id 118) (st_sig_id 45)))))
       (union_signs
        (2
         (((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (un_sig_cases ((ExprType (Value Void)))) (un_sig_methods ())
-          (un_sig_base_id 134))
+          (un_sig_base_id 127))
          ((un_sig_attributes (((attribute_ident attr) (attribute_exprs ()))))
           (un_sig_cases ((ExprType (Value Void)))) (un_sig_methods ())
-          (un_sig_base_id 131)))))
+          (un_sig_base_id 124)))))
       (attr_executors <opaque>))) |}]
 
 let%expect_test "runtime assignment" =


### PR DESCRIPTION
This type is a type of returning value when function with brackets `[]` was called.
For example, with such declaration:
```
struct Test[X: Type] { ... }
```
The expression `Test[Integer]` will have type `TypeCall {func: Test; args: [Integer]}`.
It is not changed nothing for now, but in the future it will allow adding type inference based
on this type.