### PR TITLE
Compile smart contracts to .cell files if func/fift are available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ _opam
 .conflicts
 .DS_Store
 *.fc
+!bin/stdlib.fc
 *.fif
 *.cell

--- a/bin/dune
+++ b/bin/dune
@@ -3,4 +3,6 @@
  (package tact)
  (name main)
  (modules main)
- (libraries tact linenoise base))
+ (preprocess
+  (pps ppx_blob))
+ (libraries core tact linenoise base bos ppx_blob))

--- a/bin/dune
+++ b/bin/dune
@@ -5,4 +5,4 @@
  (modules main)
  (preprocess
   (pps ppx_blob))
- (libraries core tact linenoise base bos ppx_blob))
+ (libraries core tact linenoise base bos cmdliner ppx_blob))

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -17,41 +17,73 @@ let toolchain_available () =
 
 let stdlib_fc = [%blob "stdlib.fc"]
 
-let compile filename program =
-  let cell_file =
-    (Filename.chop_extension filename |> Filename.basename) ^ ".cell"
+let compile ?(target = `Cell) filename program =
+  let ext =
+    match target with `Cell -> ".cell" | `Func -> ".func" | `Fift -> ".fift"
+  and is_func = match target with `Func -> true | _ -> false
+  and is_fift = match target with `Fift -> true | _ -> false in
+  let out_file =
+    (Filename.chop_extension filename |> Filename.basename) ^ ext
   in
-  ignore
-  @@ OS.File.with_tmp_oc
-       (format_of_string "tact_%s")
-       (fun path out () ->
-         Stdio.Out_channel.(
-           output_string out stdlib_fc ;
-           output_string out program ;
-           flush out ) ;
-         let output =
-           OS.Cmd.(
-             run_out Cmd.(v "func" % "-APS" % Fpath.to_string path) |> to_string )
-         in
-         match output with
-         | Ok fift ->
-             let fift = fift ^ "\nboc>B \"" ^ cell_file ^ "\" B>file\n" in
-             ( ignore
-             @@ OS.Cmd.(in_string fift |> run_io Cmd.(v "fift") |> to_null) ) ;
-             Caml.Format.print_string ("Compiled to " ^ cell_file) ;
-             Caml.Format.print_newline ()
-         | _ ->
-             Caml.Format.print_string "Failed to use the toolchain" ;
-             Caml.Format.print_newline () )
-       () ;
+  if is_func then (
+    ignore
+    @@ OS.File.with_oc
+         (Option.value_exn @@ Result.ok @@ Fpath.of_string out_file)
+         (fun out () ->
+           Stdio.Out_channel.(output_string out program ; flush out) ;
+           Ok () )
+         () ;
+    Caml.Format.print_string ("Compiled to " ^ out_file) ;
+    Caml.Format.print_newline () )
+  else
+    ignore
+    @@ OS.File.with_tmp_oc
+         (format_of_string "tact_%s")
+         (fun path out () ->
+           Stdio.Out_channel.(
+             output_string out stdlib_fc ;
+             output_string out program ;
+             flush out ) ;
+           let output =
+             OS.Cmd.(
+               run_out Cmd.(v "func" % "-APS" % Fpath.to_string path)
+               |> to_string )
+           in
+           match output with
+           | Ok fift ->
+               let fift = fift ^ "\nboc>B \"" ^ out_file ^ "\" B>file\n" in
+               ( if is_fift then
+                 ignore
+                 @@ OS.File.with_oc
+                      (Option.value_exn @@ Result.ok @@ Fpath.of_string out_file)
+                      (fun out () ->
+                        Stdio.Out_channel.(output_string out fift ; flush out) ;
+                        Ok () )
+                      ()
+               else
+                 ignore
+                 @@ OS.Cmd.(in_string fift |> run_io Cmd.(v "fift") |> to_null)
+               ) ;
+               Caml.Format.print_string ("Compiled to " ^ out_file) ;
+               Caml.Format.print_newline ()
+           | _ ->
+               Caml.Format.print_string "Failed to use the toolchain" ;
+               Caml.Format.print_newline () )
+         () ;
   ()
 
-let interpret_file argv =
-  let filename = Array.get argv 1 in
+let interpret_file ~target filename =
   match Tact.Compiler.compile_with_std ~filename (Caml.open_in filename) with
-  | Ok program ->
-      if toolchain_available () then compile filename program
-      else Caml.Format.print_string program
+  | Ok program -> (
+      let is_toolchain_available = toolchain_available () in
+      match (is_toolchain_available, target) with
+      | _, `Func ->
+          compile ~target filename program
+      | false, _ ->
+          Caml.Format.print_string
+            "Can't compile for this target without a toolchain"
+      | true, target ->
+          compile ~target filename program )
   | Error errors ->
       Caml.Format.print_string errors
 
@@ -97,10 +129,38 @@ let rec repl ?(program = default_program ()) ?(prompt = prompt) () =
           Caml.Format.print_flush () ;
           repl ~prompt () )
 
-let () =
-  let argv = Sys.get_argv () in
-  if Array.length argv > 1 then interpret_file argv
-  else (
-    LNoise.set_multiline true ;
-    ignore @@ LNoise.history_set ~max_length:1000 ;
-    repl () )
+open Cmdliner
+
+let tact target filename =
+  match (target, filename) with
+  | _, None ->
+      LNoise.set_multiline true ;
+      ignore @@ LNoise.history_set ~max_length:1000 ;
+      repl ()
+  | target, Some filename ->
+      interpret_file ~target filename
+
+let tact_t =
+  let target =
+    let doc = "Output target [cell, func, fift] (ignored for REPL)" in
+    Arg.(
+      value
+      & opt (enum [("cell", `Cell); ("func", `Func); ("fift", `Fift)]) `Cell
+      & info ["t"; "target"] ~doc )
+  and filename =
+    let doc = "Input filename, if none given, will start REPL" in
+    Arg.(
+      value
+      & pos ~rev:true 0 (some non_dir_file) None
+      & info [] ~doc ~docv:"FILE" )
+  in
+  Term.(const tact $ target $ filename)
+
+let cmd =
+  let doc = "compile Tact smart contract" in
+  let info = Cmd.info "tact" ~doc in
+  Cmd.v info tact_t
+
+let main () = exit (Cmd.eval cmd)
+
+let () = main ()

--- a/bin/stdlib.fc
+++ b/bin/stdlib.fc
@@ -1,0 +1,208 @@
+;; Standard library for funC
+;;
+
+forall X -> tuple cons(X head, tuple tail) asm "CONS";
+forall X -> (X, tuple) uncons(tuple list) asm "UNCONS";
+forall X -> (tuple, X) list_next(tuple list) asm( -> 1 0) "UNCONS";
+forall X -> X car(tuple list) asm "CAR";
+tuple cdr(tuple list) asm "CDR";
+tuple empty_tuple() asm "NIL";
+forall X -> tuple tpush(tuple t, X value) asm "TPUSH";
+forall X -> (tuple, ()) ~tpush(tuple t, X value) asm "TPUSH";
+forall X -> [X] single(X x) asm "SINGLE";
+forall X -> X unsingle([X] t) asm "UNSINGLE";
+forall X, Y -> [X, Y] pair(X x, Y y) asm "PAIR";
+forall X, Y -> (X, Y) unpair([X, Y] t) asm "UNPAIR";
+forall X, Y, Z -> [X, Y, Z] triple(X x, Y y, Z z) asm "TRIPLE";
+forall X, Y, Z -> (X, Y, Z) untriple([X, Y, Z] t) asm "UNTRIPLE";
+forall X, Y, Z, W -> [X, Y, Z, W] tuple4(X x, Y y, Z z, W w) asm "4 TUPLE";
+forall X, Y, Z, W -> (X, Y, Z, W) untuple4([X, Y, Z, W] t) asm "4 UNTUPLE";
+forall X -> X first(tuple t) asm "FIRST";
+forall X -> X second(tuple t) asm "SECOND";
+forall X -> X third(tuple t) asm "THIRD";
+forall X -> X fourth(tuple t) asm "3 INDEX";
+forall X, Y -> X pair_first([X, Y] p) asm "FIRST";
+forall X, Y -> Y pair_second([X, Y] p) asm "SECOND";
+forall X, Y, Z -> X triple_first([X, Y, Z] p) asm "FIRST";
+forall X, Y, Z -> Y triple_second([X, Y, Z] p) asm "SECOND";
+forall X, Y, Z -> Z triple_third([X, Y, Z] p) asm "THIRD";
+forall X -> X null() asm "PUSHNULL";
+forall X -> (X, ()) ~impure_touch(X x) impure asm "NOP";
+
+int now() asm "NOW";
+slice my_address() asm "MYADDR";
+[int, cell] get_balance() asm "BALANCE";
+int cur_lt() asm "LTIME";
+int block_lt() asm "BLOCKLT";
+
+int cell_hash(cell c) asm "HASHCU";
+int slice_hash(slice s) asm "HASHSU";
+int string_hash(slice s) asm "SHA256U";
+
+int check_signature(int hash, slice signature, int public_key) asm "CHKSIGNU";
+int check_data_signature(slice data, slice signature, int public_key) asm "CHKSIGNS";
+
+(int, int, int) compute_data_size(cell c, int max_cells) impure asm "CDATASIZE";
+(int, int, int) slice_compute_data_size(slice s, int max_cells) impure asm "SDATASIZE";
+(int, int, int, int) compute_data_size?(cell c, int max_cells) asm "CDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+(int, int, int, int) slice_compute_data_size?(cell c, int max_cells) asm "SDATASIZEQ NULLSWAPIFNOT2 NULLSWAPIFNOT";
+
+;; () throw_if(int excno, int cond) impure asm "THROWARGIF";
+
+() dump_stack() impure asm "DUMPSTK";
+
+cell get_data() asm "c4 PUSH";
+() set_data(cell c) impure asm "c4 POP";
+cont get_c3() impure asm "c3 PUSH";
+() set_c3(cont c) impure asm "c3 POP";
+cont bless(slice s) impure asm "BLESS";
+
+() accept_message() impure asm "ACCEPT";
+() set_gas_limit(int limit) impure asm "SETGASLIMIT";
+() commit() impure asm "COMMIT";
+() buy_gas(int gram) impure asm "BUYGAS";
+
+int min(int x, int y) asm "MIN";
+int max(int x, int y) asm "MAX";
+(int, int) minmax(int x, int y) asm "MINMAX";
+int abs(int x) asm "ABS";
+
+slice begin_parse(cell c) asm "CTOS";
+() end_parse(slice s) impure asm "ENDS";
+(slice, cell) load_ref(slice s) asm( -> 1 0) "LDREF";
+cell preload_ref(slice s) asm "PLDREF";
+;; (slice, int) ~load_int(slice s, int len) asm(s len -> 1 0) "LDIX";
+;; (slice, int) ~load_uint(slice s, int len) asm( -> 1 0) "LDUX";
+;; int preload_int(slice s, int len) asm "PLDIX";
+;; int preload_uint(slice s, int len) asm "PLDUX";
+;; (slice, slice) load_bits(slice s, int len) asm(s len -> 1 0) "LDSLICEX";
+;; slice preload_bits(slice s, int len) asm "PLDSLICEX";
+(slice, int) load_grams(slice s) asm( -> 1 0) "LDGRAMS";
+slice skip_bits(slice s, int len) asm "SDSKIPFIRST";
+(slice, ()) ~skip_bits(slice s, int len) asm "SDSKIPFIRST";
+slice first_bits(slice s, int len) asm "SDCUTFIRST";
+slice skip_last_bits(slice s, int len) asm "SDSKIPLAST";
+(slice, ()) ~skip_last_bits(slice s, int len) asm "SDSKIPLAST";
+slice slice_last(slice s, int len) asm "SDCUTLAST";
+(slice, cell) load_dict(slice s) asm( -> 1 0) "LDDICT";
+cell preload_dict(slice s) asm "PLDDICT";
+slice skip_dict(slice s) asm "SKIPDICT";
+
+(slice, cell) load_maybe_ref(slice s) asm( -> 1 0) "LDOPTREF";
+cell preload_maybe_ref(slice s) asm "PLDOPTREF";
+builder store_maybe_ref(builder b, cell c) asm(c b) "STOPTREF";
+
+int cell_depth(cell c) asm "CDEPTH";
+
+int slice_refs(slice s) asm "SREFS";
+int slice_bits(slice s) asm "SBITS";
+(int, int) slice_bits_refs(slice s) asm "SBITREFS";
+int slice_empty?(slice s) asm "SEMPTY";
+int slice_data_empty?(slice s) asm "SDEMPTY";
+int slice_refs_empty?(slice s) asm "SREMPTY";
+int slice_depth(slice s) asm "SDEPTH";
+
+int builder_refs(builder b) asm "BREFS";
+int builder_bits(builder b) asm "BBITS";
+int builder_depth(builder b) asm "BDEPTH";
+
+builder begin_cell() asm "NEWC";
+cell end_cell(builder b) asm "ENDC";
+builder store_ref(builder b, cell c) asm(c b) "STREF";
+;; builder store_uint(builder b, int x, int len) asm(x b len) "STUX";
+;; builder store_int(builder b, int x, int len) asm(x b len) "STIX";
+builder store_slice(builder b, slice s) asm "STSLICER";
+builder store_grams(builder b, int x) asm "STGRAMS";
+builder store_dict(builder b, cell c) asm(c b) "STDICT";
+
+(slice, slice) load_msg_addr(slice s) asm( -> 1 0) "LDMSGADDR";
+tuple parse_addr(slice s) asm "PARSEMSGADDR";
+(int, int) parse_std_addr(slice s) asm "REWRITESTDADDR";
+(int, slice) parse_var_addr(slice s) asm "REWRITEVARADDR";
+
+cell idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
+(cell, ()) ~idict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETREF";
+cell udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
+(cell, ()) ~udict_set_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETREF";
+cell idict_get_ref(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETOPTREF";
+(cell, int) idict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGETREF";
+(cell, int) udict_get_ref?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGETREF";
+(cell, cell) idict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTISETGETOPTREF";
+(cell, cell) udict_set_get_ref(cell dict, int key_len, int index, cell value) asm(value index dict key_len) "DICTUSETGETOPTREF";
+(cell, int) idict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDEL";
+(cell, int) udict_delete?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDEL";
+(slice, int) idict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIGET" "NULLSWAPIFNOT";
+(slice, int) udict_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUGET" "NULLSWAPIFNOT";
+(cell, slice, int) idict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDELGET" "NULLSWAPIFNOT";
+(cell, slice, int) udict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDELGET" "NULLSWAPIFNOT";
+(cell, (slice, int)) ~idict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTIDELGET" "NULLSWAPIFNOT";
+(cell, (slice, int)) ~udict_delete_get?(cell dict, int key_len, int index) asm(index dict key_len) "DICTUDELGET" "NULLSWAPIFNOT";
+cell udict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUSET";
+(cell, ()) ~udict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUSET";
+cell idict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTISET";
+(cell, ()) ~idict_set(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTISET";
+cell dict_set(cell dict, int key_len, slice index, slice value) asm(value index dict key_len) "DICTSET";
+(cell, ()) ~dict_set(cell dict, int key_len, slice index, slice value) asm(value index dict key_len) "DICTSET";
+(cell, int) udict_add?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUADD";
+(cell, int) udict_replace?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTUREPLACE";
+(cell, int) idict_add?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTIADD";
+(cell, int) idict_replace?(cell dict, int key_len, int index, slice value) asm(value index dict key_len) "DICTIREPLACE";
+cell udict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUSETB";
+(cell, ()) ~udict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUSETB";
+cell idict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTISETB";
+(cell, ()) ~idict_set_builder(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTISETB";
+cell dict_set_builder(cell dict, int key_len, slice index, builder value) asm(value index dict key_len) "DICTSETB";
+(cell, ()) ~dict_set_builder(cell dict, int key_len, slice index, builder value) asm(value index dict key_len) "DICTSETB";
+(cell, int) udict_add_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUADDB";
+(cell, int) udict_replace_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTUREPLACEB";
+(cell, int) idict_add_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTIADDB";
+(cell, int) idict_replace_builder?(cell dict, int key_len, int index, builder value) asm(value index dict key_len) "DICTIREPLACEB";
+(cell, int, slice, int) udict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMIN" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~udict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMIN" "NULLSWAPIFNOT2";
+(cell, int, slice, int) idict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMIN" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~idict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMIN" "NULLSWAPIFNOT2";
+(cell, slice, slice, int) dict_delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMIN" "NULLSWAPIFNOT2";
+(cell, (slice, slice, int)) ~dict::delete_get_min(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMIN" "NULLSWAPIFNOT2";
+(cell, int, slice, int) udict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMAX" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~udict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTUREMMAX" "NULLSWAPIFNOT2";
+(cell, int, slice, int) idict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMAX" "NULLSWAPIFNOT2";
+(cell, (int, slice, int)) ~idict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTIREMMAX" "NULLSWAPIFNOT2";
+(cell, slice, slice, int) dict_delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMAX" "NULLSWAPIFNOT2";
+(cell, (slice, slice, int)) ~dict::delete_get_max(cell dict, int key_len) asm(-> 0 2 1 3) "DICTREMMAX" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_min?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMIN" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_max?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMAX" "NULLSWAPIFNOT2";
+(int, cell, int) udict_get_min_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMINREF" "NULLSWAPIFNOT2";
+(int, cell, int) udict_get_max_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTUMAXREF" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_min?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMIN" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_max?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMAX" "NULLSWAPIFNOT2";
+(int, cell, int) idict_get_min_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMINREF" "NULLSWAPIFNOT2";
+(int, cell, int) idict_get_max_ref?(cell dict, int key_len) asm (-> 1 0 2) "DICTIMAXREF" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_next?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETNEXT" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_nexteq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETNEXTEQ" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_prev?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETPREV" "NULLSWAPIFNOT2";
+(int, slice, int) udict_get_preveq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTUGETPREVEQ" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_next?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETNEXT" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_nexteq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETNEXTEQ" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_prev?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETPREV" "NULLSWAPIFNOT2";
+(int, slice, int) idict_get_preveq?(cell dict, int key_len, int pivot) asm(pivot dict key_len -> 1 0 2) "DICTIGETPREVEQ" "NULLSWAPIFNOT2";
+cell new_dict() asm "NEWDICT";
+int dict_empty?(cell c) asm "DICTEMPTY";
+
+(slice, slice, slice, int) pfxdict_get?(cell dict, int key_len, slice key) asm(key dict key_len) "PFXDICTGETQ" "NULLSWAPIFNOT2";
+(cell, int) pfxdict_set?(cell dict, int key_len, slice key, slice value) asm(value key dict key_len) "PFXDICTSET";
+(cell, int) pfxdict_delete?(cell dict, int key_len, slice key) asm(key dict key_len) "PFXDICTDEL";
+
+cell config_param(int x) asm "CONFIGOPTPARAM";
+int cell_null?(cell c) asm "ISNULL";
+
+() raw_reserve(int amount, int mode) impure asm "RAWRESERVE";
+() raw_reserve_extra(int amount, cell extra_amount, int mode) impure asm "RAWRESERVEX";
+() send_raw_message(cell msg, int mode) impure asm "SENDRAWMSG";
+() set_code(cell new_code) impure asm "SETCODE";
+
+int random() impure asm "RANDU256";
+int rand(int range) impure asm "RAND";
+int get_seed() impure asm "RANDSEED";
+int set_seed() impure asm "SETRAND";
+() randomize(int x) impure asm "ADDRAND";
+() randomize_lt() impure asm "LTIME" "ADDRAND";

--- a/dune-project
+++ b/dune-project
@@ -42,6 +42,7 @@
    (visitors (= 20210608))
    (containers (>= 3.8.0))
    (linenoise (>= 1.3.1))
+   (bos (>= 0.2.1))
    (core (and :with-test (>= 0.15.0)))
    (ppx_expect (and :with-test (>= 0.15.0)))
    (ppx_matches (and :with-test (>= 0.1)))

--- a/dune-project
+++ b/dune-project
@@ -43,6 +43,7 @@
    (containers (>= 3.8.0))
    (linenoise (>= 1.3.1))
    (bos (>= 0.2.1))
+   (cmdliner (>= 1.1.1))
    (core (and :with-test (>= 0.15.0)))
    (ppx_expect (and :with-test (>= 0.15.0)))
    (ppx_matches (and :with-test (>= 0.1)))

--- a/tact.opam
+++ b/tact.opam
@@ -22,6 +22,7 @@ depends: [
   "visitors" {= "20210608"}
   "containers" {>= "3.8.0"}
   "linenoise" {>= "1.3.1"}
+  "bos" {>= "0.2.1"}
   "core" {with-test & >= "0.15.0"}
   "ppx_expect" {with-test & >= "0.15.0"}
   "ppx_matches" {with-test & >= "0.1"}

--- a/tact.opam
+++ b/tact.opam
@@ -23,6 +23,7 @@ depends: [
   "containers" {>= "3.8.0"}
   "linenoise" {>= "1.3.1"}
   "bos" {>= "0.2.1"}
+  "cmdliner" {>= "1.1.1"}
   "core" {with-test & >= "0.15.0"}
   "ppx_expect" {with-test & >= "0.15.0"}
   "ppx_matches" {with-test & >= "0.1"}


### PR DESCRIPTION
This requires the presence of `func` and `fift` executables and
`FIFTPATH` environment variable has to be set as well.

This simplifies the process of getting from .tact to .cell from this:

```
FIFTPATH=/path/to/fiftlib tact examples/wallet_v3.tact > examples/wallet_v3.fc && cat examples/stdlib.fc examples/wallet_v3.fc > examples/wallet_v3.merged.fc && func -APS -o examples/wallet_v3.fif examples/wallet_v3.merged.fc && echo "boc>B \"wallet_v3.cell\" B>file" >> examples/wallet_v3.fif && fift examples/wallet_v3.fif
```

to

```
tact examples/wallet_v3.tact
```