### PR TITLE
Initial prototype for better error locations in ambiguous scenarios

### DIFF
--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -38,9 +38,8 @@ and eval_stmt ~(constructor : _ Lang.constructor) ~filename text =
             ( attempt (locate stmt)
             <|> ( locate expr
                 |>> fun s -> Syntax.map_located s ~f:(fun _ -> Syntax.Expr s) )
-          <|> locate (return (Syntax.CodeBlock [])) )
-            ) )
-        text () 
+            <|> locate (return (Syntax.CodeBlock [])) ) ) )
+      text ()
   with
   | Success stx -> (
       let errors = constructor#get_errors in

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -34,11 +34,13 @@ and eval_stmt ~(constructor : _ Lang.constructor) ~filename text =
     MParser.(
       parse_string
         Parser.(
-          attempt (locate stmt)
-          <|> ( locate expr
-              |>> fun s -> Syntax.map_located s ~f:(fun _ -> Syntax.Expr s) )
+          handle_errors
+            ( attempt (locate stmt)
+            <|> ( locate expr
+                |>> fun s -> Syntax.map_located s ~f:(fun _ -> Syntax.Expr s) )
           <|> locate (return (Syntax.CodeBlock [])) )
-        text () )
+            ) )
+        text () 
   with
   | Success stx -> (
       let errors = constructor#get_errors in

--- a/lib/parser.ml
+++ b/lib/parser.ml
@@ -29,7 +29,7 @@ module Make (Config : Config.T) = struct
     | other ->
         other
 
-  (** Infix alias for [must_parse] *)
+  (** Prefix alias for [must_parse] *)
   let ( !!! ) = must_parse
 
   (** Handles exception raised by [must_parse] or [!!!] alias operator **)


### PR DESCRIPTION
Here's the problem. The way I set it up, all these `attempts` in the
parser are used for dual-purposed errors.

First class of errors is "this is not me" and this is where `attempt`
should be effected.

The second class of errors is "this is me, but wrong syntaxx" and this
is where we should simply fail without trying to backtrack.

Being somewhat tired towards the end of the day, I implemented this with
an exception. Feedback is welcome.