### PR TITLE
Wallet v3 simplification

### DIFF
--- a/examples/wallet_v3.tact
+++ b/examples/wallet_v3.tact
@@ -2,55 +2,47 @@ struct MsgBody {
   val subwallet: Uint32
   val valid_until: Uint32
   val seqno: Uint32
+
+  @derive impl Deserialize {}
+}
+
+struct WalletState {
+  val seqno: Uint32
+  val subwallet: Uint32
+  val public_key: Uint256
+
+  @derive impl Deserialize {}
+  @derive impl Serialize {}
 }
 
 struct NextMessage {
   val cell: RefCell
   val flags: SendRawMsgFlags
   
-  fn from_slice(slice: mut Slice) -> Option[Self] {
-     if (slice.has_refs()) {
-         return Some(Self {
-            cell: slice.read_ref(),
-            flags: slice.read(SendRawMsgFlags)
-         })
-     }
-     return None;
+  @derive impl Deserialize {}
+}
+
+fn recv_internal(_: Slice) {}
+
+fn recv_external(input: Slice) {
+  let {value as signed, slice} = SignedBody[MsgBody].deserialize(input);
+  let state = WalletState.deserialize(Slice.parse(Globals.load_state())).value;
+
+  let body = signed.verify_body(state.public_key);
+
+  if (body.valid_until <= Globals.get_now()) { thrown(35) }
+  if (body.seqno != state.seqno) { thrown(33) }
+  if (body.subwallet != state.subwallet) { thrown(34) }
+
+  builtin_accept_message();
+
+  while (slice.refs_count() != 0) {
+    let {value as next, slice as new_slice} = NextMessage.deserialize(slice);
+    slice = new_slice;
+    send_raw_msg(next.cell.inner, next.flags);
   }
+
+  state.seqno = state.seqno + 1;
+  let new_state = state.serialize(Builder.new()).build();
+  Globals.save_state(new_state);
 }
-
-let Expired = 35;
-let InvalidSignature = 35;
-let SeqnoMismatch = 35;
-let WalletMismatch = 35;
-
-struct Wallet {
-  val seqno: Uint32
-  val subwallet: Uint32
-  val public_key: Uint256
-  
-  // 1. State automatically loads and saves
-  // 2. Typed message in the argument with automatic deserialization
-  // 3. Named error constants
-  // 4. Mutable cell slices
-  fn receive_external(message: SignedMessage[MsgBody]) {
-      // load happens automatically here
-  
-      let body = message.verify_body(state.public_key, InvalidSignature);
-
-      verify(body.valid_until <= Globals.get_now(), Expired);
-      verify(body.seqno != state.seqno, SeqnoMismatch);
-      verify(body.subwallet != state.subwallet, WalletMismatch);
-      
-      accept_message();  // TODO: I wish there was better structural separation between two phases
-      
-      while (let next = NextMessage.from_slice(body)) { // TODO: we need some notion of mutability for slice args
-          send_raw_msg(next.cell.inner, next.flags);
-      }
-      self.seqno = self.seqno + 1; 
-
-      // saving happens automatically here if we did not fail
-    }
-
-}
-

--- a/examples/wallet_v3.tact
+++ b/examples/wallet_v3.tact
@@ -2,47 +2,55 @@ struct MsgBody {
   val subwallet: Uint32
   val valid_until: Uint32
   val seqno: Uint32
-
-  @derive impl Deserialize {}
-}
-
-struct WalletState {
-  val seqno: Uint32
-  val subwallet: Uint32
-  val public_key: Uint256
-
-  @derive impl Deserialize {}
-  @derive impl Serialize {}
 }
 
 struct NextMessage {
   val cell: RefCell
   val flags: SendRawMsgFlags
   
-  @derive impl Deserialize {}
-}
-
-fn recv_internal(_: Slice) {}
-
-fn recv_external(input: Slice) {
-  let {value as signed, slice} = SignedBody[MsgBody].deserialize(input);
-  let state = WalletState.deserialize(Slice.parse(Globals.load_state())).value;
-
-  let body = signed.verify_body(state.public_key);
-
-  if (body.valid_until <= Globals.get_now()) { thrown(35) }
-  if (body.seqno != state.seqno) { thrown(33) }
-  if (body.subwallet != state.subwallet) { thrown(34) }
-
-  builtin_accept_message();
-
-  while (slice.refs_count() != 0) {
-    let {value as next, slice as new_slice} = NextMessage.deserialize(slice);
-    slice = new_slice;
-    send_raw_msg(next.cell.inner, next.flags);
+  fn from_slice(slice: mut Slice) -> Option[Self] {
+     if (slice.has_refs()) {
+         return Some(Self {
+            cell: slice.read_ref(),
+            flags: slice.read(SendRawMsgFlags)
+         })
+     }
+     return None;
   }
-
-  state.seqno = state.seqno + 1;
-  let new_state = state.serialize(Builder.new()).build();
-  Globals.save_state(new_state);
 }
+
+let Expired = 35;
+let InvalidSignature = 35;
+let SeqnoMismatch = 35;
+let WalletMismatch = 35;
+
+struct Wallet {
+  val seqno: Uint32
+  val subwallet: Uint32
+  val public_key: Uint256
+  
+  // 1. State automatically loads and saves
+  // 2. Typed message in the argument with automatic deserialization
+  // 3. Named error constants
+  // 4. Mutable cell slices
+  fn receive_external(message: SignedMessage[MsgBody]) {
+      // load happens automatically here
+  
+      let body = message.verify_body(state.public_key, InvalidSignature);
+
+      verify(body.valid_until <= Globals.get_now(), Expired);
+      verify(body.seqno != state.seqno, SeqnoMismatch);
+      verify(body.subwallet != state.subwallet, WalletMismatch);
+      
+      accept_message();  // TODO: I wish there was better structural separation between two phases
+      
+      while (let next = NextMessage.from_slice(body)) { // TODO: we need some notion of mutability for slice args
+          send_raw_msg(next.cell.inner, next.flags);
+      }
+      self.seqno = self.seqno + 1; 
+
+      // saving happens automatically here if we did not fail
+    }
+
+}
+


### PR DESCRIPTION
Adding a rough sketch of how we can simplify wallet v3 code with some language improvements.

- automatic load/storage of the state on a happy path;
- mutable slices for use in loops and to minimize clutter;
- reading structs from slices via read(T);
